### PR TITLE
fix(ci): tolerate taskkill race in Windows smoke-test cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,7 +192,15 @@ jobs:
             datapaw datasource list
           } finally {
             if (-not $server.HasExited) {
-              taskkill /PID $server.Id /T /F | Out-Null
+              # taskkill races child processes that exit on their own while the
+              # tree is being killed and then returns a non-zero exit code that
+              # would fail the step. Tolerate that race and verify termination
+              # of the root process instead.
+              taskkill /PID $server.Id /T /F 2>&1 | Out-Null
+              $global:LASTEXITCODE = 0
+              if (-not $server.WaitForExit(30000)) {
+                throw "start_local.ps1 (PID $($server.Id)) is still running after taskkill"
+              }
             }
             if (Test-Path $stdout) { Get-Content $stdout }
             if (Test-Path $stderr) { Get-Content $stderr }


### PR DESCRIPTION
## Problem

The **Native Windows** job fails intermittently in the *Native lifecycle smoke test* cleanup even when the test itself passes (seen on #16 and Dependabot PRs #2/#6/#15):

```text
ERROR: The process with PID 6596 (child process of PID 7688) could not be terminated.
Reason: There is no running instance of the task.
Error: Process completed with exit code 1.
```

`taskkill /PID <root> /T /F` enumerates the process tree, and when a child (typically the vite/npm process) exits on its own before being killed, taskkill returns a non-zero exit code that fails the pwsh step via `$LASTEXITCODE`.

## Fix

In the `finally` cleanup block: swallow taskkill's exit code, then assert the outcome that actually matters — `$server.WaitForExit(30000)` — and throw only if the root process is genuinely still alive.

The equivalent Python taskkill call sites (`scripts/_local_common.py`, `host-core tools/workspace.py`) already use `check=False` and are unaffected.