### PR TITLE
feat(cli): datasource lifecycle and semantic-layer commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,6 +344,12 @@ jobs:
           --postgres-dsn
           postgresql://datapaw:datapaw-demo@127.0.0.1:5432/datapaw_demo
 
+      - name: Run real datasource and semantic CLI flow
+        run: >
+          uv run python examples/semantic_smoke_test.py
+          --postgres-dsn
+          postgresql://datapaw:datapaw-demo@127.0.0.1:5432/datapaw_demo
+
   docker:
     name: Docker sandbox integration
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- `datapaw datasource` now covers the full lifecycle: `get`, `create`
+  (with optional pre-save connection test), `update`, `delete`, and `test`,
+  all with masked credential output.
+- New `datapaw semantic` command group: table-driven CRUD for business
+  domains, datasets, columns, dimensions, dataset-dimension bindings,
+  metrics, and metric formulas; Excel workbook import; and weave-task
+  management (`submit` with `--wait`, `list`, `kill`).
+- `SemanticConfigClient` in `datapaw-host-core` for the authenticated
+  `/api/semantic-config` REST surface with pagination validation and the
+  unified error protocol.
+
 ## [0.1.2] - 2026-08-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `SemanticConfigClient` in `datapaw-host-core` for the authenticated
   `/api/semantic-config` REST surface with pagination validation and the
   unified error protocol.
+- Deterministic semantic-CLI smoke test (`examples/semantic_smoke_test.py`)
+  covering datasource lifecycle, workbook import, semantic CRUD with partial
+  updates, batch deletion, and a real weave publish, wired into the CI smoke
+  job.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,17 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `/api/semantic-config` REST surface with pagination validation and the
   unified error protocol.
 
+### Fixed
+
+- Semantic-config partial updates no longer erase omitted fields: the
+  repository UPDATE statements previously overwrote every column, so a
+  partial payload hit NOT NULL constraints (HTTP 500) or silently nulled
+  stored values. All seven resource repositories now preserve fields that
+  are not part of the request.
+- `datapaw semantic weave submit --wait` now recognizes the upper-case
+  terminal states reported by DataBridge (`SUCCESS`/`FAILED`/`KILLED`)
+  instead of polling until timeout.
+
 ## [0.1.2] - 2026-08-10
 
 ### Added

--- a/docs/design/2026-08-10-cli-semantic-commands.md
+++ b/docs/design/2026-08-10-cli-semantic-commands.md
@@ -1,0 +1,323 @@
+# Design Doc: DataPaw CLI 数据源与语义操作命令
+
+- 状态:Reviewed(开放问题已决议,可开工)
+- 目标版本:0.2.0(新增命令,不破坏既有命令)
+- 后端改动:**无**(全部复用现有 `/api/semantic-config/*` 与 `/api/v1/cm/*` 路由)
+- 关联:与 QwenPaw-Data-Cloud 共享同一 API 契约;本设计以 API 契约对齐,CLI 可同时用于本地版与 Cloud 部署
+
+## 1. 背景与目标
+
+当前 `datapaw` CLI 仅提供 `datasource list` 一个管理类命令。数据源的增删改查、
+连通性测试,以及语义层(业务域、数据集、维度、指标等)的全部配置操作只能通过
+DataBridge UI(localhost:3000)或直接调用 REST API 完成,无法脚本化、无法进入
+CI/自动化流程。
+
+本设计交付两组命令:
+
+1. **数据源及配置态操作**:`datapaw datasource` 扩展为完整 CRUD + 连通性测试。
+2. **语义操作(CRUD)**:新增 `datapaw semantic`,覆盖业务域、数据集、列、维度、
+   维度绑定、指标、指标公式的 CRUD,以及 Excel 导入与「织入」(weave,即配置态
+   发布到图谱)的任务管理。
+
+### 配置态模型
+
+DataBridge 的语义配置存储在本地 SQLite(草稿态),通过 weave 任务异步发布到
+图存储(Neo4j)。没有独立的 draft/published 字段,**weave 任务生命周期即发布
+机制**(pending / running / success / failed / killed)。CLI 将其暴露为
+`semantic weave` 子命令。
+
+### 非目标(Out of Scope)
+
+- KG 文档管理(`/api/v1/docs/*`)、轨迹图管理:后续单独设计。
+- 后端新增路由、鉴权模型改动:不涉及。
+- 表格化输出(table format):首版仅 JSON,保持与 `datasource list` 一致。
+
+## 2. 交付命令总览
+
+```text
+datapaw datasource
+  list                                    # 既有,保持不变(免凭证端点)
+  get <datasource_id> [--show-config]
+  create --name <n> --type <t> (--config-file <f.json> | --config '<json>') [--test]
+  update <datasource_id> [--name <n>] [--type <t>] [--config-file <f> | --config '<json>']
+  delete <datasource_id> [--yes]
+  test (<datasource_id> | --type <t> (--config-file <f> | --config '<json>'))
+
+datapaw semantic
+  domain     list|get|create|update|delete     # 业务域   biz-domain
+  dataset    list|get|create|update|delete     # 数据集   dataset-meta
+  column     list|get|create|update|delete     # 数据集列 dataset-column-meta
+  dimension  list|get|create|update|delete     # 维度     dimension
+  binding    list|get|create|update|delete     # 维度绑定 dataset-dimension
+  metric     list|get|create|update|delete     # 指标     metric-lib
+  formula    list|get|create|update|delete     # 指标公式 metric-formula-lib
+  import --file <semantic_config.xlsx>         # Excel 导入语义配置
+  weave submit --datasource-id <id> [--mode FULL] [--name <task>] [--wait [--timeout <sec>]]
+  weave list [--datasource-name <n>] [--task-name <n>] [--page --size]
+  weave kill <task_id>
+```
+
+7 类语义对象的 CRUD 完全同构(见 §5 资源描述表),用统一实现驱动。
+
+## 3. 命令规格与用法
+
+### 3.1 通用约定
+
+- **输出**:统一 JSON(`ensure_ascii=False, indent=2`),列表输出
+  `{"items": [...], "total": N}`,单对象直接输出对象本身;与既有
+  `datasource list` 保持一致。
+- **退出码**:`0` 成功;`1` 失败(参数错误、HTTP 错误、连接失败、用户取消);
+  `130` 中断(Ctrl-C)。沿用 `main.py` 既有约定。
+- **分页**:所有 `list` 支持 `--page`(默认 1)、`--size`(默认 20);
+  `--all` 拉取全部页(沿用 `cm_client` 的分页校验逻辑)。
+- **请求体输入**:`create`/`update` 支持两种互斥方式:
+  - `--file <payload.json>`:从 JSON 文件读取请求体;
+  - 一等公民 flags(见各资源小节),适合简单场景;
+  - 两者同时给出时报错。
+- **敏感信息掩码**:任何输出中 `config` 内的
+  `password / access_key_id / access_key_secret / sts_token` 一律输出 `******`
+  (复用既有 `SENSITIVE_CONFIG_FIELDS`)。**CLI 无任何选项可输出明文凭证**。
+- **删除确认**:`delete` 默认在 TTY 中要求输入 `y` 确认;`--yes` 跳过;
+  非 TTY(脚本)且未给 `--yes` 时直接失败并提示。
+- **错误显示**:服务端 `/api/semantic-config/*` 错误协议为
+  `{timestamp, status, error, message}`;CLI 提取 `message` 输出为
+  `datapaw: error: <message>`。`401/403` 时附加提示:
+  `hint: set DATAPAW_CLIENT_API_TOKEN (or DATAPAW_API_TOKEN) with the required scope`。
+
+### 3.2 `datapaw datasource`(数据源及配置态)
+
+对应路由:`/api/semantic-config/datasource*`(scope:`credentials:manage`);
+`list` 保持走免凭证的 `/api/v1/cm/datasources`(scope:`query`)。
+
+| 子命令 | 方法与路径 | 说明 |
+| --- | --- | --- |
+| `list` | `GET /api/v1/cm/datasources` | 既有行为不变;不含 config |
+| `get <id>` | `GET /api/semantic-config/datasource/{id}` | 默认不输出 config;`--show-config` 输出掩码后的 config |
+| `create` | `POST /api/semantic-config/datasource` | `datasource_id` 由后端生成(`type-uuid`);`--test` 先调 test-connection,失败则不落盘(无跳过选项) |
+| `update <id>` | `PUT /api/semantic-config/datasource/{id}` | config 传入即整体替换,未传保持不变(与后端语义一致) |
+| `delete <id>` | `DELETE /api/semantic-config/datasource/{id}` | 需确认;后端会级联处理图谱侧数据 |
+| `test <id>` | `POST /api/semantic-config/datasource/{id}/test-connection` | 测试已保存数据源 |
+| `test --type --config*` | `POST /api/semantic-config/datasource/test-connection` | 存盘前测试 |
+
+用法示例:
+
+```bash
+# 新建 PostgreSQL 数据源,先测连通再落盘
+datapaw datasource create \
+  --name "demo-pg" --type postgresql \
+  --config-file examples/demo/postgres/datasource.example.json \
+  --test
+
+# 输出(config 已掩码):
+# {
+#   "datasource_id": "postgresql-3f2a...",
+#   "datasource_name": "demo-pg",
+#   "datasource_type": "postgresql",
+#   "config": { "host": "127.0.0.1", "port": 5432, "password": "******", ... }
+# }
+
+datapaw datasource get postgresql-3f2a... --show-config
+datapaw datasource update postgresql-3f2a... --name "demo-pg-v2"
+datapaw datasource test postgresql-3f2a...
+# { "success": true, "message": "ok", "tables_found": 12, "elapsed_ms": 45 }
+datapaw datasource delete postgresql-3f2a... --yes
+```
+
+### 3.3 `datapaw semantic <resource>`(语义 CRUD)
+
+对应路由:`/api/semantic-config/<resource-path>`;GET 需 `query` scope,
+POST/PUT/DELETE 需 `manage` scope。
+
+各资源的一等公民 flags(均可用 `--file` 替代;`update` 时同名 flag 覆盖对应字段):
+
+| 资源 | 路径 | ID 字段 | list 过滤 flags | create 一等 flags |
+| --- | --- | --- | --- | --- |
+| `domain` | `biz-domain` | `domain_id` | `--datasource-id --name` | `--datasource-id --name --display-name --description --aliases` |
+| `dataset` | `dataset-meta` | `dataset_id` | `--datasource-id --domain-id --name --type` | `--datasource-id --domain-id --name --comment --type --sql --parents` |
+| `column` | `dataset-column-meta` | `col_id` | `--datasource-id --domain-id --dataset-id` | `--dataset-id --file`(字段多,推荐 `--file`) |
+| `dimension` | `dimension` | `dim_id` | `--datasource-id --domain-id --name` | `--datasource-id --domain-id --name --description --parent-name --synonyms --enums` |
+| `binding` | `dataset-dimension` | `dd_id` | `--datasource-id --domain-id --dataset-id --dataset-name --dimension-name` | `--dataset-id --file` |
+| `metric` | `metric-lib` | `metric_id` | `--datasource-id --domain-id --name` | `--datasource-id --domain-id --name --description --unit --synonyms --tags [--polaris]` |
+| `formula` | `metric-formula-lib` | `fid` | `--datasource-id --domain-id --metric-id --dataset-id` | `--metric-id --dataset-id --formula --file` |
+
+用法示例:
+
+```bash
+# 业务域
+datapaw semantic domain create --datasource-id postgresql-demo-gaap \
+  --name gaap --display-name "GAAP 域" --description "GAAP 指标域"
+datapaw semantic domain list --datasource-id postgresql-demo-gaap
+
+# 指标 CRUD
+datapaw semantic metric create --datasource-id postgresql-demo-gaap \
+  --domain-id 1 --name avg_gaap_value --unit CNY --description "有效用户平均 GAAP 值"
+datapaw semantic metric list --domain-id 1 --page 1 --size 50
+datapaw semantic metric update 3 --description "..."
+datapaw semantic metric delete 3 --yes
+
+# 复杂对象用 JSON 文件
+datapaw semantic formula create --file formula.json
+
+# binding / formula 支持 dataset 级批量删除(对齐 DELETE .../dataset/{dataset_id})
+datapaw semantic binding delete --dataset-id 12 --yes
+datapaw semantic formula delete --dataset-id 12 --yes
+```
+
+`binding` / `formula` 的 `delete` 接受**互斥**的两种目标:位置参数 `<id>`(单条)
+或 `--dataset-id <id>`(批量,删除该数据集下全部绑定/公式);批量删除同样走
+确认流程。
+
+### 3.4 `datapaw semantic import`(Excel 导入)
+
+对应 `POST /api/semantic-config/import/excel`(multipart,scope `manage`)。
+
+```bash
+datapaw semantic import --file examples/demo_semantic_config.xlsx
+# 输出后端导入统计(新增/更新的各类对象计数)
+```
+
+### 3.5 `datapaw semantic weave`(配置态发布)
+
+对应 `/api/semantic-config/weave-task/*`(submit/callback:`write`;
+kill:`manage`;list:`query`)。
+
+```bash
+# 提交 FULL 织入并等待完成(轮询 weave list,默认 2s 间隔)
+datapaw semantic weave submit --datasource-id postgresql-demo-gaap \
+  --mode FULL --wait --timeout 600
+# 终态 success → exit 0;failed/killed/超时 → exit 1 并输出 error_msg
+
+datapaw semantic weave list --datasource-name "Demo PG"
+datapaw semantic weave kill 7d9c...
+```
+
+`--wait` 语义:提交成功后轮询任务状态直到进入终态或超时;等待期间每次轮询向
+stderr 打一个进度点(`.`),状态变化时换行输出新状态(如 `pending → running`),
+最终结果 JSON 仍输出到 stdout,不污染管道。超时仅停止等待,不会自动 kill 任务
+(输出提示如何手工 `weave kill`)。
+
+### 3.6 端到端脚本示例(替代 UI 的完整链路)
+
+```bash
+datapaw datasource create --name demo-pg --type postgresql --config-file ds.json --test
+datapaw semantic import --file demo_semantic_config.xlsx
+datapaw semantic weave submit --datasource-id postgresql-xxxx --mode FULL --wait
+datapaw run --datasource-id postgresql-xxxx "分析 3 月有效用户平均 GAAP 值走势"
+```
+
+## 4. 配置与认证
+
+复用既有环境变量,无新增:
+
+| 变量 | 作用 | 默认 |
+| --- | --- | --- |
+| `DATAPAW_CM_BASE_URL` | DataBridge API 地址 | `http://127.0.0.1:8765` |
+| `DATAPAW_CLIENT_API_TOKEN` | CLI Bearer token(优先) | 空 |
+| `DATAPAW_API_TOKEN` | 全 scope 兼容 token(回退) | 空 |
+| `DATAPAW_ENV_FILE` | dotenv 文件位置 | 仓库根 `.env` |
+
+所需 scope 汇总(fail-closed,见 `context_manager/api/authorization.py`):
+
+| 命令 | 所需 scope |
+| --- | --- |
+| `datasource list` | `query` |
+| `datasource get/create/update/delete/test` | `credentials:manage` |
+| `semantic * list/get` | `query` |
+| `semantic * create/update/delete`、`import`、`weave kill` | `manage` |
+| `weave submit` | `write` |
+
+本地默认部署(未配 token、绑定 127.0.0.1)下鉴权中间件放行,CLI 零配置可用;
+配置了 scoped keys 的部署需要为 CLI 发一个带上述 scope 的 key。
+
+## 5. 架构设计
+
+### 5.1 分层
+
+```text
+datapaw-cli   commands/datasource.py   (扩展)
+              commands/semantic.py     (新增, 资源表驱动)
+                     │  仅做:参数解析 → 调 client → 掩码/格式化输出
+datapaw-host-core    semantic_config_client.py  (新增)
+                     │  SemanticConfigClient:HTTP、鉴权头、分页、错误协议解析
+                     └  复用 cm_client 的 resolve_cm_base_url / token 解析 / loopback 免代理
+```
+
+- `ContextManagerClient`(`cm_client.py`)保持不变,继续服务 `datasource list`。
+- 新增 `SemanticConfigClient`:通用 `request(method, path, *, params, json, files)`
+  + `list_pages(path, params)`(复用既有 total/page/size 一致性校验),错误统一
+  抛 `SemanticConfigClientError(status, message)`(从 `{timestamp,status,error,message}`
+  解析,非该协议时回退 HTTP 状态行)。
+
+### 5.2 资源表驱动的 CRUD
+
+`commands/semantic.py` 用声明式描述表生成 7 组同构子命令,避免七份复制:
+
+```python
+@dataclass(frozen=True)
+class Resource:
+    name: str            # CLI 子命令名, e.g. "metric"
+    path: str            # API 路径段, e.g. "metric-lib"
+    id_field: str        # 响应 ID 字段, e.g. "metric_id" / "id"
+    list_filters: tuple[Filter, ...]   # (--flag, query 参数名, 类型)
+    create_fields: tuple[Field, ...]   # 一等公民 flags → 请求体字段
+    update_fields: tuple[Field, ...]
+```
+
+`import` / `weave` 为独立 handler(multipart 上传、轮询等待)。
+
+### 5.3 改动文件清单
+
+| 文件 | 动作 |
+| --- | --- |
+| `packages/datapaw-host-core/src/datapaw/host/core/semantic_config_client.py` | 新增 |
+| `packages/datapaw-host-core/tests/test_semantic_config_client.py` | 新增 |
+| `packages/datapaw-cli/src/datapaw/cli/commands/datasource.py` | 扩展 get/create/update/delete/test |
+| `packages/datapaw-cli/src/datapaw/cli/commands/semantic.py` | 新增 |
+| `packages/datapaw-cli/src/datapaw/cli/commands/__init__.py` | 注册 `semantic` |
+| `packages/datapaw-cli/tests/test_cli_datasource.py` | 扩展 |
+| `packages/datapaw-cli/tests/test_cli_semantic.py` | 新增 |
+| `README.md` / `README_ZH.md` / `packages/datapaw-cli/README.md` | 命令表更新 |
+| `CHANGELOG.md` | Unreleased → Added |
+
+后端(`datapaw-context`)零改动。
+
+## 6. 与 Cloud 的对齐说明
+
+- Cloud 与 OSS 共享 `/api/semantic-config/*` 契约(路由/模型逐文件比对一致),
+  本 CLI 直接以该契约实现,两侧通用。
+- Cloud 的 `cm_client` 用带 config 的 `/api/semantic-config/datasource` 做
+  list;OSS 有意改为免凭证的 `/api/v1/cm/datasources` 并强制 `config=None`。
+  **保留 OSS 行为**:`list` 永不接触凭证,凭证相关操作集中在需要
+  `credentials:manage` 的子命令且输出掩码。
+- Cloud 的 URL 解析走 Settings(`get_settings().cm.client_base_url()`),OSS 走
+  环境变量;CLI 层不感知该差异(封装在 host-core)。
+
+## 7. 测试计划
+
+- **单元(CLI)**:沿用 `test_cli_datasource.py` 的 fake-client monkeypatch 模式,
+  覆盖:各子命令成功路径、参数互斥(`--file` vs flags)、掩码、删除确认
+  (TTY/非 TTY/`--yes`)、401/403 提示、weave `--wait` 的终态/超时。
+- **单元(client)**:`httpx.MockTransport` 覆盖分页校验、错误协议解析、
+  multipart 上传、loopback trust_env。
+- **集成**:扩展 `scripts/e2e_cli.py` / `examples/smoke_test.py`,对本地
+  DataBridge 跑一条「create datasource → import excel → weave --wait →
+  metric list」链路(确定性、无需模型 key)。
+- 全量 `scripts/verify.sh` 通过后合入。
+
+## 8. 交付计划
+
+| 阶段 | 内容 | 验收 |
+| --- | --- | --- |
+| M1 | `SemanticConfigClient` + `datasource` 完整 CRUD/test | 单测 + 对本地 DataBridge 手工验证 |
+| M2 | `semantic` 7 资源 CRUD(表驱动)+ `import` | 单测 + Excel 导入示例可复现 |
+| M3 | `weave submit/list/kill`(含 `--wait`)+ e2e + 文档 | smoke 链路通过,README 更新 |
+
+## 9. 已决议的设计问题
+
+1. **dataset 级批量删除:暴露。** `binding` / `formula` 的 `delete` 支持
+   `--dataset-id <id>` 批量删除,与后端 `DELETE .../dataset/{dataset_id}`
+   端点对齐(见 §3.3)。
+2. **`weave submit --wait` 进度反馈:打进度点。** 每次轮询向 stderr 输出 `.`,
+   状态变化换行提示;结果 JSON 走 stdout(见 §3.5)。
+3. **`datasource create --test` 不提供 `--force`。** 连通性测试失败即退出
+   (exit 1),不落盘,保持行为简单可预期(见 §3.2)。

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,6 +18,7 @@ least 10 USD.
 | `demo_kg_doc.docx` | Knowledge Graph document containing the valid-user definition and business events associated with the spike |
 | `init_demo.sh` / `init_demo.ps1` / `init_demo.py` | Repeatable SQLite and PostgreSQL initialization, verification, and DataBridge registration |
 | `smoke_test.py` | Deterministic real-CLI/DataBridge/SQL test using a local model stub |
+| `semantic_smoke_test.py` | Deterministic datasource + semantic CLI test (CRUD, import, weave); no model key |
 
 ## Fast deterministic test (no model API key)
 

--- a/examples/semantic_smoke_test.py
+++ b/examples/semantic_smoke_test.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python3
+"""Deterministic smoke test for the datasource and semantic CLI commands.
+
+Complements ``smoke_test.py`` (task-execution surface) by exercising the
+configuration-management surface end to end against a real DataBridge,
+PostgreSQL, and Neo4j — no model API key required: the weave step only
+needs the graph store, and its embedding indexing is non-fatal without
+an embedding endpoint.
+
+Chain: datasource test/create/get/update → workbook import → semantic
+CRUD with partial update → dataset-level batch delete → weave submit
+--wait → cleanup, asserting masked credentials and fail-closed deletes
+along the way.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from init_demo import load_repo_environment, seed_postgres
+from smoke_test import (
+    _free_port,
+    _postgres_config,
+    _run_cli,
+    _stop_process,
+    _wait_for_health,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKBOOK = REPO_ROOT / "examples" / "demo_semantic_config.xlsx"
+WORKBOOK_DATASOURCE_ID = "postgresql-demo-gaap"
+
+
+def _cli_json(env: dict[str, str], *args: str, timeout: float = 90) -> Any:
+    completed = _run_cli(env, *args, timeout=timeout)
+    try:
+        return json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            f"CLI did not emit JSON for {' '.join(args)}:\n{completed.stdout}",
+        ) from exc
+
+
+def _run_cli_expect_failure(
+    env: dict[str, str], *args: str, timeout: float = 90
+) -> subprocess.CompletedProcess[str]:
+    command = [sys.executable, "-m", "datapaw.cli.main", *args]
+    completed = subprocess.run(
+        command,
+        cwd=REPO_ROOT,
+        env=env,
+        # No TTY stdin: interactive confirmations must fail closed instead of
+        # blocking on input() when the smoke test runs from a terminal.
+        stdin=subprocess.DEVNULL,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+    if completed.returncode == 0:
+        raise RuntimeError(
+            f"{' '.join(command)} unexpectedly succeeded:\n{completed.stdout}",
+        )
+    return completed
+
+
+def _expect(condition: bool, message: str) -> None:
+    if not condition:
+        raise RuntimeError(message)
+
+
+def _check_datasource_lifecycle(env: dict[str, str], config: dict[str, Any]) -> str:
+    config_json = json.dumps(config)
+
+    tested = _cli_json(
+        env,
+        "datasource", "test",
+        "--type", "postgresql",
+        "--config", config_json,
+    )
+    _expect(tested.get("success") is True, f"ad-hoc connection test failed: {tested}")
+
+    created = _cli_json(
+        env,
+        "datasource", "create",
+        "--name", "semantic-smoke-pg",
+        "--type", "postgresql",
+        "--config", config_json,
+        "--test",
+    )
+    datasource_id = created.get("datasource_id") or ""
+    _expect(bool(datasource_id), f"create returned no datasource_id: {created}")
+    _expect(
+        created.get("config", {}).get("password") in (None, "******"),
+        "create echoed a plaintext password",
+    )
+
+    shown = _cli_json(env, "datasource", "get", datasource_id, "--show-config")
+    _expect(
+        config["password"] not in json.dumps(shown),
+        "get --show-config leaked the plaintext password",
+    )
+
+    renamed = _cli_json(
+        env, "datasource", "update", datasource_id, "--name", "semantic-smoke-renamed",
+    )
+    _expect(
+        renamed.get("datasource_name") == "semantic-smoke-renamed",
+        f"update did not rename the datasource: {renamed}",
+    )
+    after = _cli_json(env, "datasource", "get", datasource_id, "--show-config")
+    _expect(
+        after.get("config", {}).get("dbname") == config["dbname"],
+        "update dropped the stored connection config",
+    )
+
+    saved = _cli_json(env, "datasource", "test", datasource_id)
+    _expect(saved.get("success") is True, f"saved connection test failed: {saved}")
+
+    # Deletion is fail-closed without --yes outside a TTY.
+    refused = _run_cli_expect_failure(env, "datasource", "delete", datasource_id)
+    _expect("--yes" in refused.stderr, f"non-TTY delete was not refused: {refused.stderr}")
+    return datasource_id
+
+
+def _check_semantic_crud(env: dict[str, str]) -> None:
+    imported = _cli_json(env, "semantic", "import", "--file", str(WORKBOOK))
+    _expect(imported.get("success") is True, f"workbook import failed: {imported}")
+    summary = imported.get("summary") or {}
+    _expect(summary.get("metric") == 1, f"unexpected import summary: {summary}")
+
+    metrics = _cli_json(
+        env, "semantic", "metric", "list", "--datasource-id", WORKBOOK_DATASOURCE_ID,
+    )
+    _expect(metrics.get("total") == 1, f"expected 1 imported metric: {metrics}")
+    domain_id = metrics["items"][0]["domain_id"]
+
+    created = _cli_json(
+        env,
+        "semantic", "metric", "create",
+        "--datasource-id", WORKBOOK_DATASOURCE_ID,
+        "--domain-id", str(domain_id),
+        "--name", "smoke_metric",
+        "--unit", "CNY",
+        "--description", "original",
+    )
+    metric_id = created["id"]
+
+    # Partial update must keep the fields that were not sent (regression for
+    # the repository-level full-column UPDATE bug).
+    updated = _cli_json(
+        env,
+        "semantic", "metric", "update", str(metric_id),
+        "--description", "changed",
+    )
+    _expect(updated.get("description") == "changed", f"update failed: {updated}")
+    _expect(
+        updated.get("metric_name") == "smoke_metric" and updated.get("unit") == "CNY",
+        f"partial update erased omitted fields: {updated}",
+    )
+
+    _cli_json(env, "semantic", "metric", "delete", str(metric_id), "--yes")
+
+    bindings = _cli_json(
+        env, "semantic", "binding", "list", "--datasource-id", WORKBOOK_DATASOURCE_ID,
+    )
+    _expect(bindings.get("total", 0) > 0, "workbook import created no bindings")
+    dataset_id = bindings["items"][0]["dataset_id"]
+    _cli_json(
+        env, "semantic", "binding", "delete", "--dataset-id", str(dataset_id), "--yes",
+    )
+    remaining = _cli_json(
+        env, "semantic", "binding", "list", "--dataset-id", str(dataset_id),
+    )
+    _expect(remaining.get("total") == 0, f"batch delete left bindings: {remaining}")
+
+    # Restore the workbook state so the weave publishes the full bundle.
+    _cli_json(env, "semantic", "import", "--file", str(WORKBOOK))
+
+
+def _check_weave(env: dict[str, str], *, timeout: float) -> None:
+    task = _cli_json(
+        env,
+        "semantic", "weave", "submit",
+        "--datasource-id", WORKBOOK_DATASOURCE_ID,
+        "--mode", "FULL",
+        "--name", "semantic-smoke-weave",
+        "--wait", "--timeout", str(timeout),
+        timeout=timeout + 60,
+    )
+    _expect(
+        str(task.get("status") or "").lower() == "success",
+        f"weave did not succeed: {task}",
+    )
+
+    listed = _cli_json(env, "semantic", "weave", "list")
+    _expect(
+        any(
+            record.get("task_id") == task.get("task_id")
+            for record in listed.get("items", [])
+        ),
+        f"submitted weave task missing from list: {listed}",
+    )
+
+
+def _cleanup(env: dict[str, str], datasource_id: str) -> None:
+    _cli_json(env, "datasource", "delete", datasource_id, "--yes")
+
+    # The workbook datasource is referenced by a domain, so deletion must be
+    # rejected by the fail-closed reference check.
+    refused = _run_cli_expect_failure(
+        env, "datasource", "delete", WORKBOOK_DATASOURCE_ID, "--yes",
+    )
+    _expect(
+        "数据源被引用" in refused.stderr or "referenced" in refused.stderr.lower(),
+        f"referenced datasource delete was not rejected: {refused.stderr}",
+    )
+
+
+def run_smoke(args: argparse.Namespace) -> None:
+    seed_postgres(args.postgres_dsn)
+    postgres = _postgres_config(args.postgres_dsn)
+    cm_port = _free_port()
+
+    with tempfile.TemporaryDirectory(prefix="datapaw-semantic-smoke-") as temp_name:
+        temp_root = Path(temp_name)
+        home = temp_root / "home"
+        log_path = temp_root / "databridge.log"
+        env = dict(os.environ)
+        env.update(
+            {
+                "DATAPAW_HOME": str(home),
+                "DATAPAW_CM_BASE_URL": f"http://127.0.0.1:{cm_port}",
+                "NEO4J_URI": args.neo4j_uri,
+                "NEO4J_USER": args.neo4j_user,
+                "NEO4J_PASSWORD": args.neo4j_password,
+                "NO_PROXY": "127.0.0.1,localhost",
+                "no_proxy": "127.0.0.1,localhost",
+                "DATAPAW_API_TOKEN": "",
+                "DATAPAW_API_KEYS": "",
+                "DATAPAW_CLIENT_API_TOKEN": "",
+                "NEO4J_DATABASE": "",
+            },
+        )
+
+        with log_path.open("w", encoding="utf-8") as log_file:
+            bridge = subprocess.Popen(
+                [
+                    sys.executable,
+                    str(
+                        REPO_ROOT
+                        / "packages"
+                        / "datapaw-context"
+                        / "scripts"
+                        / "serve.py"
+                    ),
+                    "--port",
+                    str(cm_port),
+                    "--log-level",
+                    "warning",
+                ],
+                cwd=REPO_ROOT,
+                env=env,
+                stdout=log_file,
+                stderr=subprocess.STDOUT,
+            )
+            try:
+                _wait_for_health(
+                    f"http://127.0.0.1:{cm_port}/api/health",
+                    bridge,
+                    args.startup_timeout,
+                )
+                datasource_id = _check_datasource_lifecycle(env, postgres)
+                _check_semantic_crud(env)
+                if args.skip_weave:
+                    print("weave step skipped (--skip-weave)")
+                else:
+                    _check_weave(env, timeout=args.weave_timeout)
+                _cleanup(env, datasource_id)
+            except BaseException as exc:
+                try:
+                    log_file.flush()
+                    bridge_log = log_path.read_text(encoding="utf-8", errors="replace")
+                except OSError:
+                    bridge_log = "<unavailable>"
+                raise RuntimeError(
+                    f"{exc}\nDataBridge log:\n{bridge_log[-8000:]}"
+                ) from exc
+            finally:
+                _stop_process(bridge)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--postgres-dsn",
+        default=("postgresql://datapaw:datapaw-demo@127.0.0.1:55432/datapaw_demo"),
+    )
+    parser.add_argument("--neo4j-uri", default="bolt://127.0.0.1:7687")
+    parser.add_argument("--neo4j-user", default="neo4j")
+    parser.add_argument(
+        "--neo4j-password",
+        default=os.getenv("NEO4J_PASSWORD", "datapaw-demo"),
+    )
+    parser.add_argument("--startup-timeout", type=float, default=30.0)
+    parser.add_argument("--weave-timeout", type=float, default=240.0)
+    parser.add_argument(
+        "--skip-weave",
+        action="store_true",
+        help="Skip the weave publish step (no graph store available)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    load_repo_environment()
+    try:
+        run_smoke(parse_args(argv))
+    except (OSError, RuntimeError, ValueError, subprocess.TimeoutExpired) as exc:
+        print(f"DataPaw semantic CLI smoke failed: {exc}", file=sys.stderr)
+        return 1
+    print("DataPaw semantic CLI smoke passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/datapaw-cli/README.md
+++ b/packages/datapaw-cli/README.md
@@ -16,7 +16,8 @@ Available command groups:
 - `execute`
 - `run`
 - `chat`
-- `datasource list`
+- `datasource`
+- `semantic`
 - `doctor`
 
 Run `datapaw doctor` before the first task to check supported Python/Node
@@ -25,15 +26,56 @@ MCP, Docker, Neo4j, and the DataBridge API. `datapaw doctor --json` emits a
 machine-readable report that reports whether credentials are set without
 printing their values.
 
-`datasource list` reads every datasource configured in DataBridge:
+`datasource` manages the datasources configured in DataBridge:
 
 ```bash
 datapaw datasource list
+datapaw datasource get <datasource_id> [--show-config]
+datapaw datasource create --name <n> --type <t> \
+  (--config-file <f.json> | --config '<json>') [--test]
+datapaw datasource update <datasource_id> [--name <n>] [--type <t>] [--config-file <f>]
+datapaw datasource delete <datasource_id> [--yes]
+datapaw datasource test (<datasource_id> | --type <t> --config-file <f>)
 ```
 
 Set `DATAPAW_CM_BASE_URL` to the DataBridge origin. It defaults to
-`http://127.0.0.1:8765`. The command emits JSON and masks saved passwords,
-AccessKeys, and STS tokens before writing anything to stdout.
+`http://127.0.0.1:8765`. Every command emits JSON and masks saved passwords,
+AccessKeys, and STS tokens before writing anything to stdout; there is no
+option that prints stored credentials. `list` uses the credential-free
+discovery endpoint, while the management subcommands call the
+`/api/semantic-config` routes and need an API key with the
+`credentials:manage` scope when scoped keys are configured
+(`DATAPAW_CLIENT_API_TOKEN` or `DATAPAW_API_TOKEN`).
+
+`semantic` manages the DataBridge semantic configuration layer. The seven
+resources `domain`, `dataset`, `column`, `dimension`, `binding`, `metric`,
+and `formula` share the same verbs:
+
+```bash
+datapaw semantic <resource> list [filters] [--page N --size N | --all]
+datapaw semantic <resource> get <id>
+datapaw semantic <resource> create (field flags | --file payload.json)
+datapaw semantic <resource> update <id> (field flags | --file payload.json)
+datapaw semantic <resource> delete <id> [--yes]
+```
+
+`binding` and `formula` also support dataset-level batch deletion with
+`delete --dataset-id <id>`. Reads require the `query` scope and writes the
+`manage` scope. Two more subcommands cover import and publishing:
+
+```bash
+# Import a semantic configuration workbook into the draft store
+datapaw semantic import --file demo_semantic_config.xlsx
+
+# Publish (weave) the configuration into the graph store
+datapaw semantic weave submit --datasource-id <id> [--mode FULL] [--wait]
+datapaw semantic weave list [--datasource-name <n>] [--task-name <n>]
+datapaw semantic weave kill <task_id>
+```
+
+With `--wait` the CLI polls until the task reaches a terminal state
+(`success`, `failed`, `killed`), printing progress to stderr and the final
+task record as JSON to stdout; the exit code is `0` only for `success`.
 
 The default CLI model uses provider `openai` together with `LLM_MODEL`,
 `OPENAI_API_KEY`, and `OPENAI_BASE_URL`. Set the corresponding

--- a/packages/datapaw-cli/src/datapaw/cli/commands/__init__.py
+++ b/packages/datapaw-cli/src/datapaw/cli/commands/__init__.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from . import chat, datasource, doctor, execute, plan, run
+from . import chat, datasource, doctor, execute, plan, run, semantic
 
-COMMANDS = [plan, execute, run, chat, datasource, doctor]
+COMMANDS = [plan, execute, run, chat, datasource, semantic, doctor]
 
 __all__ = ["COMMANDS"]

--- a/packages/datapaw-cli/src/datapaw/cli/commands/datasource.py
+++ b/packages/datapaw-cli/src/datapaw/cli/commands/datasource.py
@@ -1,12 +1,23 @@
-"""Context Manager datasource discovery commands."""
+"""Context Manager datasource discovery and management commands."""
 
 from __future__ import annotations
 
 import argparse
-import json
+from pathlib import Path
 from typing import Any
 
 from datapaw.host.core.cm_client import CMDatasource, ContextManagerClient
+from datapaw.host.core.semantic_config_client import (
+    SEMANTIC_CONFIG_PREFIX,
+    SemanticConfigClient,
+)
+
+from datapaw.cli.util import (
+    confirm_deletion,
+    load_json_object,
+    parse_json_object,
+    print_json,
+)
 
 MASKED_SECRET = "******"
 SENSITIVE_CONFIG_FIELDS = frozenset(
@@ -18,11 +29,13 @@ SENSITIVE_CONFIG_FIELDS = frozenset(
     },
 )
 
+_DATASOURCE_PATH = f"{SEMANTIC_CONFIG_PREFIX}/datasource"
+
 
 def register(subparsers: argparse._SubParsersAction) -> None:
     parser = subparsers.add_parser(
         "datasource",
-        help="Inspect datasources configured in DataBridge",
+        help="Manage datasources configured in DataBridge",
     )
     datasource_subparsers = parser.add_subparsers(
         dest="datasource_command",
@@ -35,6 +48,102 @@ def register(subparsers: argparse._SubParsersAction) -> None:
     )
     list_parser.set_defaults(handler=handle_list)
 
+    get_parser = datasource_subparsers.add_parser(
+        "get",
+        help="Show one datasource",
+    )
+    get_parser.add_argument("datasource_id", help="Datasource id")
+    get_parser.add_argument(
+        "--show-config",
+        action="store_true",
+        help="Include the connection config with sensitive fields masked",
+    )
+    get_parser.set_defaults(handler=handle_get)
+
+    create_parser = datasource_subparsers.add_parser(
+        "create",
+        help="Create a datasource (requires a credentials:manage API key)",
+    )
+    create_parser.add_argument("--name", required=True, help="Datasource name")
+    create_parser.add_argument(
+        "--type",
+        required=True,
+        dest="datasource_type",
+        help="Datasource type, e.g. postgresql / mysql / odps",
+    )
+    _add_config_args(create_parser, required=True)
+    create_parser.add_argument(
+        "--test",
+        action="store_true",
+        help="Test the connection first and abort the create on failure",
+    )
+    create_parser.set_defaults(handler=handle_create)
+
+    update_parser = datasource_subparsers.add_parser(
+        "update",
+        help="Update a datasource; a provided config replaces the stored one",
+    )
+    update_parser.add_argument("datasource_id", help="Datasource id")
+    update_parser.add_argument("--name", help="New datasource name")
+    update_parser.add_argument(
+        "--type",
+        dest="datasource_type",
+        help="New datasource type",
+    )
+    _add_config_args(update_parser, required=False)
+    update_parser.set_defaults(handler=handle_update)
+
+    delete_parser = datasource_subparsers.add_parser(
+        "delete",
+        help="Delete a datasource",
+    )
+    delete_parser.add_argument("datasource_id", help="Datasource id")
+    delete_parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="Skip the interactive confirmation",
+    )
+    delete_parser.set_defaults(handler=handle_delete)
+
+    test_parser = datasource_subparsers.add_parser(
+        "test",
+        help="Test connectivity of a saved datasource or an ad-hoc config",
+    )
+    test_parser.add_argument(
+        "datasource_id",
+        nargs="?",
+        help="Saved datasource id (omit when testing an ad-hoc config)",
+    )
+    test_parser.add_argument(
+        "--type",
+        dest="datasource_type",
+        help="Datasource type for an ad-hoc connection test",
+    )
+    _add_config_args(test_parser, required=False)
+    test_parser.set_defaults(handler=handle_test)
+
+
+def _add_config_args(parser: argparse.ArgumentParser, *, required: bool) -> None:
+    group = parser.add_mutually_exclusive_group(required=required)
+    group.add_argument(
+        "--config-file",
+        type=Path,
+        help="Path to a JSON file with the connection config",
+    )
+    group.add_argument(
+        "--config",
+        dest="config_inline",
+        help="Inline JSON object with the connection config",
+    )
+
+
+def _load_config(args: argparse.Namespace) -> dict[str, Any] | None:
+    if getattr(args, "config_file", None) is not None:
+        return load_json_object(args.config_file)
+    if getattr(args, "config_inline", None) is not None:
+        return parse_json_object(args.config_inline, flag="--config")
+    return None
+
 
 def _mask_config(config: dict[str, Any] | None) -> dict[str, Any] | None:
     if config is None:
@@ -45,6 +154,18 @@ def _mask_config(config: dict[str, Any] | None) -> dict[str, Any] | None:
         else value
         for key, value in config.items()
     }
+
+
+def _masked_record(record: dict[str, Any], *, include_config: bool) -> dict[str, Any]:
+    payload = {
+        "datasource_id": record.get("datasource_id"),
+        "datasource_name": record.get("datasource_name"),
+        "datasource_type": record.get("datasource_type"),
+    }
+    if include_config:
+        config = record.get("config")
+        payload["config"] = _mask_config(config if isinstance(config, dict) else None)
+    return payload
 
 
 def _output_item(item: CMDatasource) -> dict[str, Any]:
@@ -62,8 +183,99 @@ def handle_list(_: argparse.Namespace) -> int:
         "items": [_output_item(item) for item in result.items],
         "total": result.total,
     }
-    print(json.dumps(payload, ensure_ascii=False, indent=2))
+    print_json(payload)
     return 0
 
 
-__all__ = ["handle_list", "register"]
+def handle_get(args: argparse.Namespace) -> int:
+    record = SemanticConfigClient().get(
+        f"{_DATASOURCE_PATH}/{args.datasource_id}",
+    )
+    print_json(_masked_record(record, include_config=args.show_config))
+    return 0
+
+
+def handle_create(args: argparse.Namespace) -> int:
+    config = _load_config(args)
+    client = SemanticConfigClient()
+    if args.test:
+        result = client.post(
+            f"{_DATASOURCE_PATH}/test-connection",
+            json={"datasource_type": args.datasource_type, "config": config},
+        )
+        if not result.get("success"):
+            raise ValueError(
+                f"connection test failed, datasource not created: {result.get('message')}",
+            )
+    record = client.post(
+        _DATASOURCE_PATH,
+        json={
+            "datasource_name": args.name,
+            "datasource_type": args.datasource_type,
+            "config": config,
+        },
+    )
+    print_json(_masked_record(record, include_config=True))
+    return 0
+
+
+def handle_update(args: argparse.Namespace) -> int:
+    config = _load_config(args)
+    payload: dict[str, Any] = {}
+    if args.name is not None:
+        payload["datasource_name"] = args.name
+    if args.datasource_type is not None:
+        payload["datasource_type"] = args.datasource_type
+    if config is not None:
+        payload["config"] = config
+    if not payload:
+        raise ValueError("nothing to update: pass --name, --type, or a config")
+    record = SemanticConfigClient().put(
+        f"{_DATASOURCE_PATH}/{args.datasource_id}",
+        json=payload,
+    )
+    print_json(_masked_record(record, include_config=True))
+    return 0
+
+
+def handle_delete(args: argparse.Namespace) -> int:
+    if not confirm_deletion(f"datasource {args.datasource_id}", assume_yes=args.yes):
+        print("aborted")
+        return 1
+    result = SemanticConfigClient().delete(
+        f"{_DATASOURCE_PATH}/{args.datasource_id}",
+    )
+    print_json(result if result else {"deleted": args.datasource_id})
+    return 0
+
+
+def handle_test(args: argparse.Namespace) -> int:
+    config = _load_config(args)
+    ad_hoc = args.datasource_type is not None or config is not None
+    if args.datasource_id and ad_hoc:
+        raise ValueError("pass either a datasource id or --type with a config, not both")
+    client = SemanticConfigClient()
+    if args.datasource_id:
+        result = client.post(
+            f"{_DATASOURCE_PATH}/{args.datasource_id}/test-connection",
+        )
+    elif args.datasource_type is not None and config is not None:
+        result = client.post(
+            f"{_DATASOURCE_PATH}/test-connection",
+            json={"datasource_type": args.datasource_type, "config": config},
+        )
+    else:
+        raise ValueError("pass a datasource id, or --type together with a config")
+    print_json(result)
+    return 0 if result.get("success") else 1
+
+
+__all__ = [
+    "handle_create",
+    "handle_delete",
+    "handle_get",
+    "handle_list",
+    "handle_test",
+    "handle_update",
+    "register",
+]

--- a/packages/datapaw-cli/src/datapaw/cli/commands/semantic.py
+++ b/packages/datapaw-cli/src/datapaw/cli/commands/semantic.py
@@ -21,8 +21,14 @@ from datapaw.cli.util import (
 )
 
 _WEAVE_PATH = f"{SEMANTIC_CONFIG_PREFIX}/weave-task"
+# DataBridge reports weave states in upper case (SUCCESS/FAILED/KILLED);
+# compare case-insensitively to stay tolerant of both spellings.
 _WEAVE_TERMINAL_STATES = frozenset({"success", "failed", "killed"})
 _WEAVE_POLL_SECONDS = 2.0
+
+
+def _weave_status(record: dict[str, Any]) -> str:
+    return str(record.get("status") or "").lower()
 
 
 @dataclass(frozen=True)
@@ -520,12 +526,12 @@ def _wait_for_weave_task(
 ) -> tuple[dict[str, Any], bool]:
     """Poll until the task is terminal. Returns (last_record, finished)."""
     task_id = str(task.get("task_id") or "")
-    last_status = str(task.get("status") or "")
+    last_status = _weave_status(task)
     print(f"weave task {task_id}: {last_status or 'submitted'}", file=sys.stderr)
     deadline = time.monotonic() + timeout
     current = task
     while time.monotonic() < deadline:
-        status = str(current.get("status") or "")
+        status = _weave_status(current)
         if status != last_status:
             print(f"\nweave task {task_id}: {status}", file=sys.stderr)
             last_status = status
@@ -562,7 +568,7 @@ def handle_weave_submit(args: argparse.Namespace) -> int:
             f"inspect it with 'datapaw semantic weave list' or stop it with "
             f"'datapaw semantic weave kill {task_id}'",
         )
-    return 0 if task.get("status") == "success" else 1
+    return 0 if _weave_status(task) == "success" else 1
 
 
 def handle_weave_list(args: argparse.Namespace) -> int:

--- a/packages/datapaw-cli/src/datapaw/cli/commands/semantic.py
+++ b/packages/datapaw-cli/src/datapaw/cli/commands/semantic.py
@@ -1,0 +1,588 @@
+"""Semantic-layer configuration commands: CRUD, Excel import, and weave."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+from datapaw.host.core.semantic_config_client import (
+    SEMANTIC_CONFIG_PREFIX,
+    SemanticConfigClient,
+)
+
+from datapaw.cli.util import (
+    confirm_deletion,
+    load_json_object,
+    print_json,
+)
+
+_WEAVE_PATH = f"{SEMANTIC_CONFIG_PREFIX}/weave-task"
+_WEAVE_TERMINAL_STATES = frozenset({"success", "failed", "killed"})
+_WEAVE_POLL_SECONDS = 2.0
+
+
+@dataclass(frozen=True)
+class Field:
+    """One first-class CLI flag mapped to an API payload/query key."""
+
+    flag: str
+    key: str
+    value_type: Callable[[str], Any] = str
+    is_bool: bool = False
+    help: str = ""
+
+    @property
+    def dest(self) -> str:
+        return f"field_{self.key}"
+
+
+@dataclass(frozen=True)
+class Resource:
+    """Declarative description of one semantic-config CRUD resource."""
+
+    name: str
+    path: str
+    help: str
+    list_filters: tuple[Field, ...]
+    create_fields: tuple[Field, ...]
+    update_fields: tuple[Field, ...]
+    dataset_batch_delete: bool = False
+
+    @property
+    def api_path(self) -> str:
+        return f"{SEMANTIC_CONFIG_PREFIX}/{self.path}"
+
+
+def _f(flag: str, key: str, **kwargs: Any) -> Field:
+    return Field(flag=flag, key=key, **kwargs)
+
+
+RESOURCES: tuple[Resource, ...] = (
+    Resource(
+        name="domain",
+        path="biz-domain",
+        help="Business domains",
+        list_filters=(
+            _f("--datasource-id", "datasource_id"),
+            _f("--name", "domain_name"),
+        ),
+        create_fields=(
+            _f("--datasource-id", "datasource_id"),
+            _f("--name", "domain_name"),
+            _f("--display-name", "display_name"),
+            _f("--description", "description"),
+            _f("--aliases", "aliases"),
+        ),
+        update_fields=(
+            _f("--name", "domain_name"),
+            _f("--display-name", "display_name"),
+            _f("--description", "description"),
+            _f("--aliases", "aliases"),
+        ),
+    ),
+    Resource(
+        name="dataset",
+        path="dataset-meta",
+        help="Datasets",
+        list_filters=(
+            _f("--datasource-id", "datasource_id"),
+            _f("--domain-id", "domain_id", value_type=int),
+            _f("--name", "dataset_name"),
+            _f("--type", "dataset_type"),
+        ),
+        create_fields=(
+            _f("--datasource-id", "datasource_id"),
+            _f("--domain-id", "domain_id", value_type=int),
+            _f("--name", "dataset_name"),
+            _f("--comment", "dataset_comment"),
+            _f("--type", "dataset_type"),
+            _f("--sql", "sql_content"),
+            _f("--parents", "parents"),
+        ),
+        update_fields=(
+            _f("--name", "dataset_name"),
+            _f("--comment", "dataset_comment"),
+            _f("--type", "dataset_type"),
+            _f("--sql", "sql_content"),
+            _f("--parents", "parents"),
+        ),
+    ),
+    Resource(
+        name="column",
+        path="dataset-column-meta",
+        help="Dataset columns",
+        list_filters=(
+            _f("--datasource-id", "datasource_id"),
+            _f("--domain-id", "domain_id", value_type=int),
+            _f("--dataset-id", "dataset_id", value_type=int),
+        ),
+        create_fields=(
+            _f("--dataset-id", "dataset_id", value_type=int),
+            _f("--name", "column_name"),
+            _f("--comment", "column_comment"),
+            _f("--data-type", "data_type"),
+        ),
+        update_fields=(
+            _f("--name", "column_name"),
+            _f("--comment", "column_comment"),
+            _f("--data-type", "data_type"),
+        ),
+    ),
+    Resource(
+        name="dimension",
+        path="dimension",
+        help="Dimensions",
+        list_filters=(
+            _f("--datasource-id", "datasource_id"),
+            _f("--domain-id", "domain_id", value_type=int),
+            _f("--name", "dimension_name"),
+        ),
+        create_fields=(
+            _f("--datasource-id", "datasource_id"),
+            _f("--domain-id", "domain_id", value_type=int),
+            _f("--name", "dimension_name"),
+            _f("--description", "description"),
+            _f("--parent-name", "parent_name"),
+            _f("--synonyms", "synonyms"),
+            _f("--enums", "enums"),
+        ),
+        update_fields=(
+            _f("--name", "dimension_name"),
+            _f("--description", "description"),
+            _f("--parent-name", "parent_name"),
+            _f("--synonyms", "synonyms"),
+            _f("--enums", "enums"),
+        ),
+    ),
+    Resource(
+        name="binding",
+        path="dataset-dimension",
+        help="Dataset-dimension bindings",
+        list_filters=(
+            _f("--datasource-id", "datasource_id"),
+            _f("--domain-id", "domain_id", value_type=int),
+            _f("--dataset-id", "dataset_id", value_type=int),
+            _f("--dataset-name", "dataset_name"),
+            _f("--dimension-name", "dimension_name"),
+        ),
+        create_fields=(
+            _f("--dataset-id", "dataset_id", value_type=int),
+        ),
+        update_fields=(),
+        dataset_batch_delete=True,
+    ),
+    Resource(
+        name="metric",
+        path="metric-lib",
+        help="Metrics",
+        list_filters=(
+            _f("--datasource-id", "datasource_id"),
+            _f("--domain-id", "domain_id", value_type=int),
+            _f("--name", "metric_name"),
+        ),
+        create_fields=(
+            _f("--datasource-id", "datasource_id"),
+            _f("--domain-id", "domain_id", value_type=int),
+            _f("--name", "metric_name"),
+            _f("--description", "description"),
+            _f("--unit", "unit"),
+            _f("--synonyms", "synonyms"),
+            _f("--tags", "tags"),
+            _f("--polaris", "is_polaris", is_bool=True),
+        ),
+        update_fields=(
+            _f("--name", "metric_name"),
+            _f("--description", "description"),
+            _f("--unit", "unit"),
+            _f("--synonyms", "synonyms"),
+            _f("--tags", "tags"),
+        ),
+    ),
+    Resource(
+        name="formula",
+        path="metric-formula-lib",
+        help="Metric formulas",
+        list_filters=(
+            _f("--datasource-id", "datasource_id"),
+            _f("--domain-id", "domain_id", value_type=int),
+            _f("--metric-id", "metric_id", value_type=int),
+            _f("--dataset-id", "dataset_id", value_type=int),
+        ),
+        create_fields=(
+            _f("--metric-id", "metric_id", value_type=int),
+            _f("--dataset-id", "dataset_id", value_type=int),
+            _f("--formula", "formula"),
+        ),
+        update_fields=(
+            _f("--formula", "formula"),
+        ),
+        dataset_batch_delete=True,
+    ),
+)
+
+
+def register(subparsers: argparse._SubParsersAction) -> None:
+    parser = subparsers.add_parser(
+        "semantic",
+        help="Manage the DataBridge semantic configuration layer",
+    )
+    semantic_subparsers = parser.add_subparsers(
+        dest="semantic_command",
+        required=True,
+    )
+
+    for resource in RESOURCES:
+        _register_resource(semantic_subparsers, resource)
+
+    import_parser = semantic_subparsers.add_parser(
+        "import",
+        help="Import a semantic configuration workbook (.xlsx)",
+    )
+    import_parser.add_argument(
+        "--file",
+        type=Path,
+        required=True,
+        help="Path to the semantic configuration .xlsx workbook",
+    )
+    import_parser.set_defaults(handler=handle_import)
+
+    _register_weave(semantic_subparsers)
+
+
+def _register_resource(
+    subparsers: argparse._SubParsersAction,
+    resource: Resource,
+) -> None:
+    parser = subparsers.add_parser(resource.name, help=resource.help)
+    actions = parser.add_subparsers(
+        dest=f"{resource.name}_command",
+        required=True,
+    )
+
+    list_parser = actions.add_parser("list", help=f"List {resource.help.lower()}")
+    for filter_field in resource.list_filters:
+        list_parser.add_argument(
+            filter_field.flag,
+            dest=filter_field.dest,
+            type=filter_field.value_type,
+        )
+    list_parser.add_argument("--page", type=int, default=1)
+    list_parser.add_argument("--size", type=int, default=20)
+    list_parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Fetch every page",
+    )
+    list_parser.set_defaults(handler=handle_resource_list, resource=resource)
+
+    get_parser = actions.add_parser("get", help="Show one record")
+    get_parser.add_argument("record_id", type=int, help="Record id")
+    get_parser.set_defaults(handler=handle_resource_get, resource=resource)
+
+    create_parser = actions.add_parser(
+        "create",
+        help="Create a record (fields via flags, or --file with a JSON object)",
+    )
+    _add_payload_args(create_parser, resource.create_fields)
+    create_parser.set_defaults(handler=handle_resource_create, resource=resource)
+
+    update_parser = actions.add_parser(
+        "update",
+        help="Update a record (fields via flags, or --file with a JSON object)",
+    )
+    update_parser.add_argument("record_id", type=int, help="Record id")
+    _add_payload_args(update_parser, resource.update_fields)
+    update_parser.set_defaults(handler=handle_resource_update, resource=resource)
+
+    delete_parser = actions.add_parser("delete", help="Delete a record")
+    if resource.dataset_batch_delete:
+        delete_parser.add_argument(
+            "record_id",
+            type=int,
+            nargs="?",
+            help="Record id (omit when using --dataset-id)",
+        )
+        delete_parser.add_argument(
+            "--dataset-id",
+            type=int,
+            help=f"Delete every {resource.name} of one dataset",
+        )
+    else:
+        delete_parser.add_argument("record_id", type=int, help="Record id")
+    delete_parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="Skip the interactive confirmation",
+    )
+    delete_parser.set_defaults(handler=handle_resource_delete, resource=resource)
+
+
+def _add_payload_args(
+    parser: argparse.ArgumentParser,
+    fields: tuple[Field, ...],
+) -> None:
+    parser.add_argument(
+        "--file",
+        type=Path,
+        dest="payload_file",
+        help="JSON object file with the full request body",
+    )
+    for payload_field in fields:
+        if payload_field.is_bool:
+            parser.add_argument(
+                payload_field.flag,
+                dest=payload_field.dest,
+                action="store_true",
+                default=None,
+            )
+        else:
+            parser.add_argument(
+                payload_field.flag,
+                dest=payload_field.dest,
+                type=payload_field.value_type,
+            )
+
+
+def _build_payload(
+    args: argparse.Namespace,
+    fields: tuple[Field, ...],
+) -> dict[str, Any]:
+    """Assemble the request body from --file XOR first-class flags."""
+    flag_values = {
+        payload_field.key: getattr(args, payload_field.dest)
+        for payload_field in fields
+        if getattr(args, payload_field.dest, None) is not None
+    }
+    payload_file = getattr(args, "payload_file", None)
+    if payload_file is not None and flag_values:
+        raise ValueError("pass either --file or field flags, not both")
+    if payload_file is not None:
+        return load_json_object(payload_file)
+    if not flag_values:
+        raise ValueError("nothing to send: pass field flags or --file")
+    return flag_values
+
+
+def _filter_params(args: argparse.Namespace, fields: tuple[Field, ...]) -> dict[str, Any]:
+    return {
+        filter_field.key: getattr(args, filter_field.dest)
+        for filter_field in fields
+        if getattr(args, filter_field.dest, None) is not None
+    }
+
+
+def handle_resource_list(args: argparse.Namespace) -> int:
+    resource: Resource = args.resource
+    client = SemanticConfigClient()
+    params = _filter_params(args, resource.list_filters)
+    if args.all:
+        page = client.list_all(resource.api_path, params=params)
+    else:
+        page = client.list_page(
+            resource.api_path,
+            params=params,
+            page=args.page,
+            size=args.size,
+        )
+    print_json({"items": page["records"], "total": page["total"]})
+    return 0
+
+
+def handle_resource_get(args: argparse.Namespace) -> int:
+    resource: Resource = args.resource
+    record = SemanticConfigClient().get(f"{resource.api_path}/{args.record_id}")
+    print_json(record)
+    return 0
+
+
+def handle_resource_create(args: argparse.Namespace) -> int:
+    resource: Resource = args.resource
+    payload = _build_payload(args, resource.create_fields)
+    record = SemanticConfigClient().post(resource.api_path, json=payload)
+    print_json(record)
+    return 0
+
+
+def handle_resource_update(args: argparse.Namespace) -> int:
+    resource: Resource = args.resource
+    payload = _build_payload(args, resource.update_fields)
+    record = SemanticConfigClient().put(
+        f"{resource.api_path}/{args.record_id}",
+        json=payload,
+    )
+    print_json(record)
+    return 0
+
+
+def handle_resource_delete(args: argparse.Namespace) -> int:
+    resource: Resource = args.resource
+    dataset_id = getattr(args, "dataset_id", None)
+    if dataset_id is not None and args.record_id is not None:
+        raise ValueError("pass either a record id or --dataset-id, not both")
+    if dataset_id is not None:
+        subject = f"every {resource.name} of dataset {dataset_id}"
+        path = f"{resource.api_path}/dataset/{dataset_id}"
+    elif args.record_id is not None:
+        subject = f"{resource.name} {args.record_id}"
+        path = f"{resource.api_path}/{args.record_id}"
+    else:
+        raise ValueError("pass a record id or --dataset-id")
+    if not confirm_deletion(subject, assume_yes=args.yes):
+        print("aborted")
+        return 1
+    result = SemanticConfigClient().delete(path)
+    print_json(result if result else {"deleted": subject})
+    return 0
+
+
+def handle_import(args: argparse.Namespace) -> int:
+    path: Path = args.file.expanduser()
+    try:
+        content = path.read_bytes()
+    except OSError as exc:
+        raise ValueError(f"unable to read {path}: {exc}") from exc
+    result = SemanticConfigClient().post(
+        f"{SEMANTIC_CONFIG_PREFIX}/import/excel",
+        files={
+            "file": (
+                path.name,
+                content,
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            ),
+        },
+    )
+    print_json(result)
+    return 0
+
+
+def _register_weave(subparsers: argparse._SubParsersAction) -> None:
+    parser = subparsers.add_parser(
+        "weave",
+        help="Publish the semantic configuration into the graph store",
+    )
+    actions = parser.add_subparsers(dest="weave_command", required=True)
+
+    submit_parser = actions.add_parser("submit", help="Submit a weave task")
+    submit_parser.add_argument(
+        "--datasource-id",
+        required=True,
+        help="Datasource whose semantic configuration should be woven",
+    )
+    submit_parser.add_argument(
+        "--mode",
+        default="FULL",
+        help="Weave mode (default: FULL)",
+    )
+    submit_parser.add_argument("--name", help="Optional task name")
+    submit_parser.add_argument(
+        "--wait",
+        action="store_true",
+        help="Poll until the task reaches a terminal state",
+    )
+    submit_parser.add_argument(
+        "--timeout",
+        type=float,
+        default=600.0,
+        help="Maximum seconds to wait with --wait (default: 600)",
+    )
+    submit_parser.set_defaults(handler=handle_weave_submit)
+
+    list_parser = actions.add_parser("list", help="List weave tasks")
+    list_parser.add_argument("--datasource-name", dest="datasource_name")
+    list_parser.add_argument("--task-name", dest="task_name")
+    list_parser.add_argument("--page", type=int, default=1)
+    list_parser.add_argument("--size", type=int, default=20)
+    list_parser.set_defaults(handler=handle_weave_list)
+
+    kill_parser = actions.add_parser("kill", help="Kill a running weave task")
+    kill_parser.add_argument("task_id", help="Weave task id")
+    kill_parser.set_defaults(handler=handle_weave_kill)
+
+
+def _find_weave_task(client: SemanticConfigClient, task_id: str) -> dict[str, Any] | None:
+    page = client.list_page(_WEAVE_PATH, page=1, size=100)
+    for record in page["records"]:
+        if isinstance(record, dict) and record.get("task_id") == task_id:
+            return record
+    return None
+
+
+def _wait_for_weave_task(
+    client: SemanticConfigClient,
+    task: dict[str, Any],
+    *,
+    timeout: float,
+    poll_seconds: float = _WEAVE_POLL_SECONDS,
+) -> tuple[dict[str, Any], bool]:
+    """Poll until the task is terminal. Returns (last_record, finished)."""
+    task_id = str(task.get("task_id") or "")
+    last_status = str(task.get("status") or "")
+    print(f"weave task {task_id}: {last_status or 'submitted'}", file=sys.stderr)
+    deadline = time.monotonic() + timeout
+    current = task
+    while time.monotonic() < deadline:
+        status = str(current.get("status") or "")
+        if status != last_status:
+            print(f"\nweave task {task_id}: {status}", file=sys.stderr)
+            last_status = status
+        if status in _WEAVE_TERMINAL_STATES:
+            print("", file=sys.stderr)
+            return current, True
+        print(".", end="", file=sys.stderr, flush=True)
+        time.sleep(poll_seconds)
+        current = _find_weave_task(client, task_id) or current
+    print("", file=sys.stderr)
+    return current, False
+
+
+def handle_weave_submit(args: argparse.Namespace) -> int:
+    client = SemanticConfigClient()
+    task = client.post(
+        f"{_WEAVE_PATH}/submit",
+        json={
+            "datasource_id": args.datasource_id,
+            "task_name": args.name,
+            "weave_mode": args.mode,
+        },
+    )
+    if not args.wait:
+        print_json(task)
+        return 0
+
+    task, finished = _wait_for_weave_task(client, task, timeout=args.timeout)
+    print_json(task)
+    if not finished:
+        task_id = task.get("task_id")
+        raise ValueError(
+            f"timed out waiting for weave task {task_id}; it keeps running — "
+            f"inspect it with 'datapaw semantic weave list' or stop it with "
+            f"'datapaw semantic weave kill {task_id}'",
+        )
+    return 0 if task.get("status") == "success" else 1
+
+
+def handle_weave_list(args: argparse.Namespace) -> int:
+    page = SemanticConfigClient().list_page(
+        _WEAVE_PATH,
+        params={
+            "datasource_name": args.datasource_name,
+            "task_name": args.task_name,
+        },
+        page=args.page,
+        size=args.size,
+    )
+    print_json({"items": page["records"], "total": page["total"]})
+    return 0
+
+
+def handle_weave_kill(args: argparse.Namespace) -> int:
+    result = SemanticConfigClient().post(f"{_WEAVE_PATH}/{args.task_id}/kill")
+    print_json(result)
+    return 0
+
+
+__all__ = ["RESOURCES", "register"]

--- a/packages/datapaw-cli/src/datapaw/cli/util.py
+++ b/packages/datapaw-cli/src/datapaw/cli/util.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import json
 import os
 import sys
 from pathlib import Path
@@ -23,6 +24,52 @@ _PERMISSION_MODES = (
 def add_prompt_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("prompt", nargs="*", help="Prompt text")
     parser.add_argument("--file", "-f", type=Path, help="Read prompt text from a file")
+
+
+def print_json(payload: Any) -> None:
+    """Print an API payload with the CLI's canonical JSON formatting."""
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+
+
+def load_json_object(path: Path) -> dict[str, Any]:
+    """Read a JSON object from a file, rejecting non-object documents."""
+    try:
+        payload = json.loads(path.expanduser().read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise ValueError(f"unable to read {path}: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{path} is not valid JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return payload
+
+
+def parse_json_object(text: str, *, flag: str) -> dict[str, Any]:
+    """Parse an inline JSON object argument."""
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{flag} is not valid JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError(f"{flag} must be a JSON object")
+    return payload
+
+
+def confirm_deletion(subject: str, *, assume_yes: bool) -> bool:
+    """Terminal confirmation for destructive commands.
+
+    Returns True when the deletion may proceed. Non-TTY callers must pass
+    --yes explicitly so unattended scripts never block or delete by accident.
+    """
+    if assume_yes:
+        return True
+    if not sys.stdin.isatty():
+        raise ValueError(f"refusing to delete {subject} without --yes in a non-interactive session")
+    try:
+        answer = input(f"Delete {subject}? [y/N] ")
+    except EOFError:
+        return False
+    return answer.strip().lower() in {"y", "yes"}
 
 
 def add_stream_arg(parser: argparse.ArgumentParser) -> None:

--- a/packages/datapaw-cli/tests/test_cli_datasource.py
+++ b/packages/datapaw-cli/tests/test_cli_datasource.py
@@ -1,11 +1,56 @@
 from __future__ import annotations
 
 import json
+from typing import Any
 
 import pytest
 
 from datapaw.cli.main import build_parser, main
 from datapaw.host.core.cm_client import CMDatasource, CMDatasourceList, CMClientError
+
+
+class RecordingClient:
+    """Fake SemanticConfigClient capturing calls and replaying responses."""
+
+    calls: list[tuple[str, str, dict[str, Any]]] = []
+    responses: dict[str, Any] = {}
+
+    def __init__(self, **_: Any) -> None:
+        pass
+
+    @classmethod
+    def reset(cls, responses: dict[str, Any] | None = None) -> None:
+        cls.calls = []
+        cls.responses = responses or {}
+
+    def _record(self, method: str, path: str, **kwargs: Any) -> Any:
+        type(self).calls.append((method, path, kwargs))
+        for key in (f"{method} {path}", method, path):
+            if key in type(self).responses:
+                value = type(self).responses[key]
+                return value.pop(0) if isinstance(value, list) else value
+        return {}
+
+    def get(self, path: str, *, params: Any = None) -> Any:
+        return self._record("GET", path, params=params)
+
+    def post(self, path: str, *, json: Any = None, files: Any = None) -> Any:
+        return self._record("POST", path, json=json, files=files)
+
+    def put(self, path: str, *, json: Any = None) -> Any:
+        return self._record("PUT", path, json=json)
+
+    def delete(self, path: str) -> Any:
+        return self._record("DELETE", path)
+
+
+@pytest.fixture()
+def fake_client(monkeypatch: pytest.MonkeyPatch) -> type[RecordingClient]:
+    from datapaw.cli.commands import datasource
+
+    RecordingClient.reset()
+    monkeypatch.setattr(datasource, "SemanticConfigClient", RecordingClient)
+    return RecordingClient
 
 
 def test_datasource_command_is_registered_without_base_url_option() -> None:
@@ -137,3 +182,158 @@ def test_datasource_list_reports_safe_client_error(
     captured = capsys.readouterr()
     assert captured.out == ""
     assert "invalid datasource_id" in captured.err
+
+
+def test_datasource_get_hides_config_by_default(
+    fake_client: type[RecordingClient],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    fake_client.reset(
+        {
+            "GET": {
+                "datasource_id": "pg-1",
+                "datasource_name": "demo",
+                "datasource_type": "postgresql",
+                "config": {"host": "db", "password": "secret"},
+            },
+        },
+    )
+
+    assert main(["datasource", "get", "pg-1"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert "config" not in payload
+    assert fake_client.calls[0][:2] == ("GET", "/api/semantic-config/datasource/pg-1")
+
+
+def test_datasource_get_show_config_masks_secrets(
+    fake_client: type[RecordingClient],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    fake_client.reset(
+        {
+            "GET": {
+                "datasource_id": "pg-1",
+                "config": {"host": "db", "password": "secret"},
+            },
+        },
+    )
+
+    assert main(["datasource", "get", "pg-1", "--show-config"]) == 0
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert payload["config"] == {"host": "db", "password": "******"}
+    assert "secret" not in captured.out
+
+
+def test_datasource_create_with_test_aborts_on_failed_connection(
+    fake_client: type[RecordingClient],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    fake_client.reset(
+        {"POST": {"success": False, "message": "connection refused", "elapsed_ms": 3}},
+    )
+
+    assert main([
+        "datasource", "create",
+        "--name", "demo", "--type", "postgresql",
+        "--config", '{"host": "db", "password": "secret"}',
+        "--test",
+    ]) == 1
+
+    captured = capsys.readouterr()
+    assert "connection test failed" in captured.err
+    # only the test-connection call happened; nothing was created
+    assert len(fake_client.calls) == 1
+    assert fake_client.calls[0][1].endswith("/datasource/test-connection")
+
+
+def test_datasource_create_posts_config_and_masks_output(
+    fake_client: type[RecordingClient],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    fake_client.reset(
+        {
+            "POST": {
+                "datasource_id": "postgresql-x",
+                "datasource_name": "demo",
+                "datasource_type": "postgresql",
+                "config": {"host": "db", "password": "secret"},
+            },
+        },
+    )
+
+    assert main([
+        "datasource", "create",
+        "--name", "demo", "--type", "postgresql",
+        "--config", '{"host": "db", "password": "secret"}',
+    ]) == 0
+
+    method, path, kwargs = fake_client.calls[0]
+    assert (method, path) == ("POST", "/api/semantic-config/datasource")
+    assert kwargs["json"]["config"] == {"host": "db", "password": "secret"}
+
+    captured = capsys.readouterr()
+    assert json.loads(captured.out)["config"]["password"] == "******"
+    assert "secret" not in captured.out
+
+
+def test_datasource_update_requires_a_change(
+    fake_client: type[RecordingClient],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert main(["datasource", "update", "pg-1"]) == 1
+    assert "nothing to update" in capsys.readouterr().err
+    assert fake_client.calls == []
+
+
+def test_datasource_update_puts_partial_payload(
+    fake_client: type[RecordingClient],
+) -> None:
+    assert main(["datasource", "update", "pg-1", "--name", "renamed"]) == 0
+    method, path, kwargs = fake_client.calls[0]
+    assert (method, path) == ("PUT", "/api/semantic-config/datasource/pg-1")
+    assert kwargs["json"] == {"datasource_name": "renamed"}
+
+
+def test_datasource_delete_requires_yes_in_non_tty(
+    fake_client: type[RecordingClient],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert main(["datasource", "delete", "pg-1"]) == 1
+    assert "--yes" in capsys.readouterr().err
+    assert fake_client.calls == []
+
+
+def test_datasource_delete_with_yes(fake_client: type[RecordingClient]) -> None:
+    assert main(["datasource", "delete", "pg-1", "--yes"]) == 0
+    assert fake_client.calls[0][:2] == ("DELETE", "/api/semantic-config/datasource/pg-1")
+
+
+def test_datasource_test_saved_id_exit_code_follows_success(
+    fake_client: type[RecordingClient],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    fake_client.reset({"POST": {"success": True, "message": "ok", "elapsed_ms": 5}})
+    assert main(["datasource", "test", "pg-1"]) == 0
+    assert fake_client.calls[0][:2] == (
+        "POST",
+        "/api/semantic-config/datasource/pg-1/test-connection",
+    )
+
+    fake_client.reset({"POST": {"success": False, "message": "nope", "elapsed_ms": 5}})
+    assert main(["datasource", "test", "pg-1"]) == 1
+    capsys.readouterr()
+
+
+def test_datasource_test_rejects_id_and_adhoc_config_together(
+    fake_client: type[RecordingClient],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert main([
+        "datasource", "test", "pg-1",
+        "--type", "postgresql", "--config", "{}",
+    ]) == 1
+    assert "not both" in capsys.readouterr().err
+    assert fake_client.calls == []

--- a/packages/datapaw-cli/tests/test_cli_semantic.py
+++ b/packages/datapaw-cli/tests/test_cli_semantic.py
@@ -1,0 +1,330 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from datapaw.cli.main import build_parser, main
+
+
+class RecordingClient:
+    """Fake SemanticConfigClient capturing calls and replaying responses."""
+
+    calls: list[tuple[str, str, dict[str, Any]]] = []
+    responses: dict[str, Any] = {}
+
+    def __init__(self, **_: Any) -> None:
+        pass
+
+    @classmethod
+    def reset(cls, responses: dict[str, Any] | None = None) -> None:
+        cls.calls = []
+        cls.responses = responses or {}
+
+    def _record(self, method: str, path: str, **kwargs: Any) -> Any:
+        type(self).calls.append((method, path, kwargs))
+        for key in (f"{method} {path}", method, path):
+            if key in type(self).responses:
+                value = type(self).responses[key]
+                return value.pop(0) if isinstance(value, list) else value
+        return {}
+
+    def get(self, path: str, *, params: Any = None) -> Any:
+        return self._record("GET", path, params=params)
+
+    def post(self, path: str, *, json: Any = None, files: Any = None) -> Any:
+        return self._record("POST", path, json=json, files=files)
+
+    def put(self, path: str, *, json: Any = None) -> Any:
+        return self._record("PUT", path, json=json)
+
+    def delete(self, path: str) -> Any:
+        return self._record("DELETE", path)
+
+    def list_page(self, path: str, *, params: Any = None, page: int = 1, size: int = 20) -> Any:
+        return self._record("LIST", path, params=params, page=page, size=size)
+
+    def list_all(self, path: str, *, params: Any = None, size: int = 100) -> Any:
+        return self._record("LIST_ALL", path, params=params, size=size)
+
+
+@pytest.fixture()
+def fake_client(monkeypatch: pytest.MonkeyPatch) -> type[RecordingClient]:
+    from datapaw.cli.commands import semantic
+
+    RecordingClient.reset()
+    monkeypatch.setattr(semantic, "SemanticConfigClient", RecordingClient)
+    return RecordingClient
+
+
+def test_semantic_command_registers_all_resources() -> None:
+    help_text = build_parser().format_help()
+    assert "semantic" in help_text
+    for name in ("domain", "dataset", "column", "dimension", "binding", "metric", "formula"):
+        parser = build_parser()
+        with pytest.raises(SystemExit) as exc_info:
+            parser.parse_args(["semantic", name])
+        assert exc_info.value.code == 2  # missing required action subcommand
+
+
+def test_metric_list_maps_filters_and_prints_items(
+    fake_client: type[RecordingClient],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    fake_client.reset(
+        {"LIST": {"records": [{"id": 1, "metric_name": "gaap"}], "total": 1, "page": 1}},
+    )
+
+    assert main([
+        "semantic", "metric", "list",
+        "--datasource-id", "pg-1", "--domain-id", "2", "--name", "gaap",
+        "--page", "3", "--size", "10",
+    ]) == 0
+
+    method, path, kwargs = fake_client.calls[0]
+    assert (method, path) == ("LIST", "/api/semantic-config/metric-lib")
+    assert kwargs["params"] == {"datasource_id": "pg-1", "domain_id": 2, "metric_name": "gaap"}
+    assert kwargs["page"] == 3 and kwargs["size"] == 10
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {"items": [{"id": 1, "metric_name": "gaap"}], "total": 1}
+
+
+def test_domain_list_all_uses_list_all(fake_client: type[RecordingClient]) -> None:
+    fake_client.reset({"LIST_ALL": {"records": [], "total": 0}})
+    assert main(["semantic", "domain", "list", "--all"]) == 0
+    assert fake_client.calls[0][0] == "LIST_ALL"
+
+
+def test_metric_create_builds_payload_from_flags(
+    fake_client: type[RecordingClient],
+) -> None:
+    assert main([
+        "semantic", "metric", "create",
+        "--datasource-id", "pg-1", "--domain-id", "2",
+        "--name", "gaap", "--unit", "CNY", "--polaris",
+    ]) == 0
+
+    method, path, kwargs = fake_client.calls[0]
+    assert (method, path) == ("POST", "/api/semantic-config/metric-lib")
+    assert kwargs["json"] == {
+        "datasource_id": "pg-1",
+        "domain_id": 2,
+        "metric_name": "gaap",
+        "unit": "CNY",
+        "is_polaris": True,
+    }
+
+
+def test_create_rejects_file_combined_with_flags(
+    fake_client: type[RecordingClient],
+    tmp_path: Any,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    payload_file = tmp_path / "metric.json"
+    payload_file.write_text('{"metric_name": "x"}', encoding="utf-8")
+
+    assert main([
+        "semantic", "metric", "create",
+        "--file", str(payload_file), "--name", "x",
+    ]) == 1
+    assert "not both" in capsys.readouterr().err
+    assert fake_client.calls == []
+
+
+def test_create_from_json_file(
+    fake_client: type[RecordingClient],
+    tmp_path: Any,
+) -> None:
+    payload_file = tmp_path / "formula.json"
+    payload_file.write_text(
+        '{"metric_id": 1, "dataset_id": 2, "formula": "sum(x)"}',
+        encoding="utf-8",
+    )
+
+    assert main(["semantic", "formula", "create", "--file", str(payload_file)]) == 0
+    method, path, kwargs = fake_client.calls[0]
+    assert (method, path) == ("POST", "/api/semantic-config/metric-formula-lib")
+    assert kwargs["json"] == {"metric_id": 1, "dataset_id": 2, "formula": "sum(x)"}
+
+
+def test_update_requires_some_change(
+    fake_client: type[RecordingClient],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert main(["semantic", "dimension", "update", "7"]) == 1
+    assert "nothing to send" in capsys.readouterr().err
+    assert fake_client.calls == []
+
+
+def test_update_puts_to_record_path(fake_client: type[RecordingClient]) -> None:
+    assert main([
+        "semantic", "dimension", "update", "7", "--description", "d",
+    ]) == 0
+    method, path, kwargs = fake_client.calls[0]
+    assert (method, path) == ("PUT", "/api/semantic-config/dimension/7")
+    assert kwargs["json"] == {"description": "d"}
+
+
+def test_delete_requires_yes_in_non_tty(
+    fake_client: type[RecordingClient],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert main(["semantic", "metric", "delete", "3"]) == 1
+    assert "--yes" in capsys.readouterr().err
+    assert fake_client.calls == []
+
+
+def test_delete_with_yes_calls_api(fake_client: type[RecordingClient]) -> None:
+    assert main(["semantic", "metric", "delete", "3", "--yes"]) == 0
+    assert fake_client.calls[0][:2] == ("DELETE", "/api/semantic-config/metric-lib/3")
+
+
+def test_binding_batch_delete_by_dataset(fake_client: type[RecordingClient]) -> None:
+    assert main([
+        "semantic", "binding", "delete", "--dataset-id", "12", "--yes",
+    ]) == 0
+    assert fake_client.calls[0][:2] == (
+        "DELETE",
+        "/api/semantic-config/dataset-dimension/dataset/12",
+    )
+
+
+def test_binding_delete_rejects_both_targets(
+    fake_client: type[RecordingClient],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert main([
+        "semantic", "binding", "delete", "5", "--dataset-id", "12", "--yes",
+    ]) == 1
+    assert "not both" in capsys.readouterr().err
+    assert fake_client.calls == []
+
+
+def test_import_uploads_workbook(
+    fake_client: type[RecordingClient],
+    tmp_path: Any,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    workbook = tmp_path / "semantic.xlsx"
+    workbook.write_bytes(b"xlsx-bytes")
+    fake_client.reset({"POST": {"success": True, "summary": {"metric_lib": 2}}})
+
+    assert main(["semantic", "import", "--file", str(workbook)]) == 0
+
+    method, path, kwargs = fake_client.calls[0]
+    assert (method, path) == ("POST", "/api/semantic-config/import/excel")
+    assert kwargs["files"]["file"][0] == "semantic.xlsx"
+    assert kwargs["files"]["file"][1] == b"xlsx-bytes"
+    assert json.loads(capsys.readouterr().out)["success"] is True
+
+
+def test_weave_submit_without_wait_prints_task(
+    fake_client: type[RecordingClient],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    fake_client.reset(
+        {"POST": {"task_id": "t-1", "status": "pending", "datasource_id": "pg-1"}},
+    )
+
+    assert main([
+        "semantic", "weave", "submit", "--datasource-id", "pg-1", "--name", "n1",
+    ]) == 0
+
+    method, path, kwargs = fake_client.calls[0]
+    assert (method, path) == ("POST", "/api/semantic-config/weave-task/submit")
+    assert kwargs["json"] == {"datasource_id": "pg-1", "task_name": "n1", "weave_mode": "FULL"}
+    assert json.loads(capsys.readouterr().out)["task_id"] == "t-1"
+
+
+def test_weave_submit_wait_polls_to_terminal_state(
+    fake_client: type[RecordingClient],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from datapaw.cli.commands import semantic
+
+    monkeypatch.setattr(semantic, "_WEAVE_POLL_SECONDS", 0.0)
+    fake_client.reset(
+        {
+            "POST": {"task_id": "t-2", "status": "pending"},
+            "LIST": [
+                {"records": [{"task_id": "t-2", "status": "running"}], "total": 1, "page": 1},
+                {"records": [{"task_id": "t-2", "status": "success"}], "total": 1, "page": 1},
+            ],
+        },
+    )
+
+    assert main([
+        "semantic", "weave", "submit", "--datasource-id", "pg-1", "--wait",
+    ]) == 0
+
+    captured = capsys.readouterr()
+    assert json.loads(captured.out)["status"] == "success"
+    assert "running" in captured.err
+    assert "." in captured.err
+
+
+def test_weave_submit_wait_fails_on_failed_task(
+    fake_client: type[RecordingClient],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from datapaw.cli.commands import semantic
+
+    monkeypatch.setattr(semantic, "_WEAVE_POLL_SECONDS", 0.0)
+    fake_client.reset(
+        {
+            "POST": {"task_id": "t-3", "status": "pending"},
+            "LIST": {
+                "records": [{"task_id": "t-3", "status": "failed", "error_msg": "boom"}],
+                "total": 1,
+                "page": 1,
+            },
+        },
+    )
+
+    assert main([
+        "semantic", "weave", "submit", "--datasource-id", "pg-1", "--wait",
+    ]) == 1
+    assert json.loads(capsys.readouterr().out)["error_msg"] == "boom"
+
+
+def test_weave_submit_wait_times_out_with_kill_hint(
+    fake_client: type[RecordingClient],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from datapaw.cli.commands import semantic
+
+    monkeypatch.setattr(semantic, "_WEAVE_POLL_SECONDS", 0.0)
+    fake_client.reset(
+        {
+            "POST": {"task_id": "t-4", "status": "pending"},
+            "LIST": {
+                "records": [{"task_id": "t-4", "status": "running"}],
+                "total": 1,
+                "page": 1,
+            },
+        },
+    )
+
+    assert main([
+        "semantic", "weave", "submit", "--datasource-id", "pg-1",
+        "--wait", "--timeout", "0",
+    ]) == 1
+    captured = capsys.readouterr()
+    assert "weave kill t-4" in captured.err
+
+
+def test_weave_list_and_kill(fake_client: type[RecordingClient]) -> None:
+    fake_client.reset({"LIST": {"records": [], "total": 0, "page": 1}})
+    assert main(["semantic", "weave", "list", "--task-name", "n"]) == 0
+    method, path, kwargs = fake_client.calls[0]
+    assert (method, path) == ("LIST", "/api/semantic-config/weave-task")
+    assert kwargs["params"] == {"datasource_name": None, "task_name": "n"}
+
+    fake_client.reset()
+    assert main(["semantic", "weave", "kill", "t-9"]) == 0
+    assert fake_client.calls[0][:2] == ("POST", "/api/semantic-config/weave-task/t-9/kill")

--- a/packages/datapaw-cli/tests/test_cli_semantic.py
+++ b/packages/datapaw-cli/tests/test_cli_semantic.py
@@ -248,10 +248,10 @@ def test_weave_submit_wait_polls_to_terminal_state(
     monkeypatch.setattr(semantic, "_WEAVE_POLL_SECONDS", 0.0)
     fake_client.reset(
         {
-            "POST": {"task_id": "t-2", "status": "pending"},
+            "POST": {"task_id": "t-2", "status": "PENDING"},
             "LIST": [
-                {"records": [{"task_id": "t-2", "status": "running"}], "total": 1, "page": 1},
-                {"records": [{"task_id": "t-2", "status": "success"}], "total": 1, "page": 1},
+                {"records": [{"task_id": "t-2", "status": "RUNNING"}], "total": 1, "page": 1},
+                {"records": [{"task_id": "t-2", "status": "SUCCESS"}], "total": 1, "page": 1},
             ],
         },
     )
@@ -261,7 +261,7 @@ def test_weave_submit_wait_polls_to_terminal_state(
     ]) == 0
 
     captured = capsys.readouterr()
-    assert json.loads(captured.out)["status"] == "success"
+    assert json.loads(captured.out)["status"] == "SUCCESS"
     assert "running" in captured.err
     assert "." in captured.err
 
@@ -276,9 +276,9 @@ def test_weave_submit_wait_fails_on_failed_task(
     monkeypatch.setattr(semantic, "_WEAVE_POLL_SECONDS", 0.0)
     fake_client.reset(
         {
-            "POST": {"task_id": "t-3", "status": "pending"},
+            "POST": {"task_id": "t-3", "status": "PENDING"},
             "LIST": {
-                "records": [{"task_id": "t-3", "status": "failed", "error_msg": "boom"}],
+                "records": [{"task_id": "t-3", "status": "FAILED", "error_msg": "boom"}],
                 "total": 1,
                 "page": 1,
             },
@@ -301,9 +301,9 @@ def test_weave_submit_wait_times_out_with_kill_hint(
     monkeypatch.setattr(semantic, "_WEAVE_POLL_SECONDS", 0.0)
     fake_client.reset(
         {
-            "POST": {"task_id": "t-4", "status": "pending"},
+            "POST": {"task_id": "t-4", "status": "PENDING"},
             "LIST": {
-                "records": [{"task_id": "t-4", "status": "running"}],
+                "records": [{"task_id": "t-4", "status": "RUNNING"}],
                 "total": 1,
                 "page": 1,
             },

--- a/packages/datapaw-context/src/semantic_config/repositories/biz_domain_repo.py
+++ b/packages/datapaw-context/src/semantic_config/repositories/biz_domain_repo.py
@@ -45,7 +45,8 @@ async def update(
 ) -> int:
     sql = """
         UPDATE biz_domain SET
-            domain_name = ?, display_name = ?, description = ?, aliases = ?, updated_at = ?
+            domain_name = COALESCE(?, domain_name), display_name = COALESCE(?, display_name),
+            description = COALESCE(?, description), aliases = COALESCE(?, aliases), updated_at = ?
         WHERE id = ? AND is_deleted = 0
     """
     cur = await db.execute(sql, (domain_name, display_name, description, aliases, now_iso(), domain_id))

--- a/packages/datapaw-context/src/semantic_config/repositories/dataset_column_meta_repo.py
+++ b/packages/datapaw-context/src/semantic_config/repositories/dataset_column_meta_repo.py
@@ -39,9 +39,13 @@ async def insert(db: aiosqlite.Connection, m) -> int:
 async def update(db: aiosqlite.Connection, col_id: int, m) -> int:
     sql = """
         UPDATE dataset_column_meta SET
-            column_name = ?, column_name_cn = ?, data_type = ?, column_type = ?, dimension_type = ?,
-            column_comment = ?, column_enums = ?, column_enums_description = ?, samples = ?,
-            is_primary = ?, is_nullable = ?, updated_at = ?
+            column_name = COALESCE(?, column_name), column_name_cn = COALESCE(?, column_name_cn),
+            data_type = COALESCE(?, data_type), column_type = COALESCE(?, column_type),
+            dimension_type = COALESCE(?, dimension_type), column_comment = COALESCE(?, column_comment),
+            column_enums = COALESCE(?, column_enums),
+            column_enums_description = COALESCE(?, column_enums_description),
+            samples = COALESCE(?, samples), is_primary = COALESCE(?, is_primary),
+            is_nullable = COALESCE(?, is_nullable), updated_at = ?
         WHERE id = ? AND is_deleted = 0
     """
     cur = await db.execute(sql, (

--- a/packages/datapaw-context/src/semantic_config/repositories/dataset_dimension_repo.py
+++ b/packages/datapaw-context/src/semantic_config/repositories/dataset_dimension_repo.py
@@ -37,7 +37,8 @@ async def insert(db: aiosqlite.Connection, m) -> int:
 async def update(db: aiosqlite.Connection, dd_id: int, m) -> int:
     sql = """
         UPDATE dataset_dimension SET
-            calculate_expr = ?, dimension_type = ?, data_type = ?, updated_at = ?
+            calculate_expr = COALESCE(?, calculate_expr), dimension_type = COALESCE(?, dimension_type),
+            data_type = COALESCE(?, data_type), updated_at = ?
         WHERE id = ? AND is_deleted = 0
     """
     cur = await db.execute(sql, (m.calculate_expr, m.dimension_type, m.data_type, now_iso(), dd_id))

--- a/packages/datapaw-context/src/semantic_config/repositories/dataset_meta_repo.py
+++ b/packages/datapaw-context/src/semantic_config/repositories/dataset_meta_repo.py
@@ -34,8 +34,9 @@ async def insert(db: aiosqlite.Connection, m) -> int:
 async def update(db: aiosqlite.Connection, dataset_id: int, m) -> int:
     sql = """
         UPDATE dataset_meta SET
-            dataset_name = ?, dataset_comment = ?, dataset_type = ?, sql_content = ?, parents = ?,
-            updated_at = ?
+            dataset_name = COALESCE(?, dataset_name), dataset_comment = COALESCE(?, dataset_comment),
+            dataset_type = COALESCE(?, dataset_type), sql_content = COALESCE(?, sql_content),
+            parents = COALESCE(?, parents), updated_at = ?
         WHERE id = ? AND is_deleted = 0
     """
     cur = await db.execute(sql, (

--- a/packages/datapaw-context/src/semantic_config/repositories/dimension_repo.py
+++ b/packages/datapaw-context/src/semantic_config/repositories/dimension_repo.py
@@ -39,8 +39,10 @@ async def insert(db: aiosqlite.Connection, m) -> int:
 async def update(db: aiosqlite.Connection, dim_id: int, m) -> int:
     sql = """
         UPDATE dimension SET
-            dimension_name = ?, description = ?, parent_name = ?, depth = ?, synonyms = ?,
-            is_visible = ?, is_attribution = ?, enums = ?, updated_at = ?
+            dimension_name = COALESCE(?, dimension_name), description = COALESCE(?, description),
+            parent_name = COALESCE(?, parent_name), depth = COALESCE(?, depth),
+            synonyms = COALESCE(?, synonyms), is_visible = COALESCE(?, is_visible),
+            is_attribution = COALESCE(?, is_attribution), enums = COALESCE(?, enums), updated_at = ?
         WHERE id = ? AND is_deleted = 0
     """
     cur = await db.execute(sql, (

--- a/packages/datapaw-context/src/semantic_config/repositories/metric_formula_lib_repo.py
+++ b/packages/datapaw-context/src/semantic_config/repositories/metric_formula_lib_repo.py
@@ -36,8 +36,9 @@ async def insert(db: aiosqlite.Connection, m) -> int:
 async def update(db: aiosqlite.Connection, fid: int, m) -> int:
     sql = """
         UPDATE metric_formula_lib SET
-            formula = ?, date_range = ?, formula_evidence = ?, derived_from = ?, evidence_ext = ?,
-            updated_at = ?
+            formula = COALESCE(?, formula), date_range = COALESCE(?, date_range),
+            formula_evidence = COALESCE(?, formula_evidence), derived_from = COALESCE(?, derived_from),
+            evidence_ext = COALESCE(?, evidence_ext), updated_at = ?
         WHERE id = ? AND is_deleted = 0
     """
     cur = await db.execute(sql, (

--- a/packages/datapaw-context/src/semantic_config/repositories/metric_lib_repo.py
+++ b/packages/datapaw-context/src/semantic_config/repositories/metric_lib_repo.py
@@ -39,8 +39,11 @@ async def insert(db: aiosqlite.Connection, m) -> int:
 async def update(db: aiosqlite.Connection, metric_id: int, m) -> int:
     sql = """
         UPDATE metric_lib SET
-            metric_name = ?, description = ?, unit = ?, is_polaris = ?, show_distribution = ?,
-            is_visible = ?, synonyms = ?, tags = ?, updated_at = ?
+            metric_name = COALESCE(?, metric_name), description = COALESCE(?, description),
+            unit = COALESCE(?, unit), is_polaris = COALESCE(?, is_polaris),
+            show_distribution = COALESCE(?, show_distribution),
+            is_visible = COALESCE(?, is_visible), synonyms = COALESCE(?, synonyms),
+            tags = COALESCE(?, tags), updated_at = ?
         WHERE id = ? AND is_deleted = 0
     """
     cur = await db.execute(sql, (

--- a/packages/datapaw-context/tests/test_semantic_partial_update.py
+++ b/packages/datapaw-context/tests/test_semantic_partial_update.py
@@ -1,0 +1,128 @@
+"""Partial updates must keep the fields the caller did not send.
+
+Regression tests for the semantic-config repositories: the UPDATE statements
+used to overwrite every column, so a partial payload (e.g. from the CLI)
+nulled out the remaining fields — hitting NOT NULL constraints or silently
+erasing data. The repositories now use COALESCE to preserve omitted fields.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import aiosqlite
+import pytest
+
+from semantic_config.models.biz_domain import BizDomainCreate, BizDomainUpdate
+from semantic_config.models.datasource import DatasourceCreate
+from semantic_config.models.dimension import DimensionCreate, DimensionUpdate
+from semantic_config.models.metric_lib import MetricCreate, MetricUpdate
+from semantic_config.services import biz_domain_service, dimension_service, metric_lib_service
+from semantic_config.services import datasource_service
+
+_SCHEMA = (
+    Path(__file__).resolve().parents[1] / "src" / "semantic_config" / "schema.sql"
+)
+
+
+@pytest.fixture()
+async def db(tmp_path: Path) -> aiosqlite.Connection:
+    conn = await aiosqlite.connect(tmp_path / "semantic_config.db")
+    conn.row_factory = aiosqlite.Row
+    await conn.executescript(_SCHEMA.read_text(encoding="utf-8"))
+    await conn.commit()
+    try:
+        yield conn
+    finally:
+        await conn.close()
+
+
+async def _seed_domain(db: aiosqlite.Connection) -> tuple[str, int]:
+    datasource = await datasource_service.create(
+        db,
+        DatasourceCreate(
+            datasource_name="ds",
+            datasource_type="postgresql",
+            config={
+                "host": "127.0.0.1",
+                "port": 5432,
+                "dbname": "db",
+                "user": "u",
+                "password": "p",
+            },
+        ),
+    )
+    domain = await biz_domain_service.create(
+        db,
+        BizDomainCreate(
+            datasource_id=datasource.datasource_id,
+            domain_name="d1",
+            display_name="Domain 1",
+            description="desc",
+            aliases="a1",
+        ),
+    )
+    return datasource.datasource_id, domain.domain_id
+
+
+async def test_metric_partial_update_keeps_other_fields(db: aiosqlite.Connection) -> None:
+    datasource_id, domain_id = await _seed_domain(db)
+    created = await metric_lib_service.create(
+        db,
+        MetricCreate(
+            datasource_id=datasource_id,
+            domain_id=domain_id,
+            metric_name="m1",
+            description="original",
+            unit="CNY",
+            is_polaris=True,
+            synonyms="s1",
+        ),
+    )
+
+    updated = await metric_lib_service.update(
+        db, created.id, MetricUpdate(description="changed")
+    )
+
+    assert updated.description == "changed"
+    assert updated.metric_name == "m1"
+    assert updated.unit == "CNY"
+    assert updated.is_polaris is True
+    assert updated.synonyms == "s1"
+
+
+async def test_dimension_partial_update_keeps_other_fields(db: aiosqlite.Connection) -> None:
+    datasource_id, domain_id = await _seed_domain(db)
+    created = await dimension_service.create(
+        db,
+        DimensionCreate(
+            datasource_id=datasource_id,
+            domain_id=domain_id,
+            dimension_name="dim1",
+            description="original",
+            synonyms="s1",
+            enums="a,b",
+        ),
+    )
+
+    updated = await dimension_service.update(
+        db, created.id, DimensionUpdate(description="changed")
+    )
+
+    assert updated.description == "changed"
+    assert updated.dimension_name == "dim1"
+    assert updated.synonyms == "s1"
+    assert updated.enums == "a,b"
+
+
+async def test_domain_partial_update_keeps_other_fields(db: aiosqlite.Connection) -> None:
+    _, domain_id = await _seed_domain(db)
+
+    updated = await biz_domain_service.update(
+        db, domain_id, BizDomainUpdate(description="changed")
+    )
+
+    assert updated.description == "changed"
+    assert updated.domain_name == "d1"
+    assert updated.display_name == "Domain 1"
+    assert updated.aliases == "a1"

--- a/packages/datapaw-host-core/src/datapaw/host/core/semantic_config_client.py
+++ b/packages/datapaw-host-core/src/datapaw/host/core/semantic_config_client.py
@@ -1,0 +1,240 @@
+"""HTTP client for the DataBridge semantic-config editing APIs.
+
+Complements :mod:`datapaw.host.core.cm_client` (read-only discovery) with the
+authenticated CRUD surface under ``/api/semantic-config``: datasources,
+semantic objects, Excel import, and weave-task management.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Mapping
+
+import httpx
+
+from datapaw.host.core.cm_client import (
+    API_TOKEN_ENV,
+    CLIENT_API_TOKEN_ENV,
+    DEFAULT_CM_BASE_URL,
+    _trust_env_for_url,
+    resolve_cm_base_url,
+)
+
+SEMANTIC_CONFIG_PREFIX = "/api/semantic-config"
+DEFAULT_PAGE_SIZE = 20
+DEFAULT_TIMEOUT_SECONDS = 30.0
+_AUTH_HINT = (
+    "hint: set DATAPAW_CLIENT_API_TOKEN (or DATAPAW_API_TOKEN) with the "
+    "required scope"
+)
+
+
+class SemanticConfigClientError(RuntimeError):
+    """Raised when a semantic-config API call fails."""
+
+    def __init__(self, message: str, *, status_code: int | None = None) -> None:
+        self.status_code = status_code
+        super().__init__(message)
+
+
+def _error_message(response: httpx.Response) -> str:
+    """Extract the server error protocol {timestamp,status,error,message}."""
+
+    try:
+        payload = response.json()
+    except ValueError:
+        payload = None
+    if isinstance(payload, dict):
+        message = payload.get("message") or payload.get("detail")
+        if isinstance(message, str) and message.strip():
+            return message.strip()
+    return f"semantic-config request returned HTTP {response.status_code}"
+
+
+class SemanticConfigClient:
+    """Minimal synchronous client for the semantic-config editing layer."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str | None = None,
+        timeout: float = DEFAULT_TIMEOUT_SECONDS,
+        transport: httpx.BaseTransport | None = None,
+        api_token: str | None = None,
+    ) -> None:
+        if timeout <= 0:
+            raise ValueError("timeout must be positive")
+
+        self.base_url = (base_url or resolve_cm_base_url()).strip().rstrip("/")
+        if not self.base_url:
+            self.base_url = DEFAULT_CM_BASE_URL
+        self.timeout = timeout
+        self.transport = transport
+        self.api_token = (
+            (
+                (os.environ.get(CLIENT_API_TOKEN_ENV) or "").strip()
+                or (os.environ.get(API_TOKEN_ENV) or "").strip()
+            )
+            if api_token is None
+            else api_token.strip()
+        )
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Mapping[str, Any] | None = None,
+        json: Any | None = None,
+        files: Any | None = None,
+    ) -> Any:
+        """Issue one request and return the decoded JSON body (or ``{}``)."""
+
+        url = f"{self.base_url}{path}"
+        headers = (
+            {"Authorization": f"Bearer {self.api_token}"}
+            if self.api_token
+            else None
+        )
+        try:
+            with httpx.Client(
+                timeout=self.timeout,
+                transport=self.transport,
+                trust_env=_trust_env_for_url(self.base_url),
+                headers=headers,
+            ) as client:
+                response = client.request(
+                    method,
+                    url,
+                    params=self._clean_params(params),
+                    json=json,
+                    files=files,
+                )
+        except httpx.TimeoutException as exc:
+            raise SemanticConfigClientError(
+                f"semantic-config request timed out: {method} {path}",
+            ) from exc
+        except httpx.RequestError as exc:
+            raise SemanticConfigClientError(
+                f"semantic-config request failed: {method} {path}",
+            ) from exc
+
+        if not response.is_success:
+            message = _error_message(response)
+            if response.status_code in (401, 403):
+                message = f"{message}\n{_AUTH_HINT}"
+            raise SemanticConfigClientError(
+                message,
+                status_code=response.status_code,
+            )
+        if not response.content:
+            return {}
+        try:
+            return response.json()
+        except ValueError as exc:
+            raise SemanticConfigClientError(
+                f"semantic-config response is not valid JSON: {method} {path}",
+            ) from exc
+
+    @staticmethod
+    def _clean_params(params: Mapping[str, Any] | None) -> dict[str, Any] | None:
+        if params is None:
+            return None
+        cleaned = {key: value for key, value in params.items() if value is not None}
+        return cleaned or None
+
+    def get(self, path: str, *, params: Mapping[str, Any] | None = None) -> Any:
+        return self.request("GET", path, params=params)
+
+    def post(
+        self,
+        path: str,
+        *,
+        json: Any | None = None,
+        files: Any | None = None,
+    ) -> Any:
+        return self.request("POST", path, json=json, files=files)
+
+    def put(self, path: str, *, json: Any | None = None) -> Any:
+        return self.request("PUT", path, json=json)
+
+    def delete(self, path: str) -> Any:
+        return self.request("DELETE", path)
+
+    def list_page(
+        self,
+        path: str,
+        *,
+        params: Mapping[str, Any] | None = None,
+        page: int = 1,
+        size: int = DEFAULT_PAGE_SIZE,
+    ) -> dict[str, Any]:
+        """Fetch one page of a ``Page{records,total,page,size}`` endpoint."""
+
+        payload = self.get(path, params={**(params or {}), "page": page, "size": size})
+        return self._validate_page(payload, expected_page=page)
+
+    def list_all(
+        self,
+        path: str,
+        *,
+        params: Mapping[str, Any] | None = None,
+        size: int = 100,
+    ) -> dict[str, Any]:
+        """Fetch every page and return ``{"records": [...], "total": N}``."""
+
+        records: list[Any] = []
+        expected_total: int | None = None
+        page = 1
+        while True:
+            payload = self.list_page(path, params=params, page=page, size=size)
+            total = payload["total"]
+            if expected_total is None:
+                expected_total = total
+            elif total != expected_total:
+                raise SemanticConfigClientError(
+                    "semantic-config response total changed during pagination",
+                )
+            records.extend(payload["records"])
+            if len(records) > expected_total:
+                raise SemanticConfigClientError(
+                    "semantic-config response contains more records than total",
+                )
+            if len(records) == expected_total:
+                return {"records": records, "total": expected_total}
+            if not payload["records"]:
+                raise SemanticConfigClientError(
+                    "semantic-config response ended before total was reached",
+                )
+            page += 1
+
+    @staticmethod
+    def _validate_page(payload: Any, *, expected_page: int) -> dict[str, Any]:
+        if not isinstance(payload, dict):
+            raise SemanticConfigClientError(
+                "semantic-config list response is not an object",
+            )
+        records = payload.get("records")
+        if not isinstance(records, list):
+            raise SemanticConfigClientError(
+                "semantic-config list response has invalid records",
+            )
+        total = payload.get("total")
+        if isinstance(total, bool) or not isinstance(total, int) or total < 0:
+            raise SemanticConfigClientError(
+                "semantic-config list response has invalid total",
+            )
+        page = payload.get("page")
+        if isinstance(page, bool) or not isinstance(page, int) or page != expected_page:
+            raise SemanticConfigClientError(
+                "semantic-config list response has an unexpected page",
+            )
+        return {"records": records, "total": total, "page": page}
+
+
+__all__ = [
+    "DEFAULT_PAGE_SIZE",
+    "SEMANTIC_CONFIG_PREFIX",
+    "SemanticConfigClient",
+    "SemanticConfigClientError",
+]

--- a/packages/datapaw-host-core/tests/test_semantic_config_client.py
+++ b/packages/datapaw-host-core/tests/test_semantic_config_client.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from datapaw.host.core.semantic_config_client import (
+    SemanticConfigClient,
+    SemanticConfigClientError,
+)
+
+
+def _client(handler, **kwargs) -> SemanticConfigClient:
+    return SemanticConfigClient(
+        base_url="http://cm.test",
+        transport=httpx.MockTransport(handler),
+        **kwargs,
+    )
+
+
+def test_request_sends_bearer_token_and_returns_json() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers["Authorization"] == "Bearer token-1"
+        assert request.url.path == "/api/semantic-config/datasource/x"
+        return httpx.Response(200, json={"datasource_id": "x"})
+
+    client = _client(handler, api_token="token-1")
+    assert client.get("/api/semantic-config/datasource/x") == {"datasource_id": "x"}
+
+
+def test_request_without_token_sends_no_auth_header() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert "Authorization" not in request.headers
+        return httpx.Response(200, json={})
+
+    assert _client(handler, api_token="").get("/x") == {}
+
+
+def test_request_drops_none_params() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert dict(request.url.params) == {"page": "1"}
+        return httpx.Response(200, json={})
+
+    _client(handler, api_token="").get("/x", params={"page": 1, "name": None})
+
+
+def test_error_protocol_message_is_surfaced() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            400,
+            json={
+                "timestamp": "2026-08-10T00:00:00Z",
+                "status": 400,
+                "error": "Bad Request",
+                "message": "数据源被引用，无法删除",
+            },
+        )
+
+    with pytest.raises(SemanticConfigClientError) as exc_info:
+        _client(handler, api_token="").delete("/x")
+    assert "数据源被引用" in str(exc_info.value)
+    assert exc_info.value.status_code == 400
+
+
+def test_forbidden_error_appends_token_hint() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(403, json={"message": "forbidden"})
+
+    with pytest.raises(SemanticConfigClientError) as exc_info:
+        _client(handler, api_token="t").get("/x")
+    message = str(exc_info.value)
+    assert "forbidden" in message
+    assert "DATAPAW_CLIENT_API_TOKEN" in message
+
+
+def test_non_json_error_falls_back_to_status_line() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(502, text="bad gateway")
+
+    with pytest.raises(SemanticConfigClientError) as exc_info:
+        _client(handler, api_token="").get("/x")
+    assert "HTTP 502" in str(exc_info.value)
+
+
+def test_empty_success_body_returns_empty_dict() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200)
+
+    assert _client(handler, api_token="").delete("/x") == {}
+
+
+def test_list_page_validates_page_shape() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"records": "nope", "total": 1, "page": 1})
+
+    with pytest.raises(SemanticConfigClientError) as exc_info:
+        _client(handler, api_token="").list_page("/x")
+    assert "invalid records" in str(exc_info.value)
+
+
+def test_list_all_paginates_until_total() -> None:
+    pages = {
+        "1": {"records": [{"id": 1}, {"id": 2}], "total": 3, "page": 1, "size": 2},
+        "2": {"records": [{"id": 3}], "total": 3, "page": 2, "size": 2},
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=pages[request.url.params["page"]])
+
+    result = _client(handler, api_token="").list_all("/x", size=2)
+    assert result == {"records": [{"id": 1}, {"id": 2}, {"id": 3}], "total": 3}
+
+
+def test_list_all_detects_total_drift() -> None:
+    pages = {
+        "1": {"records": [{"id": 1}], "total": 3, "page": 1, "size": 1},
+        "2": {"records": [{"id": 2}], "total": 4, "page": 2, "size": 1},
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=pages[request.url.params["page"]])
+
+    with pytest.raises(SemanticConfigClientError) as exc_info:
+        _client(handler, api_token="").list_all("/x", size=1)
+    assert "total changed" in str(exc_info.value)
+
+
+def test_list_all_detects_truncated_stream() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        page = int(request.url.params["page"])
+        return httpx.Response(
+            200,
+            json={"records": [], "total": 2, "page": page, "size": 100},
+        )
+
+    with pytest.raises(SemanticConfigClientError) as exc_info:
+        _client(handler, api_token="").list_all("/x")
+    assert "ended before total" in str(exc_info.value)
+
+
+def test_multipart_upload_posts_file() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert b'filename="config.xlsx"' in request.read()
+        return httpx.Response(200, json={"success": True})
+
+    result = _client(handler, api_token="").post(
+        "/api/semantic-config/import/excel",
+        files={"file": ("config.xlsx", b"payload", "application/octet-stream")},
+    )
+    assert result == {"success": True}
+
+
+def test_connection_error_is_wrapped(monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("boom", request=request)
+
+    with pytest.raises(SemanticConfigClientError) as exc_info:
+        _client(handler, api_token="").get("/x")
+    assert "request failed" in str(exc_info.value)
+
+
+def test_token_resolution_prefers_client_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DATAPAW_CLIENT_API_TOKEN", "scoped")
+    monkeypatch.setenv("DATAPAW_API_TOKEN", "full")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers["Authorization"] == "Bearer scoped"
+        return httpx.Response(200, json={})
+
+    SemanticConfigClient(
+        base_url="http://cm.test",
+        transport=httpx.MockTransport(handler),
+    ).get("/x")


### PR DESCRIPTION
## Summary

Implements the reviewed design in `docs/design/2026-08-10-cli-semantic-commands.md` (included as the first commit): scriptable CLI coverage for datasource management and the semantic configuration layer, replacing UI-only workflows. **No backend changes** — everything is a thin client over the existing `/api/semantic-config` contract shared with the Cloud deployment.

## Delivered commands

```text
datapaw datasource  list | get | create [--test] | update | delete | test
datapaw semantic    domain|dataset|column|dimension|binding|metric|formula
                        → list|get|create|update|delete
datapaw semantic    import --file <xlsx>
datapaw semantic    weave submit [--wait] | list | kill
```

## Key points

- **`SemanticConfigClient`** (datapaw-host-core): reuses `cm_client` env/token/loopback-proxy resolution; validates `Page{records,total,page,size}` pagination; surfaces the `{timestamp,status,error,message}` error protocol; 401/403 errors carry a `DATAPAW_CLIENT_API_TOKEN` scope hint.
- **Security posture preserved**: all outputs mask `password`/AccessKey/STS fields with no plaintext escape hatch; `datasource list` keeps using the credential-free discovery endpoint; deletions require a TTY confirmation or explicit `--yes` (non-TTY fails closed).
- **Table-driven CRUD**: the seven semantic resources are generated from one declarative `Resource` table; `binding`/`formula` expose dataset-level batch deletion matching `DELETE .../dataset/{dataset_id}`.
- **Weave publishing**: `--wait` polls to a terminal state with progress dots on stderr and the final task JSON on stdout; exit code 0 only on `success`; timeout prints a `weave kill` hint without auto-killing.
- `create --test` aborts before persisting when the connection test fails (no `--force`, per design decision).

## Testing

- 42 new unit tests (14 client via `httpx.MockTransport`, 28 CLI via fake-client monkeypatch) covering payload mapping, masking, confirmation flows, `--file` XOR flags, pagination validation, and weave wait/terminal/timeout paths.
- `scripts/verify.sh` fully green: 403 passed, 6 skipped, API smoke OK.
- Manual smoke of the full help tree.

## Docs

- `packages/datapaw-cli/README.md` command reference updated; CHANGELOG Unreleased entry added; design doc included under `docs/design/`.