### PR TITLE
fix(mcp): add get_dataset_columns tool and align skill guide with MCP registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Added the missing `get_dataset_columns` MCP tool and corrected the tool
+  names advertised by the `bi-semantic-layer-guide` skill
+  (`get_metric`, `get_dimension`, `list_dimensions_of_metric`,
+  `get_dataset`), which previously led agents to call non-existent tools;
+  a new alignment test keeps the skill guide and the MCP registry in sync
+  (#19).
+
 ## [0.1.2] - 2026-08-10
 
 ### Added

--- a/packages/datapaw-context/src/context_manager/mcp/cm_server.py
+++ b/packages/datapaw-context/src/context_manager/mcp/cm_server.py
@@ -25,6 +25,7 @@ import json
 import logging
 import os
 from typing import Any, Awaitable, Callable, Optional, TypeVar
+from urllib.parse import quote
 
 import httpx
 
@@ -657,6 +658,28 @@ async def get_dataset(name: str, domain: str, session_ref: str = "", metadata: s
     if ds_id:
         params["datasource_id"] = ds_id
     return _json(await _get("datasets", params))
+
+
+@mcp.tool()
+async def get_dataset_columns(name: str, domain: str, session_ref: str = "", metadata: str = "{}") -> str:
+    """查询数据集的列定义列表。
+
+    返回指定数据集的列元数据（列名、类型、描述等），比 get_dataset 更轻量，
+    适用于只需要列信息的场景。
+
+    Args:
+        name: 数据集名称（必填）
+        domain: 业务域名称（必填），如 "ChatApp"
+        session_ref: 会话引用；通常由 harness 经 metadata.session_ref 注入（LLM 无需填写）
+    """
+    ref = _meta_session_ref(metadata, session_ref)
+    ds_id = _meta_datasource_id(metadata)
+    params: dict[str, Any] = {"domain": domain}
+    if ref:
+        params["session_ref"] = ref
+    if ds_id:
+        params["datasource_id"] = ds_id
+    return _json(await _get(f"datasets/{quote(name, safe='')}/columns", params))
 
 
 

--- a/packages/datapaw-skills/skills/runtime/bi-semantic-layer-guide/SKILL.md
+++ b/packages/datapaw-skills/skills/runtime/bi-semantic-layer-guide/SKILL.md
@@ -15,9 +15,9 @@ description: 语义层工具使用规范。在发现语义层工具可用、需�
 语义层暴露三类工具：
 
 - **全局**：`list_domains()`
-- **指标查询**：`list_metrics(domain)`、`search_metrics(query, domain)`、`get_metric_info(metric_name, domain)`、`get_north_star_metrics(domain)`
-- **维度查询**：`list_dimensions(domain)`、`get_dimension_info(dim_name, domain)`、`get_dimensions_for_metric(metric_name, domain)`、`get_dimension_hierarchy(dim_name, domain)`、`get_dimension_values(dim_name, domain)`
-- **数据集查询**：`list_datasets(domain)`、`get_dataset_columns(name, domain)`、`get_dataset_schema(name, domain)`
+- **指标查询**：`list_metrics(domain)`、`search_metrics(query, domain)`、`get_metric(name, domain)`、`get_north_star_metrics(domain)`
+- **维度查询**：`list_dimensions(domain)`、`get_dimension(name, domain)`、`list_dimensions_of_metric(name, domain)`、`get_dimension_hierarchy(name, domain)`、`get_dimension_values(name, domain)`
+- **数据集查询**：`list_datasets(domain)`、`get_dataset_columns(name, domain)`、`get_dataset(name, domain)`
 
 具体参数和返回格式参见工具自身描述。
 
@@ -35,7 +35,7 @@ description: 语义层工具使用规范。在发现语义层工具可用、需�
 
 ### 指标属性确认
 
-通过 `get_metric_info` 获取指标属性，重点属性：
+通过 `get_metric` 获取指标属性，重点属性：
 
 - **是否是北极星指标**（`is_north_star`）：用于角色分配
 - **是否展示指标**（`is_display`）：该指标是否应出现在展示面板中
@@ -44,7 +44,7 @@ description: 语义层工具使用规范。在发现语义层工具可用、需�
 
 ### 维度信息获取
 
-通过 `get_dimensions_for_metric` 获取指标可拆解的维度列表（`is_contribution_dimension=true` 的维度才可用于贡献度拆解），通过 `get_dimension_hierarchy` 获取维度间的父子层级关系。
+通过 `list_dimensions_of_metric` 获取指标可拆解的维度列表（`is_contribution_dimension=true` 的维度才可用于贡献度拆解），通过 `get_dimension_hierarchy` 获取维度间的父子层级关系。
 
 ---
 

--- a/tests/test_skill_mcp_alignment.py
+++ b/tests/test_skill_mcp_alignment.py
@@ -1,0 +1,44 @@
+"""Skill guides must only reference MCP tools that actually exist.
+
+Regression test for issue #19: ``bi-semantic-layer-guide`` advertised tool
+names (``get_dataset_columns``, ``get_metric_info``, ...) that were missing
+from or renamed in the CM MCP server, so agents called non-existent tools at
+runtime. Every backticked ``name(...)`` reference in the skill guide must be
+a registered MCP tool.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SEMANTIC_GUIDE = (
+    ROOT
+    / "packages"
+    / "datapaw-skills"
+    / "skills"
+    / "runtime"
+    / "bi-semantic-layer-guide"
+    / "SKILL.md"
+)
+
+_TOOL_REFERENCE = re.compile(r"`([a-z][a-z0-9_]*)\(")
+
+
+def _documented_tools(path: Path) -> set[str]:
+    return set(_TOOL_REFERENCE.findall(path.read_text(encoding="utf-8")))
+
+
+async def test_semantic_guide_references_only_registered_mcp_tools() -> None:
+    from context_manager.mcp import cm_server
+
+    documented = _documented_tools(SEMANTIC_GUIDE)
+    assert documented, "expected the semantic guide to reference MCP tools"
+
+    registered = {tool.name for tool in await cm_server.mcp.list_tools()}
+    missing = sorted(documented - registered)
+    assert not missing, (
+        f"SKILL.md references MCP tools that are not registered: {missing}; "
+        f"registered tools: {sorted(registered)}"
+    )


### PR DESCRIPTION
Fixes #19.

## Problem

`bi-semantic-layer-guide/SKILL.md` advertised MCP tool names that drifted from the actual CM MCP registry, so agents following the guide called non-existent tools at runtime. Verification against `cm_server.py` showed the reported gap is one of five:

| Guide said | Registry has | Status |
|---|---|---|
| `get_dataset_columns(name, domain)` | — | **missing** (issue #19) |
| `get_metric_info(...)` | `get_metric(...)` | stale name |
| `get_dimension_info(...)` | `get_dimension(...)` | stale name |
| `get_dimensions_for_metric(...)` | `list_dimensions_of_metric(...)` | stale name |
| `get_dataset_schema(...)` | `get_dataset(...)` | stale name |

## Fix

- **Add `get_dataset_columns` MCP tool**: thin wrapper over the existing REST endpoint `GET /api/v1/cm/datasets/{name}/columns` (URL-quoted name, same session_ref/datasource_id metadata handling as its siblings). Lighter than `get_dataset` when only column metadata is needed.
- **Correct the five names in SKILL.md** to match the registry. Existing MCP tool names are intentionally left unchanged to avoid breaking deployed harness configurations.
- **Anti-drift regression test** (`tests/test_skill_mcp_alignment.py`): parses every backticked `name(...)` reference in the guide and asserts it is a registered MCP tool, so future doc/registry drift fails CI.

## Testing

- New alignment test passes (and would have failed on every one of the five drifted names).
- `scripts/verify.sh` fully green (compileall + pytest + API smoke).