### PR TITLE
fix(context): dict_parser reads aliases key for dimension/metric synonyms

### DIFF
--- a/packages/datapaw-context/src/context_manager/graph/dict_parser.py
+++ b/packages/datapaw-context/src/context_manager/graph/dict_parser.py
@@ -309,7 +309,7 @@ def _convert_dimensions(
             "name": name,
             "type": "enum",
             "description": str(dim.get("description") or ""),
-            "synonyms": _str_list(dim.get("synonyms")),
+            "synonyms": _str_list(dim.get("aliases") or dim.get("synonyms")),
             "hierarchy_level": int(dim.get("hierarchy_level") or 0),
             "is_display_dimension": bool(dim.get("is_display_dimension", True)),
             "is_contribution_dimension": bool(dim.get("is_contribution_dimension", True)),
@@ -413,7 +413,7 @@ def _convert_metrics(
             "is_north_star": bool(met.get("is_north_star", False)),
             "is_display": bool(met.get("is_display", True)),
             "is_display_distribution": bool(met.get("is_display_distribution", True)),
-            "synonyms": _str_list(met.get("synonyms")),
+            "synonyms": _str_list(met.get("aliases") or met.get("synonyms")),
             "tags": _str_list(met.get("tags")),
             "status": "stable",
         }

--- a/packages/datapaw-context/tests/test_dict_parser_synonyms.py
+++ b/packages/datapaw-context/tests/test_dict_parser_synonyms.py
@@ -1,0 +1,42 @@
+"""Regression test for the `aliases`/`synonyms` field mismatch in dict_parser.
+
+`SemanticImportRequest`'s `DimensionPayload`/`MetricPayload` (see
+`context_manager/contracts/import_models.py`) only define an `aliases`
+field; there is no `synonyms` field on the wire. `dict_parser._convert_*`
+must read `aliases` (falling back to `synonyms` for the legacy YAML import
+path) — reading only `synonyms` silently drops every alias, since the key
+never exists on payloads produced by `weave_assembler`.
+"""
+from context_manager.graph.dict_parser import _convert_dimensions, _convert_metrics
+
+
+def test_convert_dimensions_reads_aliases_key() -> None:
+    dims_in = [{"name": "瘦焦煤", "aliases": ["瘦煤", "Lean Coking Coal"]}]
+
+    out = _convert_dimensions(dims_in, dataset_lookup={})
+
+    assert out[0]["synonyms"] == ["瘦煤", "Lean Coking Coal"]
+
+
+def test_convert_dimensions_falls_back_to_legacy_synonyms_key() -> None:
+    dims_in = [{"name": "瘦焦煤", "synonyms": ["瘦煤"]}]
+
+    out = _convert_dimensions(dims_in, dataset_lookup={})
+
+    assert out[0]["synonyms"] == ["瘦煤"]
+
+
+def test_convert_metrics_reads_aliases_key() -> None:
+    metrics_in = [{"name": "出厂价格", "aliases": ["出厂价"]}]
+
+    out = _convert_metrics(metrics_in, dataset_lookup={})
+
+    assert out[0]["synonyms"] == ["出厂价"]
+
+
+def test_convert_metrics_falls_back_to_legacy_synonyms_key() -> None:
+    metrics_in = [{"name": "出厂价格", "synonyms": ["出厂价"]}]
+
+    out = _convert_metrics(metrics_in, dataset_lookup={})
+
+    assert out[0]["synonyms"] == ["出厂价"]


### PR DESCRIPTION
## What

`dict_parser._convert_dimensions` and `_convert_metrics` read a
`synonyms` key that doesn't exist on the wire contract, so every
dimension/metric alias imported through the Excel semantic-config
flow (`POST /api/semantic-config/import/excel`) is silently dropped
when weave runs -- the graph ends up with empty `synonyms` arrays,
and weave still reports `SUCCESS`.

## Why

`SemanticImportRequest`'s `DimensionPayload`/`MetricPayload`
(`contracts/import_models.py`) only define an `aliases` field.
`weave_assembler.py` produces payloads keyed on `aliases`
accordingly. But `dict_parser.py:312` and `:416` read
`dim.get("synonyms")` / `met.get("synonyms")`, which is always
`None` for these payloads -- the two spots weren't updated when the
domain-alias (`dict_parser.py:58`) and dimension-value-alias
(`dict_parser.py:346`) conversions were already fixed to read
`aliases`.

Found while importing ~1,800 real dimension/metric definitions
through the Excel flow: `metric.synonyms` and `dimension.synonyms`
were `[]` for every node after weave, despite the source Excel
having non-empty `synonyms` columns for ~1,400 of them.

## Fix

Read `aliases` first, fall back to `synonyms` (keeps the legacy
YAML-based import path working, since that path already uses
`synonyms` as the key name).

## How verified

- Added `tests/test_dict_parser_synonyms.py`: 4 cases covering
  `_convert_dimensions`/`_convert_metrics` reading `aliases`, and
  falling back to `synonyms`.
- Confirmed the new tests fail against the pre-fix code (both
  "reads aliases" cases fail with an empty list) and pass after
  the fix.
- `uv run python -m compileall packages` and
  `uv run pytest -q packages/datapaw-context/tests` (152 passed)
  both clean.