### PR TITLE
feat(host-core): add cron-scheduled agent runs

### DIFF
--- a/packages/qwenpaw-data-host-core/README.md
+++ b/packages/qwenpaw-data-host-core/README.md
@@ -39,6 +39,7 @@ worker. Without `QWENPAW_DATA_API_TOKEN`, only loopback clients are accepted.
 | `POST /sessions/{sid}/chats/{cid}/clarification/answer` | Deliver an `ask_user_question` result to the paused turn |
 | `GET/PUT/DELETE /preferences/providers[/{id}]` · `.../models/{id}` · `GET/PUT /preferences/active-models` | Model provider credentials (masked in responses), model overrides, active model selection |
 | `GET /datasources` | DataBridge datasource discovery proxied through the service |
+| `GET/POST /cron/jobs` · `GET/PUT/DELETE /cron/jobs/{id}` · `POST .../pause|resume|run` | Scheduled agent runs: a cron expression or one-shot time opens a console chat with the configured message/datasource (single-process APScheduler) |
 
 ### Storage backends
 

--- a/packages/qwenpaw-data-host-core/pyproject.toml
+++ b/packages/qwenpaw-data-host-core/pyproject.toml
@@ -34,6 +34,7 @@ service = [
   "sqlalchemy[asyncio]>=2.0,<3.0",
   "aiosqlite>=0.20,<1.0",
   "cryptography>=42,<47",
+  "apscheduler>=3.10,<4.0",
 ]
 
 [project.urls]

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/app.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/app.py
@@ -24,11 +24,13 @@ from qwenpaw_data.host.core.api.deps import ServiceState
 from qwenpaw_data.host.core.api.errors import http_exception_handler
 from qwenpaw_data.host.core.api.routers import chats as chats_router
 from qwenpaw_data.host.core.api.routers import clarification as clarification_router
+from qwenpaw_data.host.core.api.routers import cron as cron_router
 from qwenpaw_data.host.core.api.routers import datasources as datasources_router
 from qwenpaw_data.host.core.api.routers import events as events_router
 from qwenpaw_data.host.core.api.routers import preferences as preferences_router
 from qwenpaw_data.host.core.api.routers import sessions as sessions_router
 from qwenpaw_data.host.core.api.routers import steer as steer_router
+from qwenpaw_data.host.core.cron import CronManager
 from qwenpaw_data.host.core.domain.identity import Identity
 from qwenpaw_data.host.core.model import build_model_from_env
 from qwenpaw_data.host.core.paths import resolve_qwenpaw_data_home
@@ -38,6 +40,7 @@ from qwenpaw_data.host.core.runtime.registry import reset_runtime_registry
 from qwenpaw_data.host.core.store.json_store import (
     JSONChatEventStore,
     JSONChatStore,
+    JSONCronStore,
     JSONPreferencesStore,
     JSONSessionStore,
 )
@@ -93,6 +96,7 @@ def create_app(
             chats_store: Any = JSONChatStore(store_root)
             events_store: Any = JSONChatEventStore(store_root)
             prefs_store: Any = JSONPreferencesStore(store_root)
+            cron_store: Any = JSONCronStore(store_root)
         else:
             from qwenpaw_data.host.core.db.engine import (
                 create_engine_and_factory,
@@ -102,6 +106,7 @@ def create_app(
             from qwenpaw_data.host.core.store.sql_store import (
                 SQLChatEventStore,
                 SQLChatStore,
+                SQLCronStore,
                 SQLPreferencesStore,
                 SQLSessionStore,
             )
@@ -114,6 +119,7 @@ def create_app(
             chats_store = SQLChatStore(factory)
             events_store = SQLChatEventStore(factory)
             prefs_store = SQLPreferencesStore(factory)
+            cron_store = SQLCronStore(factory)
 
         async def resolve_model() -> Any:
             """Prefer the local user's configured default model over env."""
@@ -133,6 +139,7 @@ def create_app(
             chats=chats_store,
             events=events_store,
             prefs=prefs_store,
+            cron=cron_store,
             hosts=QwenPawDataHostRegistry(
                 home=resolved_home,
                 model=model,
@@ -144,9 +151,18 @@ def create_app(
         )
         app.state.service = state
         await _cancel_orphaned_chats(state)
+        state.cron_manager = CronManager(
+            cron=state.cron,
+            sessions=state.sessions,
+            chats=state.chats,
+            events=state.events,
+            hosts=state.hosts,
+        )
+        await state.cron_manager.start()
         try:
             yield
         finally:
+            await state.cron_manager.shutdown()
             for task in list(state.tasks):
                 task.cancel()
             for host in list(state.hosts._items.values()):
@@ -171,6 +187,7 @@ def create_app(
     app.include_router(clarification_router.router, prefix="/api/v1")
     app.include_router(preferences_router.router, prefix="/api/v1")
     app.include_router(datasources_router.router, prefix="/api/v1")
+    app.include_router(cron_router.router, prefix="/api/v1")
 
     @app.get("/health")
     async def health() -> dict[str, str]:

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/deps.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/deps.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+from typing import Any
 from dataclasses import dataclass, field
 
 from fastapi import Request
@@ -11,6 +12,7 @@ from qwenpaw_data.host.core.registry import QwenPawDataHostRegistry
 from qwenpaw_data.host.core.store.protocols import (
     ChatEventStore,
     ChatStore,
+    CronStore,
     PreferencesStore,
     SessionStore,
 )
@@ -22,7 +24,9 @@ class ServiceState:
     chats: ChatStore
     events: ChatEventStore
     prefs: PreferencesStore
+    cron: CronStore
     hosts: QwenPawDataHostRegistry
+    cron_manager: Any = None
     tasks: set[asyncio.Task] = field(default_factory=set)
 
     def track(self, task: asyncio.Task) -> None:

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/models/cron.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/models/cron.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+"""Cron API request models."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import model_validator
+
+from qwenpaw_data.host.core.api.models.common import ApiModel
+
+_DAY_OF_WEEK = {
+    "0": "sun",
+    "1": "mon",
+    "2": "tue",
+    "3": "wed",
+    "4": "thu",
+    "5": "fri",
+    "6": "sat",
+    "7": "sun",
+}
+
+
+def _normalize_dow(field: str) -> str:
+    if field == "*" or field.isalpha() or ("-" in field and not field[0].isdigit()):
+        return field
+    return ",".join(_DAY_OF_WEEK.get(p, p) for p in field.split(","))
+
+
+class ScheduleSpec(ApiModel):
+    """When to run: recurring cron expression, or a one-shot run_at time."""
+
+    type: Literal["cron", "once"] = "cron"
+    cron: str | None = None
+    run_at: datetime | None = None
+    timezone: str = "Asia/Shanghai"
+
+    @model_validator(mode="after")
+    def _validate(self) -> ScheduleSpec:
+        if self.type == "cron":
+            parts = [p for p in (self.cron or "").split() if p]
+            if len(parts) != 5:
+                raise ValueError("cron must have 5 fields: min hour dom month dow")
+            parts[4] = _normalize_dow(parts[4])
+            self.cron = " ".join(parts)
+            self.run_at = None
+            return self
+        if self.run_at is None:
+            raise ValueError("schedule.run_at is required when type=once")
+        self.cron = None
+        return self
+
+
+class CronJobWrite(ApiModel):
+    name: str
+    enabled: bool = True
+    message: str
+    datasource_id: str
+    session_id: str | None = None
+    schedule: ScheduleSpec
+
+    @model_validator(mode="after")
+    def _trim(self) -> CronJobWrite:
+        self.name = self.name.strip()
+        self.message = self.message.strip()
+        self.datasource_id = self.datasource_id.strip()
+        sid = (self.session_id or "").strip()
+        self.session_id = sid or None
+        if not self.name:
+            raise ValueError("name is required")
+        if not self.message:
+            raise ValueError("message is required")
+        if not self.datasource_id:
+            raise ValueError("datasource_id is required")
+        return self

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/routers/cron.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/routers/cron.py
@@ -1,0 +1,135 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from fastapi import APIRouter, Depends
+
+from qwenpaw_data.host.core.api.deps import ServiceState, get_identity, get_state
+from qwenpaw_data.host.core.api.errors import map_domain_error
+from qwenpaw_data.host.core.api.models.cron import CronJobWrite
+from qwenpaw_data.host.core.domain.identity import Identity
+
+router = APIRouter(prefix="/cron", tags=["cron"])
+
+
+def _map(exc: Exception) -> None:
+    http = map_domain_error(exc)
+    if http:
+        raise http from exc
+    raise exc
+
+
+async def _check_session(state: ServiceState, session_id: str | None) -> None:
+    if session_id:
+        await state.sessions.get(session_id)
+
+
+@router.get("/jobs")
+async def list_jobs(
+    identity: Identity = Depends(get_identity),
+    state: ServiceState = Depends(get_state),
+) -> dict[str, Any]:
+    jobs = await state.cron.list(identity.user_id)
+    return {"jobs": jobs, "count": len(jobs)}
+
+
+@router.post("/jobs")
+async def create_job(
+    body: CronJobWrite,
+    identity: Identity = Depends(get_identity),
+    state: ServiceState = Depends(get_state),
+) -> dict[str, Any]:
+    try:
+        await _check_session(state, body.session_id)
+        job = await state.cron.create(identity.user_id, body)
+        state.cron_manager.sync(job)
+        return {"job": job}
+    except Exception as exc:
+        _map(exc)
+
+
+@router.get("/jobs/{job_id}")
+async def get_job(
+    job_id: str,
+    identity: Identity = Depends(get_identity),
+    state: ServiceState = Depends(get_state),
+) -> dict[str, Any]:
+    try:
+        return {"job": await state.cron.get(identity.user_id, job_id)}
+    except Exception as exc:
+        _map(exc)
+
+
+@router.put("/jobs/{job_id}")
+async def replace_job(
+    job_id: str,
+    body: CronJobWrite,
+    identity: Identity = Depends(get_identity),
+    state: ServiceState = Depends(get_state),
+) -> dict[str, Any]:
+    try:
+        await _check_session(state, body.session_id)
+        job = await state.cron.replace(identity.user_id, job_id, body)
+        state.cron_manager.sync(job)
+        return {"job": job}
+    except Exception as exc:
+        _map(exc)
+
+
+@router.delete("/jobs/{job_id}")
+async def delete_job(
+    job_id: str,
+    identity: Identity = Depends(get_identity),
+    state: ServiceState = Depends(get_state),
+) -> dict[str, Any]:
+    try:
+        await state.cron.delete(identity.user_id, job_id)
+        state.cron_manager.remove(job_id)
+        return {"ok": True}
+    except Exception as exc:
+        _map(exc)
+
+
+@router.post("/jobs/{job_id}/pause")
+async def pause_job(
+    job_id: str,
+    identity: Identity = Depends(get_identity),
+    state: ServiceState = Depends(get_state),
+) -> dict[str, Any]:
+    try:
+        job = await state.cron.set_enabled(identity.user_id, job_id, False)
+        state.cron_manager.sync(job)
+        return {"job": job}
+    except Exception as exc:
+        _map(exc)
+
+
+@router.post("/jobs/{job_id}/resume")
+async def resume_job(
+    job_id: str,
+    identity: Identity = Depends(get_identity),
+    state: ServiceState = Depends(get_state),
+) -> dict[str, Any]:
+    try:
+        job = await state.cron.set_enabled(identity.user_id, job_id, True)
+        state.cron_manager.sync(job)
+        return {"job": job}
+    except Exception as exc:
+        _map(exc)
+
+
+@router.post("/jobs/{job_id}/run")
+async def run_job(
+    job_id: str,
+    identity: Identity = Depends(get_identity),
+    state: ServiceState = Depends(get_state),
+) -> dict[str, Any]:
+    """Fire the job immediately in the background."""
+    try:
+        job = await state.cron.get(identity.user_id, job_id)
+    except Exception as exc:
+        _map(exc)
+    state.track(asyncio.create_task(state.cron_manager.run(job)))
+    return {"ok": True}

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/cron/__init__.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/cron/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+from qwenpaw_data.host.core.cron.manager import CronManager
+
+__all__ = ["CronManager"]

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/cron/manager.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/cron/manager.py
@@ -1,0 +1,134 @@
+# -*- coding: utf-8 -*-
+"""Cron scheduler + console agent execution."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.cron import CronTrigger
+from apscheduler.triggers.date import DateTrigger
+
+from qwenpaw_data.host.core.api.models.cron import ScheduleSpec
+from qwenpaw_data.host.core.domain.identity import Identity
+from qwenpaw_data.host.core.domain.session import Session
+from qwenpaw_data.host.core.registry import QwenPawDataHostRegistry
+from qwenpaw_data.host.core.runtime.chat_runtime import ChatRuntime
+from qwenpaw_data.host.core.store.protocols import (
+    ChatEventStore,
+    ChatStore,
+    CronStore,
+    SessionStore,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class CronManager:
+    """App-owned scheduler that opens console chats on schedule."""
+
+    def __init__(
+        self,
+        *,
+        cron: CronStore,
+        sessions: SessionStore,
+        chats: ChatStore,
+        events: ChatEventStore,
+        hosts: QwenPawDataHostRegistry,
+    ) -> None:
+        self._cron = cron
+        self._sessions = sessions
+        self._chats = chats
+        self._events = events
+        self._hosts = hosts
+        self._scheduler = AsyncIOScheduler(timezone="UTC")
+
+    async def start(self) -> None:
+        self._scheduler.start()
+        for job in await self._cron.list_all():
+            try:
+                self.sync(job)
+            except Exception:
+                logger.exception("skip invalid cron job: %s", job.get("id"))
+
+    async def shutdown(self) -> None:
+        if self._scheduler.running:
+            self._scheduler.shutdown(wait=False)
+
+    def sync(self, job: dict[str, Any]) -> None:
+        schedule = ScheduleSpec.model_validate(job["schedule"])
+        self._scheduler.add_job(
+            self._on_schedule,
+            trigger=self._trigger(schedule),
+            id=job["id"],
+            args=[job["id"]],
+            misfire_grace_time=60,
+            max_instances=1,
+            replace_existing=True,
+        )
+        if not job["enabled"]:
+            self._scheduler.pause_job(job["id"])
+
+    def remove(self, job_id: str) -> None:
+        if self._scheduler.get_job(job_id):
+            self._scheduler.remove_job(job_id)
+
+    async def run(self, job: dict[str, Any]) -> None:
+        try:
+            await self._run_console(job)
+        except Exception:
+            logger.exception("cron run failed: %s", job["id"])
+
+    def _trigger(self, schedule: ScheduleSpec) -> CronTrigger | DateTrigger:
+        if schedule.type == "once":
+            assert schedule.run_at is not None
+            return DateTrigger(run_date=schedule.run_at, timezone=schedule.timezone)
+        assert schedule.cron is not None
+        minute, hour, day, month, dow = schedule.cron.split()
+        return CronTrigger(
+            minute=minute,
+            hour=hour,
+            day=day,
+            month=month,
+            day_of_week=dow,
+            timezone=schedule.timezone,
+        )
+
+    async def _on_schedule(self, job_id: str) -> None:
+        try:
+            job = await self._cron.get_by_id(job_id)
+        except LookupError:
+            return
+        if job["enabled"]:
+            await self.run(job)
+
+    async def _run_console(self, job: dict[str, Any]) -> None:
+        identity = Identity(user_id=job["user_id"])
+        datasource_id = (job.get("datasource_id") or "").strip()
+        if not datasource_id:
+            raise ValueError("datasource_id is required for agent cron")
+        wanted_id = (job.get("session_id") or "").strip() or None
+        if wanted_id:
+            session = await self._sessions.get(wanted_id)
+        else:
+            session = Session.create(
+                identity=identity,
+                title=(job["name"] or "定时任务")[:80],
+                datasource_id=datasource_id,
+            )
+        chat = session.open_chat(
+            text=job["message"],
+            datasource_id=datasource_id,
+            has_active_chat=await self._sessions.has_active_chat(session.id),
+        )
+        if wanted_id:
+            await self._sessions.save(session)
+        else:
+            await self._sessions.add(session)
+        await self._chats.add(chat)
+        await ChatRuntime(
+            chats=self._chats,
+            events=self._events,
+            hosts=self._hosts,
+        ).run(chat.id, identity=identity)

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/db/tables.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/db/tables.py
@@ -91,6 +91,25 @@ class ChatEventRow(UserIdColumn, Base):
     )
 
 
+class CronJobRow(UserIdColumn, Base):
+    __tablename__ = "cron_jobs"
+
+    id: Mapped[str] = mapped_column(String, primary_key=True)
+    name: Mapped[str] = mapped_column(String, nullable=False)
+    enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    message: Mapped[str] = mapped_column(Text, nullable=False)
+    datasource_id: Mapped[str] = mapped_column(String, nullable=False)
+    channel: Mapped[str] = mapped_column(String, nullable=False, default="console")
+    session_id: Mapped[str | None] = mapped_column(String, nullable=True)
+    schedule_json: Mapped[dict] = mapped_column(JSON, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=utcnow
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=utcnow
+    )
+
+
 class UserProviderRow(Base):
     __tablename__ = "user_providers"
 

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/store/json_store.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/store/json_store.py
@@ -19,6 +19,7 @@ from qwenpaw_data.host.core.api.models.stream_objects import (
     dump_stream_object,
     parse_stream_object,
 )
+from qwenpaw_data.host.core.api.models.cron import CronJobWrite, ScheduleSpec
 from qwenpaw_data.host.core.domain.chat import ACTIVE, Chat
 from qwenpaw_data.host.core.domain.identity import Identity
 from qwenpaw_data.host.core.domain.preference import (
@@ -562,3 +563,126 @@ class JSONChatEventStore:
             if data["sequence_number"] > after:
                 events.append(parse_stream_object(data))
         return events
+
+
+class JSONCronStore:
+    def __init__(self, root: Path) -> None:
+        self._cron_root = Path(root).expanduser().resolve() / "cron"
+
+    def _job_path(self, job_id: str) -> Path:
+        return self._cron_root / f"{job_id}.json"
+
+    @staticmethod
+    def _to_dict(doc: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "id": doc["id"],
+            "user_id": doc["user_id"],
+            "name": doc["name"],
+            "enabled": doc["enabled"],
+            "message": doc["message"],
+            "datasource_id": doc["datasource_id"],
+            "channel": doc.get("channel", "console"),
+            "session_id": doc.get("session_id"),
+            "schedule": ScheduleSpec.model_validate(doc["schedule"]).model_dump(
+                mode="json"
+            ),
+            "created_at": _dt_from_json(doc["created_at"]),
+            "updated_at": _dt_from_json(doc["updated_at"]),
+        }
+
+    @staticmethod
+    def _read(path: Path) -> dict[str, Any] | None:
+        with file_lock(path):
+            if not path.exists():
+                return None
+            return json.loads(path.read_text(encoding="utf-8"))
+
+    @staticmethod
+    def _write(path: Path, doc: dict[str, Any]) -> None:
+        with file_lock(path):
+            write_atomic(path, doc)
+
+    def _scan(self) -> list[dict[str, Any]]:
+        if not self._cron_root.exists():
+            return []
+        docs = []
+        for path in self._cron_root.glob("*.json"):
+            doc = self._read(path)
+            if doc is not None:
+                docs.append(doc)
+        return docs
+
+    async def _get_doc(self, user_id: str, job_id: str) -> dict[str, Any]:
+        doc = await asyncio.to_thread(self._read, self._job_path(job_id))
+        if doc is None or doc["user_id"] != user_id:
+            raise LookupError("cron job not found")
+        return doc
+
+    async def list(self, user_id: str) -> list[dict[str, Any]]:
+        docs = await asyncio.to_thread(self._scan)
+        docs = [d for d in docs if d["user_id"] == user_id]
+        docs.sort(key=lambda d: d["created_at"], reverse=True)
+        return [self._to_dict(d) for d in docs]
+
+    async def get(self, user_id: str, job_id: str) -> dict[str, Any]:
+        return self._to_dict(await self._get_doc(user_id, job_id))
+
+    async def create(self, user_id: str, body: CronJobWrite) -> dict[str, Any]:
+        from qwenpaw_data.host.core.utils.ids import create_id
+
+        now = utcnow()
+        doc = {
+            "id": create_id("cron"),
+            "user_id": user_id,
+            "name": body.name,
+            "enabled": body.enabled,
+            "message": body.message,
+            "datasource_id": body.datasource_id,
+            "channel": "console",
+            "session_id": body.session_id,
+            "schedule": body.schedule.model_dump(mode="json"),
+            "created_at": _dt_to_json(now),
+            "updated_at": _dt_to_json(now),
+        }
+        await asyncio.to_thread(self._write, self._job_path(doc["id"]), doc)
+        return self._to_dict(doc)
+
+    async def replace(
+        self, user_id: str, job_id: str, body: CronJobWrite
+    ) -> dict[str, Any]:
+        doc = await self._get_doc(user_id, job_id)
+        doc.update(
+            name=body.name,
+            enabled=body.enabled,
+            message=body.message,
+            datasource_id=body.datasource_id,
+            session_id=body.session_id,
+            schedule=body.schedule.model_dump(mode="json"),
+            updated_at=_dt_to_json(utcnow()),
+        )
+        await asyncio.to_thread(self._write, self._job_path(job_id), doc)
+        return self._to_dict(doc)
+
+    async def set_enabled(
+        self, user_id: str, job_id: str, enabled: bool
+    ) -> dict[str, Any]:
+        doc = await self._get_doc(user_id, job_id)
+        doc["enabled"] = enabled
+        doc["updated_at"] = _dt_to_json(utcnow())
+        await asyncio.to_thread(self._write, self._job_path(job_id), doc)
+        return self._to_dict(doc)
+
+    async def delete(self, user_id: str, job_id: str) -> None:
+        await self._get_doc(user_id, job_id)
+        await asyncio.to_thread(self._job_path(job_id).unlink)
+
+    async def get_by_id(self, job_id: str) -> dict[str, Any]:
+        doc = await asyncio.to_thread(self._read, self._job_path(job_id))
+        if doc is None:
+            raise LookupError("cron job not found")
+        return self._to_dict(doc)
+
+    async def list_all(self) -> list[dict[str, Any]]:
+        docs = await asyncio.to_thread(self._scan)
+        docs.sort(key=lambda d: d["created_at"])
+        return [self._to_dict(d) for d in docs]

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/store/protocols.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/store/protocols.py
@@ -10,10 +10,47 @@ from __future__ import annotations
 
 from typing import Any, Protocol
 
+from qwenpaw_data.host.core.api.models.cron import CronJobWrite
 from qwenpaw_data.host.core.api.models.stream_objects import StreamObject
 from qwenpaw_data.host.core.domain.chat import Chat
 from qwenpaw_data.host.core.domain.preference import UserPreferences
 from qwenpaw_data.host.core.domain.session import Session
+
+
+class CronStore(Protocol):
+    async def list(self, user_id: str) -> list[dict[str, Any]]: ...
+
+    async def get(self, user_id: str, job_id: str) -> dict[str, Any]: ...
+
+    async def create(
+        self,
+        user_id: str,
+        body: CronJobWrite,
+    ) -> dict[str, Any]: ...
+
+    async def replace(
+        self,
+        user_id: str,
+        job_id: str,
+        body: CronJobWrite,
+    ) -> dict[str, Any]: ...
+
+    async def set_enabled(
+        self,
+        user_id: str,
+        job_id: str,
+        enabled: bool,
+    ) -> dict[str, Any]: ...
+
+    async def delete(self, user_id: str, job_id: str) -> None: ...
+
+    async def get_by_id(self, job_id: str) -> dict[str, Any]:
+        """Load by id without identity filter (scheduler fire path)."""
+        ...
+
+    async def list_all(self) -> list[dict[str, Any]]:
+        """Load all jobs (scheduler startup)."""
+        ...
 
 
 class PreferencesStore(Protocol):

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/store/sql_store.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/store/sql_store.py
@@ -21,9 +21,11 @@ from qwenpaw_data.host.core.api.models.stream_objects import (
     dump_stream_object,
     parse_stream_object,
 )
+from qwenpaw_data.host.core.api.models.cron import CronJobWrite, ScheduleSpec
 from qwenpaw_data.host.core.db.tables import (
     ChatEventRow,
     ChatRow,
+    CronJobRow,
     SessionRow,
     UserActiveModelRow,
     UserProviderModelRow,
@@ -41,6 +43,7 @@ from qwenpaw_data.host.core.store._prefs_logic import (
     clean_model_upsert,
     merge_provider_patch,
 )
+from qwenpaw_data.host.core.utils.ids import create_id
 from qwenpaw_data.host.core.utils.secrets import decrypt_api_key
 from qwenpaw_data.host.core.utils.time import utcnow
 
@@ -610,3 +613,115 @@ class SQLChatEventStore:
             if chat is None:
                 return -1
             return chat.last_sequence_number
+
+
+def _cron_to_dict(row: CronJobRow) -> dict[str, Any]:
+    return {
+        "id": row.id,
+        "user_id": row.user_id,
+        "name": row.name,
+        "enabled": row.enabled,
+        "message": row.message,
+        "datasource_id": row.datasource_id,
+        "channel": row.channel,
+        "session_id": row.session_id,
+        "schedule": ScheduleSpec.model_validate(row.schedule_json).model_dump(
+            mode="json"
+        ),
+        "created_at": row.created_at,
+        "updated_at": row.updated_at,
+    }
+
+
+class SQLCronStore:
+    def __init__(self, session_factory: async_sessionmaker[AsyncSession]) -> None:
+        self._sessions = session_factory
+
+    @staticmethod
+    async def _get_row(db: AsyncSession, user_id: str, job_id: str) -> CronJobRow:
+        row = await db.get(CronJobRow, job_id)
+        if row is None or row.user_id != user_id:
+            raise LookupError("cron job not found")
+        return row
+
+    async def list(self, user_id: str) -> list[dict[str, Any]]:
+        async with self._sessions() as db:
+            rows = (
+                await db.scalars(
+                    select(CronJobRow)
+                    .where(CronJobRow.user_id == user_id)
+                    .order_by(CronJobRow.created_at.desc())
+                )
+            ).all()
+            return [_cron_to_dict(r) for r in rows]
+
+    async def get(self, user_id: str, job_id: str) -> dict[str, Any]:
+        async with self._sessions() as db:
+            return _cron_to_dict(await self._get_row(db, user_id, job_id))
+
+    async def create(self, user_id: str, body: CronJobWrite) -> dict[str, Any]:
+        now = utcnow()
+        async with self._sessions() as db:
+            row = CronJobRow(
+                id=create_id("cron"),
+                user_id=user_id,
+                name=body.name,
+                enabled=body.enabled,
+                message=body.message,
+                datasource_id=body.datasource_id,
+                channel="console",
+                session_id=body.session_id,
+                schedule_json=body.schedule.model_dump(mode="json"),
+                created_at=now,
+                updated_at=now,
+            )
+            db.add(row)
+            await db.commit()
+            return _cron_to_dict(row)
+
+    async def replace(
+        self, user_id: str, job_id: str, body: CronJobWrite
+    ) -> dict[str, Any]:
+        async with self._sessions() as db:
+            row = await self._get_row(db, user_id, job_id)
+            row.name = body.name
+            row.enabled = body.enabled
+            row.message = body.message
+            row.datasource_id = body.datasource_id
+            row.session_id = body.session_id
+            row.schedule_json = body.schedule.model_dump(mode="json")
+            row.updated_at = utcnow()
+            await db.commit()
+            return _cron_to_dict(row)
+
+    async def set_enabled(
+        self, user_id: str, job_id: str, enabled: bool
+    ) -> dict[str, Any]:
+        async with self._sessions() as db:
+            row = await self._get_row(db, user_id, job_id)
+            row.enabled = enabled
+            row.updated_at = utcnow()
+            await db.commit()
+            return _cron_to_dict(row)
+
+    async def delete(self, user_id: str, job_id: str) -> None:
+        async with self._sessions() as db:
+            row = await self._get_row(db, user_id, job_id)
+            await db.delete(row)
+            await db.commit()
+
+    async def get_by_id(self, job_id: str) -> dict[str, Any]:
+        async with self._sessions() as db:
+            row = await db.get(CronJobRow, job_id)
+            if row is None:
+                raise LookupError("cron job not found")
+            return _cron_to_dict(row)
+
+    async def list_all(self) -> list[dict[str, Any]]:
+        async with self._sessions() as db:
+            rows = (
+                await db.scalars(
+                    select(CronJobRow).order_by(CronJobRow.created_at.asc())
+                )
+            ).all()
+            return [_cron_to_dict(r) for r in rows]

--- a/packages/qwenpaw-data-host-core/tests/test_cron_api.py
+++ b/packages/qwenpaw-data-host-core/tests/test_cron_api.py
@@ -1,0 +1,138 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+import httpx  # noqa: E402
+
+from qwenpaw_data.host.core.api.app import create_app  # noqa: E402
+from qwenpaw_data.host.core.api.models.cron import ScheduleSpec  # noqa: E402
+from qwenpaw_data.host.core.core import QwenPawDataHost  # noqa: E402
+
+from test_service_smoke import ScriptedAgent, _script  # noqa: E402
+
+
+def test_schedule_spec_validation() -> None:
+    spec = ScheduleSpec.model_validate({"type": "cron", "cron": "0 8 * * 1,5"})
+    assert spec.cron == "0 8 * * mon,fri"
+    assert spec.run_at is None
+
+    with pytest.raises(ValueError, match="5 fields"):
+        ScheduleSpec.model_validate({"type": "cron", "cron": "0 8 *"})
+    with pytest.raises(ValueError, match="run_at"):
+        ScheduleSpec.model_validate({"type": "once"})
+
+    once = ScheduleSpec.model_validate(
+        {"type": "once", "run_at": "2026-12-01T08:00:00+08:00"}
+    )
+    assert once.cron is None
+
+
+@asynccontextmanager
+async def service_client(tmp_path: Path, monkeypatch, agent=None):
+    monkeypatch.delenv("QWENPAW_DATA_API_TOKEN", raising=False)
+    monkeypatch.delenv("QWENPAW_DATA_DB_URL", raising=False)
+    monkeypatch.delenv("QWENPAW_DATA_STORE", raising=False)
+    if agent is not None:
+
+        async def fake_get_agent(self, *, mode: str, request_context=None):
+            return agent
+
+        monkeypatch.setattr(QwenPawDataHost, "get_agent", fake_get_agent)
+    app = create_app(home=tmp_path, model=object())
+    async with app.router.lifespan_context(app):
+        transport = httpx.ASGITransport(app=app, client=("127.0.0.1", 1234))
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://testserver",
+        ) as http:
+            yield http, app
+
+
+JOB_BODY = {
+    "name": "每日晨报",
+    "message": "生成销售日报",
+    "datasource_id": "ds1",
+    "schedule": {"type": "cron", "cron": "0 8 * * *"},
+}
+
+
+async def test_cron_job_crud_and_scheduler_sync(tmp_path, monkeypatch) -> None:
+    async with service_client(tmp_path, monkeypatch) as (http, app):
+        created = await http.post("/api/v1/cron/jobs", json=JOB_BODY)
+        assert created.status_code == 200
+        job = created.json()["job"]
+        job_id = job["id"]
+
+        scheduler = app.state.service.cron_manager._scheduler
+        assert scheduler.get_job(job_id) is not None
+        assert scheduler.get_job(job_id).next_run_time is not None
+
+        paused = await http.post(f"/api/v1/cron/jobs/{job_id}/pause")
+        assert paused.json()["job"]["enabled"] is False
+        assert scheduler.get_job(job_id).next_run_time is None
+
+        resumed = await http.post(f"/api/v1/cron/jobs/{job_id}/resume")
+        assert resumed.json()["job"]["enabled"] is True
+
+        listing = await http.get("/api/v1/cron/jobs")
+        assert listing.json()["count"] == 1
+
+        # unknown session rejected
+        bad = await http.post(
+            "/api/v1/cron/jobs", json={**JOB_BODY, "session_id": "ses_missing"}
+        )
+        assert bad.status_code == 404
+
+        deleted = await http.delete(f"/api/v1/cron/jobs/{job_id}")
+        assert deleted.json()["ok"] is True
+        assert scheduler.get_job(job_id) is None
+        assert (await http.get(f"/api/v1/cron/jobs/{job_id}")).status_code == 404
+
+
+async def test_cron_run_opens_console_chat(tmp_path, monkeypatch) -> None:
+    agent = ScriptedAgent(_script())
+    async with service_client(tmp_path, monkeypatch, agent=agent) as (http, app):
+        job_id = (
+            await http.post("/api/v1/cron/jobs", json=JOB_BODY)
+        ).json()["job"]["id"]
+
+        fired = await http.post(f"/api/v1/cron/jobs/{job_id}/run")
+        assert fired.status_code == 200
+
+        state = app.state.service
+        for _ in range(200):
+            sessions, total = await state.sessions.list()
+            if total:
+                chats = await state.chats.list_for_session(sessions[0][0].id)
+                if chats and chats[0].status == "completed":
+                    break
+            await asyncio.sleep(0.02)
+        else:
+            raise AssertionError("cron run did not complete a chat")
+
+        session = sessions[0][0]
+        assert session.title == "每日晨报"
+        assert session.datasource_id == "ds1"
+        chat = chats[0]
+        assert chat.user_input == "生成销售日报"
+        events = await state.events.read_after(chat.id, -1)
+        assert events[-1].object == "response"
+        assert events[-1].status == "completed"
+
+
+async def test_cron_jobs_restore_on_restart(tmp_path, monkeypatch) -> None:
+    async with service_client(tmp_path, monkeypatch) as (http, _app):
+        job_id = (
+            await http.post("/api/v1/cron/jobs", json=JOB_BODY)
+        ).json()["job"]["id"]
+
+    # New service instance over the same home: job re-registers.
+    async with service_client(tmp_path, monkeypatch) as (http, app):
+        assert app.state.service.cron_manager._scheduler.get_job(job_id) is not None
+        assert (await http.get("/api/v1/cron/jobs")).json()["count"] == 1

--- a/packages/qwenpaw-data-host-core/tests/test_store_conformance.py
+++ b/packages/qwenpaw-data-host-core/tests/test_store_conformance.py
@@ -439,3 +439,63 @@ async def test_prefs_models_and_active_selection(prefs_backend, monkeypatch) -> 
     await prefs.delete_model("u1", "dashscope", "my-model")
     with pytest.raises(LookupError):
         await prefs.delete_model("u1", "dashscope", "my-model")
+
+
+# ---- CronStore conformance ----
+
+
+@pytest.fixture
+def cron_backend(backend: Backend, tmp_path: Path):
+    from qwenpaw_data.host.core.store.json_store import JSONCronStore
+    from qwenpaw_data.host.core.store.sql_store import SQLCronStore
+
+    if backend.name == "json":
+        return JSONCronStore(tmp_path)
+    return SQLCronStore(backend.factory)
+
+
+def _job_body(name: str = "每日晨报", **overrides):
+    from qwenpaw_data.host.core.api.models.cron import CronJobWrite
+
+    values = {
+        "name": name,
+        "message": "生成日报",
+        "datasource_id": "ds1",
+        "schedule": {"type": "cron", "cron": "0 8 * * 1"},
+    }
+    values.update(overrides)
+    return CronJobWrite.model_validate(values)
+
+
+async def test_cron_crud_roundtrip(cron_backend) -> None:
+    store = cron_backend
+    job = await store.create("u1", _job_body())
+    assert job["enabled"] is True
+    assert job["channel"] == "console"
+    assert job["schedule"]["cron"] == "0 8 * * mon"  # dow normalized
+
+    got = await store.get("u1", job["id"])
+    assert got["name"] == "每日晨报"
+
+    replaced = await store.replace(
+        "u1", job["id"], _job_body(name="改名", enabled=False)
+    )
+    assert replaced["name"] == "改名" and replaced["enabled"] is False
+
+    paused = await store.set_enabled("u1", job["id"], True)
+    assert paused["enabled"] is True
+
+    listing = await store.list("u1")
+    assert [j["id"] for j in listing] == [job["id"]]
+
+    # user isolation + unscoped scheduler paths
+    with pytest.raises(LookupError):
+        await store.get("u2", job["id"])
+    assert (await store.get_by_id(job["id"]))["id"] == job["id"]
+    assert [j["id"] for j in await store.list_all()] == [job["id"]]
+
+    await store.delete("u1", job["id"])
+    with pytest.raises(LookupError):
+        await store.get("u1", job["id"])
+    with pytest.raises(LookupError):
+        await store.get_by_id(job["id"])

--- a/uv.lock
+++ b/uv.lock
@@ -328,6 +328,18 @@ wheels = [
 ]
 
 [[package]]
+name = "apscheduler"
+version = "3.11.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzlocal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8c/6b/eeff360196bb20b312c9e762a820fd1b2c6d809466c755ef57863478e454/apscheduler-3.11.3.tar.gz", hash = "sha256:cd2fcc9330039a81a5893472ad49facf23a6d5604cbe1d918c835c6de7834d5a", size = 110312, upload-time = "2026-06-28T19:39:22.493Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/c9/8638db32514dbb9157b3d82680c6faea89283523edf9ed2415ea3884f2ae/apscheduler-3.11.3-py3-none-any.whl", hash = "sha256:bbeb2ec02d23d3c06a6c07ed7f0f3939ada6680eb121fae809a69bb42c537a30", size = 66024, upload-time = "2026-06-28T19:39:20.982Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3106,6 +3118,7 @@ dependencies = [
 [package.optional-dependencies]
 service = [
     { name = "aiosqlite" },
+    { name = "apscheduler" },
     { name = "cryptography" },
     { name = "fastapi" },
     { name = "sqlalchemy", extra = ["asyncio"] },
@@ -3116,6 +3129,7 @@ requires-dist = [
     { name = "agentscope", specifier = ">=2.0.6,<2.1" },
     { name = "aiodocker", specifier = ">=0.27,<0.28" },
     { name = "aiosqlite", marker = "extra == 'service'", specifier = ">=0.20,<1.0" },
+    { name = "apscheduler", marker = "extra == 'service'", specifier = ">=3.10,<4.0" },
     { name = "cryptography", marker = "extra == 'service'", specifier = ">=42,<47" },
     { name = "fastapi", marker = "extra == 'service'", specifier = ">=0.115,<1.0" },
     { name = "httpx", specifier = ">=0.28,<0.29" },
@@ -3598,6 +3612,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
+]
+
+[[package]]
+name = "tzlocal"
+version = "5.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/5b/879b2f932adfa7a053c360d50bc896c977fa6426109185f7c12ebdd0cb9d/tzlocal-5.4.4.tar.gz", hash = "sha256:8dbb8660838688a7b6ba4fed31d18dedf842afb4d47ca050d6d891c2c15f3be4", size = 31170, upload-time = "2026-06-29T08:03:40.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/a4/017a7a6cbe387d961a688ec31364ae60a5c4e22c96ae9921b79a947c855d/tzlocal-5.4.4-py3-none-any.whl", hash = "sha256:aae09f0126a8a86fa736be266eb4a471380d26a0de3bc14844e7821fee3e2a15", size = 18115, upload-time = "2026-06-29T08:03:38.666Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add persisted cron jobs behind the existing store abstractions
- expose create, list, update, and delete APIs for scheduled agent runs
- run due jobs through the same session and chat runtime used by interactive requests
- support both JSON and SQLite storage backends

## Stack
- stacked on #41
- retarget this PR to `main` after the preceding PRs merge

## Test plan
- [x] Run cron API and scheduler lifecycle tests
- [x] Run store conformance tests for JSON and SQLite backends
- [x] Run the full repository test suite as part of the completed stack (`762 passed`)