### PR TITLE
feat(context): add universal datasource connector framework

### DIFF
--- a/packages/qwenpaw-data-context/pyproject.toml
+++ b/packages/qwenpaw-data-context/pyproject.toml
@@ -59,7 +59,11 @@ dependencies = [
   "certifi>=2023.0,<2027.0",
   "func-timeout>=4.3,<5.0",
   "oss2>=2.19,<3.0",
+  "sqlalchemy>=2.0,<3.0",
 ]
+
+[project.optional-dependencies]
+bigquery = ["google-cloud-bigquery>=3.25,<4.0"]
 
 [project.urls]
 Homepage = "https://github.com/agentscope-ai/QwenPaw-Data"

--- a/packages/qwenpaw-data-context/src/context_manager/graph/adapters/base.py
+++ b/packages/qwenpaw-data-context/src/context_manager/graph/adapters/base.py
@@ -49,3 +49,96 @@ class SourceAdapter(Protocol):
     def test_connection(self) -> ConnectionTestResult: ...
 
     def extract_metadata(self, schemas: Sequence[str]) -> PhysicalManifest: ...
+
+
+# ---------------------------------------------------------------------- #
+# Connector framework extensions
+# ---------------------------------------------------------------------- #
+class ConnectorError(Exception):
+    """The single exception type of the access layer; callers need one
+    ``except ConnectorError``."""
+
+    def __init__(self, message: str, cause: Exception | None = None):
+        super().__init__(message)
+        self.message = message
+        self.cause = cause
+
+    def __str__(self) -> str:  # keep logs readable: append the cause summary
+        if self.cause is not None:
+            return f"{self.message} (cause: {self.cause})"
+        return self.message
+
+
+@dataclass
+class ExecResult:
+    """SQL execution result; ``logview_url``/``instance_id``/``task_status``
+    are ODPS-only."""
+
+    sql: str
+    columns: list[str] = field(default_factory=list)
+    rows: list[list] = field(default_factory=list)
+    row_count: int = 0
+    truncated: bool = False
+    elapsed_ms: float = 0.0
+    error: str | None = None
+    logview_url: str | None = None
+    instance_id: str | None = None
+    task_status: str | None = None
+
+    def to_dict(self) -> dict:
+        d = {
+            "sql": self.sql,
+            "columns": self.columns,
+            "rows": [[_jsonable(v) for v in r] for r in self.rows],
+            "row_count": self.row_count,
+            "truncated": self.truncated,
+            "elapsed_ms": round(self.elapsed_ms, 1),
+            "error": self.error,
+        }
+        if self.logview_url:
+            d["logview_url"] = self.logview_url
+        if self.instance_id:
+            d["instance_id"] = self.instance_id
+        if self.task_status:
+            d["task_status"] = self.task_status
+        return d
+
+
+@runtime_checkable
+class SqlExecutable(Protocol):
+    """Capability protocol: connectable sources that can run read queries."""
+
+    def execute_sql(self, sql: str, *, max_rows: int = 200) -> ExecResult: ...
+
+
+class BaseConnector:
+    """Common adapter base: holds ``db_id`` and a ``close()`` cleanup hook."""
+
+    #: Pooling semantics marker; ``False`` opts an adapter out of pooling
+    #: and metadata caching.
+    poolable: bool = True
+
+    def __init__(self, *, db_id: str):
+        self._db_id = db_id
+
+    @property
+    def db_id(self) -> str:
+        return self._db_id
+
+    def close(self) -> None:
+        """Release resources held by the adapter (no-op by default)."""
+        return None
+
+
+def _jsonable(v):
+    """Convert datetime / Decimal and friends into JSON-friendly types."""
+    import datetime as _dt
+    from decimal import Decimal
+
+    if v is None or isinstance(v, (str, int, float, bool, list, dict)):
+        return v
+    if isinstance(v, Decimal):
+        return float(v)
+    if isinstance(v, (_dt.date, _dt.datetime, _dt.time)):
+        return v.isoformat()
+    return str(v)

--- a/packages/qwenpaw-data-context/src/context_manager/graph/adapters/bigquery_adapter.py
+++ b/packages/qwenpaw-data-context/src/context_manager/graph/adapters/bigquery_adapter.py
@@ -1,0 +1,313 @@
+"""BigQuery adapter — direct google-cloud-bigquery port implementation, not a
+UniversalConnector subclass.
+
+选择 SDK 直连而非 sqlalchemy-bigquery dialect 的原因：
+
+- 跨项目公共数据集：``schemas`` 每项支持 ``project.dataset`` 限定（计费
+  project ≠ 数据 project）；
+- 嵌套 RECORD/STRUCT 字段展平成 ``event_params.key`` 子列，元数据对
+  text-to-SQL 可用；
+- 分区键取自 ``time_partitioning`` / ``range_partitioning``，不靠列名猜测；
+- 费用护栏：``maximum_bytes_billed``；不做 ``SELECT DISTINCT`` 采样
+ （整列扫描计费）。
+
+google-cloud-bigquery 是可选依赖（``qwenpaw-data-context[bigquery]``），
+仅在实际使用时导入。
+"""
+from __future__ import annotations
+
+import json
+import time
+from typing import TYPE_CHECKING, Any, Iterator, Optional, Sequence
+
+from pydantic import BaseModel
+
+from ...secrets.schemas import BigQueryConnection
+from ...utils import get_logger
+from ..keys import column_key, derive_layer, table_key
+from ..physical import ColumnRecord, TableRecord
+from .base import (
+    BaseConnector,
+    ConnectionTestResult,
+    ConnectorError,
+    ExecResult,
+    PhysicalManifest,
+)
+
+if TYPE_CHECKING:
+    from ...contracts.import_models import SourceConfig
+
+log = get_logger("graph.adapters.bigquery")
+
+#: Max datasets listed during test_connection (reachability only).
+_TEST_LIST_LIMIT = 10
+
+#: BigQuery legacy type name → GoogleSQL name; complex types keep lowercase raw form.
+_BQ_TYPE_RENAMES = {
+    "integer": "int64",
+    "float": "float64",
+    "boolean": "bool",
+    "record": "struct",
+}
+
+
+def _normalize_bq_type(field: Any) -> str:
+    t = str(getattr(field, "field_type", "") or "string").strip().lower()
+    t = _BQ_TYPE_RENAMES.get(t, t)
+    if str(getattr(field, "mode", "") or "").upper() == "REPEATED":
+        return f"array<{t}>"
+    return t
+
+
+def _walk_fields(fields: Sequence[Any], prefix: str = "") -> Iterator[tuple[str, Any]]:
+    """DFS 展平嵌套字段：RECORD 本身与其子字段都产出。"""
+    for f in fields:
+        name = f"{prefix}{f.name}"
+        yield name, f
+        if str(getattr(f, "field_type", "")).upper() in ("RECORD", "STRUCT"):
+            yield from _walk_fields(list(f.fields), prefix=f"{name}.")
+
+
+class BigQueryConnector(BaseConnector):
+    """BigQuery adapter: extract_metadata / execute_sql / test_connection via
+    google-cloud-bigquery."""
+
+    connection_model: type[BaseModel] = BigQueryConnection
+
+    def __init__(self, conn: BaseModel, *, db_id: str):
+        super().__init__(db_id=db_id)
+        self._conn = conn
+        self._client = self._create_client()
+
+    # ---- Construction entries ----
+    @classmethod
+    def from_config(cls, config: "SourceConfig", db_id: str) -> "BigQueryConnector":
+        conn = getattr(config, "connection", None)
+        if not isinstance(conn, cls.connection_model):
+            raise ConnectorError(
+                f"{cls.__name__} 需要 {cls.connection_model.__name__} 连接配置，"
+                f"got {type(conn).__name__}"
+            )
+        return cls(conn, db_id=db_id)
+
+    @classmethod
+    def from_connection(cls, conn: BaseModel, db_id: str) -> "BigQueryConnector":
+        if not isinstance(conn, cls.connection_model):
+            raise ConnectorError(
+                f"{cls.__name__} 需要 {cls.connection_model.__name__} 连接配置，"
+                f"got {type(conn).__name__}"
+            )
+        return cls(conn, db_id=db_id)
+
+    # ---- Client construction ----
+    def _create_client(self):
+        try:
+            from google.cloud import bigquery
+            from google.oauth2 import service_account
+        except ImportError as exc:
+            raise ConnectorError(
+                "bigquery 依赖 google-cloud-bigquery，当前环境未安装；"
+                '请先安装（pip install "qwenpaw-data-context[bigquery]"）',
+                cause=exc,
+            ) from exc
+        conn = self._conn
+        try:
+            info = json.loads(conn.service_account_json.get_secret_value())
+            creds = service_account.Credentials.from_service_account_info(info)
+            return bigquery.Client(
+                project=conn.project_id,
+                credentials=creds,
+                location=conn.location or None,
+            )
+        except Exception as exc:  # noqa: BLE001
+            raise ConnectorError(
+                f"BigQuery 客户端构造失败（project={conn.project_id!r}）: {exc}",
+                cause=exc,
+            ) from exc
+
+    def close(self) -> None:
+        try:
+            self._client.close()
+        except Exception as exc:  # noqa: BLE001
+            log.warning("bigquery client close failed: %s", exc)
+
+    # ---- Port: test_connection (never raises) ----
+    def test_connection(self) -> ConnectionTestResult:
+        try:
+            n = 0
+            for _ in self._client.list_datasets(max_results=_TEST_LIST_LIMIT):
+                n += 1
+            return ConnectionTestResult(
+                success=True,
+                message=f"connected to BigQuery project {self._conn.project_id}",
+                tables_found=n,
+            )
+        except Exception as exc:  # noqa: BLE001 — 连接失败是预期结果，不抛
+            return ConnectionTestResult(success=False, message=str(exc))
+
+    # ---- Port: execute_sql (never raises) ----
+    def execute_sql(self, sql: str, *, max_rows: int = 200) -> ExecResult:
+        t0 = time.time()
+        job = None
+        try:
+            from google.cloud import bigquery
+
+            job_config = bigquery.QueryJobConfig(use_legacy_sql=False)
+            if getattr(self._conn, "maximum_bytes_billed", None):
+                job_config.maximum_bytes_billed = int(
+                    self._conn.maximum_bytes_billed
+                )
+            job = self._client.query(sql, job_config=job_config)
+            result = job.result(max_results=max_rows)
+            cols = [str(f.name) for f in result.schema]
+            rows = [list(row) for row in result]
+            total = result.total_rows
+            truncated = bool(total is not None and total > max_rows)
+            return ExecResult(
+                sql=sql,
+                columns=cols,
+                rows=rows,
+                row_count=int(total) if total is not None else len(rows),
+                truncated=truncated,
+                elapsed_ms=(time.time() - t0) * 1000,
+                instance_id=job.job_id,
+                task_status=str(job.state),
+            )
+        except Exception as exc:  # noqa: BLE001 — SQL failure is expected
+            return ExecResult(
+                sql=sql,
+                error=str(exc),
+                elapsed_ms=(time.time() - t0) * 1000,
+                instance_id=getattr(job, "job_id", None),
+            )
+
+    # ---- Port: extract_metadata (raises ConnectorError) ----
+    def extract_metadata(self, schemas: Sequence[str]) -> PhysicalManifest:
+        db = self._db_id
+        refs = [s.strip() for s in schemas if s and s.strip()]
+        table_recs: list[TableRecord] = []
+        col_recs: list[ColumnRecord] = []
+        label = "default"
+        try:
+            if not refs:
+                refs = [d.dataset_id for d in self._client.list_datasets()]
+            for i, ref in enumerate(refs):
+                ds_label = self._reflect_dataset(ref, db, table_recs, col_recs)
+                if i == 0:
+                    label = ds_label
+        except ConnectorError:
+            raise
+        except Exception as exc:  # noqa: BLE001 — wrap into the layer exception
+            raise ConnectorError(
+                f"反射 BigQuery 数据源 {db!r} 元数据失败（datasets={refs!r}）: {exc}",
+                cause=exc,
+            ) from exc
+
+        log.info(
+            "BigQuery reflected: db=%s datasets=%s tables=%d columns=%d",
+            db, refs, len(table_recs), len(col_recs),
+        )
+        return PhysicalManifest(
+            db_id=db, schema=label, tables=table_recs, columns=col_recs, fks=[],
+        )
+
+    # ---- Reflection steps ----
+    def _dataset_ref(self, ref: str):
+        """``dataset`` 或 ``project.dataset``（GCP project id 不含点，安全按
+        首个点切分）。"""
+        from google.cloud import bigquery
+
+        if "." in ref:
+            project, dataset = ref.split(".", 1)
+        else:
+            project, dataset = self._conn.project_id, ref
+        return bigquery.DatasetReference(project, dataset)
+
+    def _reflect_dataset(
+        self,
+        ref: str,
+        db: str,
+        table_recs: list[TableRecord],
+        col_recs: list[ColumnRecord],
+    ) -> str:
+        ds_ref = self._dataset_ref(ref)
+        # 图 key 保持三段式（db.schema.table）；project 限定保留在 DDL 全名里。
+        schema_label = ds_ref.dataset_id
+        for item in self._client.list_tables(ds_ref):
+            table = self._client.get_table(item.reference)
+            partition_key = self._partition_key(table)
+            table_recs.append(
+                TableRecord(
+                    key=table_key(db, schema_label, table.table_id),
+                    db=db,
+                    schema=schema_label,
+                    name=table.table_id,
+                    layer=derive_layer(table.table_id),
+                    partition_key=partition_key,
+                    comment=(table.description or "").strip(),
+                    ddl=self._table_ddl(table),
+                )
+            )
+            for name, f in _walk_fields(list(table.schema)):
+                ctype = _normalize_bq_type(f)
+                ccomment = (getattr(f, "description", None) or "").strip()
+                text = f"{db}.{table.table_id}.{name} ({ctype})"
+                if ccomment:
+                    text += f" — {ccomment}"
+                col_recs.append(
+                    ColumnRecord(
+                        key=column_key(db, schema_label, table.table_id, name),
+                        db=db,
+                        schema=schema_label,
+                        table=table.table_id,
+                        name=name,
+                        type=ctype,
+                        pk=False,
+                        nullable=str(
+                            getattr(f, "mode", "") or "NULLABLE"
+                        ).upper() != "REQUIRED",
+                        is_partition=(name == partition_key),
+                        comment=ccomment,
+                        description=ccomment,
+                        text=text,
+                    )
+                )
+        return schema_label
+
+    @staticmethod
+    def _partition_key(table: Any) -> Optional[str]:
+        tp = getattr(table, "time_partitioning", None)
+        if tp is not None:
+            return tp.field or "_PARTITIONTIME"  # ingestion-time 分区的伪列
+        rp = getattr(table, "range_partitioning", None)
+        if rp is not None:
+            return rp.field
+        return None
+
+    @staticmethod
+    def _table_ddl(table: Any) -> str:
+        """View 用原始查询；表合成展平列清单的 CREATE TABLE（提示语料，非可执行 DDL）。"""
+        if str(getattr(table, "table_type", "")) in ("VIEW", "MATERIALIZED_VIEW"):
+            body = (
+                getattr(table, "view_query", None)
+                or getattr(table, "mview_query", None)
+                or ""
+            ).strip()
+            return body.rstrip(";") + ";" if body else ""
+        flat = list(_walk_fields(list(table.schema)))
+        if not flat:
+            return ""
+        lines = [f"CREATE TABLE `{table.reference}` ("]
+        for i, (name, f) in enumerate(flat):
+            suffix = "," if i < len(flat) - 1 else ""
+            nn = (
+                " NOT NULL"
+                if str(getattr(f, "mode", "") or "").upper() == "REQUIRED"
+                else ""
+            )
+            lines.append(f"  `{name}` {_normalize_bq_type(f)}{nn}{suffix}")
+        lines.append(");")
+        return "\n".join(lines)
+
+
+__all__ = ["BigQueryConnector"]

--- a/packages/qwenpaw-data-context/src/context_manager/graph/adapters/registry.py
+++ b/packages/qwenpaw-data-context/src/context_manager/graph/adapters/registry.py
@@ -39,6 +39,8 @@ def _register_builtins() -> None:
     from .ddl_adapter import DDLAdapter
     from .csv_adapter import CSVAdapter
     from .odps_adapter import OdpsAdapter
+    from .sqlite_adapter import SQLiteConnector
+    from .bigquery_adapter import BigQueryConnector
 
     register_adapter("postgres", PostgresAdapter.from_config)
     register_adapter("hologres", PostgresAdapter.from_config)
@@ -46,6 +48,8 @@ def _register_builtins() -> None:
     register_adapter("odps", OdpsAdapter.from_config)
     register_adapter("ddl", DDLAdapter.from_config)
     register_adapter("csv", CSVAdapter.from_config)
+    register_adapter("sqlite", SQLiteConnector.from_config)
+    register_adapter("bigquery", BigQueryConnector.from_config)
 
 
 _register_builtins()

--- a/packages/qwenpaw-data-context/src/context_manager/graph/adapters/sqlite_adapter.py
+++ b/packages/qwenpaw-data-context/src/context_manager/graph/adapters/sqlite_adapter.py
@@ -1,0 +1,57 @@
+"""SQLite adapter — minimal overrides on UniversalConnector (single local
+file, schema == ``main``)."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional, Sequence
+
+from pydantic import BaseModel
+
+from ...secrets.schemas import SqliteConnection
+from ...utils import get_logger
+from .base import ConnectorError
+from .universal import UniversalConnector
+
+log = get_logger("graph.adapters.sqlite")
+
+#: SQLite 唯一的隐式 schema 名（写进图节点 ``schema`` 字段）。
+_SQLITE_SCHEMA = "main"
+
+
+class SQLiteConnector(UniversalConnector):
+    """Single-file source: no host / credentials; construction validates the
+    file exists because sqlite3 silently creates missing databases."""
+
+    connection_model = SqliteConnection
+
+    def __init__(self, conn: SqliteConnection, *, db_id: str):
+        path = Path(conn.path).expanduser()
+        if not path.is_file():
+            raise ConnectorError(f"SQLite 数据库文件不存在: {path}")
+        super().__init__(conn, db_id=db_id)
+
+    def _engine_url(self, conn: BaseModel):
+        from sqlalchemy import URL
+
+        path = str(Path(conn.path).expanduser())
+        if getattr(conn, "read_only", True):
+            # sqlite:///file:<path>?mode=ro&uri=true — 只读 URI 打开
+            return URL.create(
+                "sqlite",
+                database=f"file:{path}",
+                query={"mode": "ro", "uri": "true"},
+            )
+        return URL.create("sqlite", database=path)
+
+    def _connect_args(self) -> dict:
+        # Engine 会被跨线程复用，必须关掉 sqlite3 的同线程检查。
+        return {"check_same_thread": False, "timeout": 5}
+
+    def _resolve_schema(self, schemas: Sequence[str]) -> Optional[str]:
+        return None  # 单库无 schema 概念；inspector 走默认
+
+    def _schema_label(self, resolved: Optional[str]) -> str:
+        return _SQLITE_SCHEMA
+
+
+__all__ = ["SQLiteConnector"]

--- a/packages/qwenpaw-data-context/src/context_manager/graph/adapters/universal.py
+++ b/packages/qwenpaw-data-context/src/context_manager/graph/adapters/universal.py
@@ -1,0 +1,387 @@
+"""UniversalConnector — generic Template-Method adapter for pure SQL sources;
+subclasses override the differing reflection hooks."""
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING, Any, Optional, Sequence
+
+from pydantic import BaseModel
+
+from ...ingest import FKInfo
+from ...utils import get_logger
+from ..keys import DEFAULT_SCHEMA, column_key, derive_layer, table_key
+from ..physical import ColumnRecord, TableRecord
+from .base import (
+    BaseConnector,
+    ConnectionTestResult,
+    ConnectorError,
+    ExecResult,
+    PhysicalManifest,
+)
+
+if TYPE_CHECKING:
+    from ...contracts.import_models import SourceConfig
+
+log = get_logger("graph.adapters.universal")
+
+#: Candidate partition-key column names.
+_PARTITION_CANDIDATES = ("ds", "dt", "stat_date", "data_date")
+
+
+def _detect_partition_key(col_names: Sequence[str]) -> Optional[str]:
+    by_lower = {c.lower(): c for c in col_names}
+    for cand in _PARTITION_CANDIDATES:
+        if cand in by_lower:
+            return by_lower[cand]
+    return None
+
+
+class UniversalConnector(BaseConnector):
+    """Generic adapter for pure SQL sources: ``inspect`` + ``text()`` + ``SELECT 1``."""
+
+    #: Subclasses must bind their Connection model (the single source of truth
+    #: of the form schema).
+    connection_model: type[BaseModel] = BaseModel
+
+    def __init__(self, conn: BaseModel, *, db_id: str):
+        super().__init__(db_id=db_id)
+        self._conn = conn
+        self._engine = self._create_engine(conn)
+
+    # ------------------------------------------------------------------ #
+    # Construction entries
+    # ------------------------------------------------------------------ #
+    @classmethod
+    def from_config(cls, config: "SourceConfig", db_id: str) -> "UniversalConnector":
+        conn = getattr(config, "connection", None)
+        if not isinstance(conn, cls.connection_model):
+            raise ConnectorError(
+                f"{cls.__name__} 需要 {cls.connection_model.__name__} 连接配置，"
+                f"got {type(conn).__name__}"
+            )
+        return cls(conn, db_id=db_id)
+
+    @classmethod
+    def from_connection(cls, conn: BaseModel, db_id: str) -> "UniversalConnector":
+        if not isinstance(conn, cls.connection_model):
+            raise ConnectorError(
+                f"{cls.__name__} 需要 {cls.connection_model.__name__} 连接配置，"
+                f"got {type(conn).__name__}"
+            )
+        return cls(conn, db_id=db_id)
+
+    # ------------------------------------------------------------------ #
+    # Subclass override points
+    # ------------------------------------------------------------------ #
+    def _engine_url(self, conn: BaseModel):
+        """Build the SQLAlchemy URL (must override; use ``URL.create`` for
+        password safety)."""
+        raise NotImplementedError
+
+    def _connect_args(self) -> dict[str, Any]:
+        """Driver-level connect_args (e.g. ``connect_timeout``)."""
+        return {}
+
+    def _resolve_schema(self, schemas: Sequence[str]) -> Optional[str]:
+        """Resolve the port-level *schemas* argument to the inspect target."""
+        return schemas[0] if schemas else None
+
+    def _schema_label(self, resolved: Optional[str]) -> str:
+        """The name written to graph-node ``schema``."""
+        return resolved or DEFAULT_SCHEMA
+
+    def _load_column_comments(
+        self, conn, schema: Optional[str], tables: Sequence[str]
+    ) -> dict[tuple[str, str], str]:
+        """Bulk column-comment hook; dialects without comments in
+        ``get_columns`` override with a catalog query."""
+        return {}
+
+    def _post_reflect(
+        self,
+        schema: Optional[str],
+        schema_label: str,
+        tables: list[TableRecord],
+        columns: list[ColumnRecord],
+    ) -> None:
+        """Post-reflection enrichment hook (no-op by default)."""
+        return None
+
+    # ------------------------------------------------------------------ #
+    # Engine lifecycle
+    # ------------------------------------------------------------------ #
+    def _create_engine(self, conn: BaseModel):
+        from sqlalchemy import create_engine
+
+        return create_engine(
+            self._engine_url(conn),
+            pool_size=5,
+            max_overflow=10,
+            pool_pre_ping=True,
+            pool_recycle=1800,
+            connect_args=self._connect_args(),
+        )
+
+    def close(self) -> None:
+        """Close every connection held by the engine pool."""
+        try:
+            self._engine.dispose()
+        except Exception as exc:  # noqa: BLE001
+            log.warning("engine dispose failed: %s", exc)
+
+    # ------------------------------------------------------------------ #
+    # Port: test_connection (never raises; failure is an expected outcome)
+    # ------------------------------------------------------------------ #
+    def test_connection(self) -> ConnectionTestResult:
+        from sqlalchemy import inspect, text
+
+        try:
+            with self._engine.connect() as conn:
+                conn.execute(text("SELECT 1"))
+                insp = inspect(conn)
+                n = len(self._list_tables(insp, self._resolve_schema([])))
+            url = self._engine.url.render_as_string(hide_password=True)
+            return ConnectionTestResult(
+                success=True,
+                message=f"connected: {url}",
+                tables_found=n,
+            )
+        except Exception as exc:  # noqa: BLE001 — connection failure is expected
+            return ConnectionTestResult(success=False, message=str(exc))
+
+    # ------------------------------------------------------------------ #
+    # Port: execute_sql
+    # ------------------------------------------------------------------ #
+    def _normalize_exec_sql(self, sql: str) -> str:
+        """Last-hop SQL normalization hook (default: no-op).
+
+        PG-family backends can override this to rewrite MySQL-style
+        introspection statements (``SHOW TABLES`` / ``DESC`` …) into catalog
+        SELECTs. Implementations must only return read-only equivalents.
+        """
+        return sql
+
+    def execute_sql(self, sql: str, *, max_rows: int = 200) -> ExecResult:
+        from sqlalchemy import text
+
+        t0 = time.time()
+        exec_sql = self._normalize_exec_sql(sql)
+        try:
+            with self._engine.connect() as conn:
+                result = conn.execute(text(exec_sql))
+                cols = [str(k) for k in result.keys()]
+                fetched = result.fetchmany(max_rows + 1)
+                truncated = len(fetched) > max_rows
+                total = len(fetched)
+                rows = [list(r) for r in fetched[:max_rows]]
+                rc = result.rowcount
+                row_count = rc if rc is not None and rc >= 0 else total
+            return ExecResult(
+                sql=sql,
+                columns=cols,
+                rows=rows,
+                row_count=row_count,
+                truncated=truncated,
+                elapsed_ms=(time.time() - t0) * 1000,
+            )
+        except Exception as exc:  # noqa: BLE001 — SQL failure is expected
+            return ExecResult(
+                sql=exec_sql,  # shows the rewritten form when normalized
+                error=str(exc),
+                elapsed_ms=(time.time() - t0) * 1000,
+            )
+
+    # ------------------------------------------------------------------ #
+    # Port: extract_metadata (Template Method; raises ConnectorError)
+    # ------------------------------------------------------------------ #
+    def extract_metadata(self, schemas: Sequence[str]) -> PhysicalManifest:
+        from sqlalchemy import inspect
+
+        resolved = self._resolve_schema(schemas)
+        schema_label = self._schema_label(resolved)
+        db = self._db_id
+        table_recs: list[TableRecord] = []
+        col_recs: list[ColumnRecord] = []
+        fks: list[FKInfo] = []
+        try:
+            with self._engine.connect() as conn:
+                insp = inspect(conn)
+                table_names = self._list_tables(insp, resolved)
+                views = set(self._list_views(insp, resolved))
+                all_names = sorted(set(table_names) | views)
+                col_comments = self._load_column_comments(conn, resolved, all_names)
+                for t in all_names:
+                    cols_raw = insp.get_columns(t, schema=resolved)
+                    pk_cols = set(self._pk_columns(insp, t, resolved))
+                    fks.extend(self._load_fks(insp, t, resolved))
+                    comment = self._table_comment(insp, t, resolved)
+                    col_names = [str(c.get("name")) for c in cols_raw]
+                    partition_col = _detect_partition_key(col_names)
+                    ddl = self._table_ddl(
+                        insp, t, resolved, cols_raw, pk_cols, is_view=t in views
+                    )
+                    table_recs.append(
+                        TableRecord(
+                            key=table_key(db, schema_label, t),
+                            db=db,
+                            schema=schema_label,
+                            name=t,
+                            layer=derive_layer(t),
+                            partition_key=partition_col,
+                            comment=comment,
+                            ddl=ddl,
+                        )
+                    )
+                    for c in cols_raw:
+                        cname = str(c.get("name"))
+                        ctype = self._normalize_type(c)
+                        ccomment = (
+                            col_comments.get((t, cname))
+                            or (c.get("comment") or "").strip()
+                        )
+                        text = f"{db}.{t}.{cname} ({ctype})"
+                        if ccomment:
+                            text += f" — {ccomment}"
+                        col_recs.append(
+                            ColumnRecord(
+                                key=column_key(db, schema_label, t, cname),
+                                db=db,
+                                schema=schema_label,
+                                table=t,
+                                name=cname,
+                                type=ctype,
+                                pk=cname in pk_cols,
+                                nullable=bool(c.get("nullable", True)),
+                                is_partition=(cname == partition_col),
+                                comment=ccomment,
+                                description=ccomment,
+                                text=text,
+                            )
+                        )
+        except ConnectorError:
+            raise
+        except Exception as exc:  # noqa: BLE001 — wrap into the layer exception
+            raise ConnectorError(
+                f"反射数据源 {db!r} 元数据失败（schema={schema_label!r}）: {exc}",
+                cause=exc,
+            ) from exc
+
+        self._post_reflect_safely(resolved, schema_label, table_recs, col_recs)
+        log.info(
+            "universal reflected: db=%s schema=%s tables=%d columns=%d fks=%d",
+            db, schema_label, len(table_recs), len(col_recs), len(fks),
+        )
+        return PhysicalManifest(
+            db_id=db, schema=schema_label,
+            tables=table_recs, columns=col_recs, fks=fks,
+        )
+
+    def _post_reflect_safely(self, schema, schema_label, tables, columns) -> None:
+        """Enrichment-hook failures never break the flow."""
+        try:
+            self._post_reflect(schema, schema_label, tables, columns)
+        except Exception as exc:  # noqa: BLE001
+            log.debug("post_reflect hook failed (skipped): %s", exc)
+
+    # ------------------------------------------------------------------ #
+    # Reflection steps (default implementations; override as needed)
+    # ------------------------------------------------------------------ #
+    def _list_tables(self, insp, schema: Optional[str]) -> list[str]:
+        return [str(t) for t in insp.get_table_names(schema=schema)]
+
+    def _list_views(self, insp, schema: Optional[str]) -> list[str]:
+        try:
+            return [str(v) for v in insp.get_view_names(schema=schema)]
+        except Exception:  # noqa: BLE001 — some dialects cannot reflect views
+            return []
+
+    def _pk_columns(self, insp, table: str, schema: Optional[str]) -> list[str]:
+        try:
+            info = insp.get_pk_constraint(table, schema=schema) or {}
+            return [str(c) for c in (info.get("constrained_columns") or [])]
+        except Exception:  # noqa: BLE001
+            return []
+
+    def _load_fks(self, insp, table: str, schema: Optional[str]) -> list[FKInfo]:
+        out: list[FKInfo] = []
+        try:
+            raw = insp.get_foreign_keys(table, schema=schema) or []
+        except Exception:  # noqa: BLE001
+            return out
+        for fk in raw:
+            ref_schema = fk.get("referred_schema")
+            if ref_schema and schema and str(ref_schema) != str(schema):
+                continue  # cross-schema references stay out (keys are schema-scoped)
+            dst_table = str(fk.get("referred_table") or "")
+            for s, d in zip(
+                fk.get("constrained_columns") or [],
+                fk.get("referred_columns") or [],
+            ):
+                out.append(
+                    FKInfo(
+                        src_table=table,
+                        src_col=str(s),
+                        dst_table=dst_table,
+                        dst_col=str(d),
+                    )
+                )
+        return out
+
+    def _table_comment(self, insp, table: str, schema: Optional[str]) -> str:
+        try:
+            info = insp.get_table_comment(table, schema=schema) or {}
+            return (info.get("text") or "").strip()
+        except Exception:  # noqa: BLE001 — some dialects have no table comments
+            return ""
+
+    def _view_ddl(self, insp, table: str, schema: Optional[str]) -> str:
+        try:
+            body = (insp.get_view_definition(table, schema=schema) or "").strip()
+            return body.rstrip(";") + ";" if body else ""
+        except Exception:  # noqa: BLE001
+            return ""
+
+    @staticmethod
+    def _normalize_type(col: dict[str, Any]) -> str:
+        t = str(col.get("type") or "").strip().lower()
+        return t if t and t != "null" else "text"
+
+    def _synthesize_ddl(
+        self,
+        table: str,
+        schema: Optional[str],
+        cols_raw: Sequence[dict[str, Any]],
+        pk_cols: set[str],
+    ) -> str:
+        """Synthesize CREATE TABLE from column definitions when no DDL exists."""
+        if not cols_raw:
+            return ""
+        quote = self._engine.dialect.identifier_preparer.quote
+        label = self._schema_label(schema)
+        lines = [f"CREATE TABLE {quote(label)}.{quote(table)} ("]
+        for i, c in enumerate(cols_raw):
+            suffix = "," if i < len(cols_raw) - 1 else ""
+            nn = "" if c.get("nullable", True) else " NOT NULL"
+            pk = " PRIMARY KEY" if str(c.get("name")) in pk_cols else ""
+            lines.append(
+                f"  {quote(str(c.get('name')))} {self._normalize_type(c)}{nn}{pk}{suffix}"
+            )
+        lines.append(");")
+        return "\n".join(lines)
+
+    def _table_ddl(
+        self,
+        insp,
+        table: str,
+        schema: Optional[str],
+        cols_raw: Sequence[dict[str, Any]],
+        pk_cols: set[str],
+        *,
+        is_view: bool,
+    ) -> str:
+        if is_view:
+            return self._view_ddl(insp, table, schema)
+        return self._synthesize_ddl(table, schema, cols_raw, pk_cols)
+
+
+__all__ = ["UniversalConnector"]

--- a/packages/qwenpaw-data-context/src/context_manager/secrets/schemas.py
+++ b/packages/qwenpaw-data-context/src/context_manager/secrets/schemas.py
@@ -44,6 +44,9 @@ class BigQueryConnection(BaseModel):
     project_id: str
     location: str = "US"
     service_account_json: SecretStr
+    maximum_bytes_billed: Optional[int] = Field(
+        default=None, ge=1, description="单条查询计费字节上限（费用护栏）"
+    )
 
 
 class SnowflakeConnection(BaseModel):
@@ -82,6 +85,9 @@ class CSVConnection(BaseModel):
 class SqliteConnection(BaseModel):
     type: Literal["sqlite"]
     path: str
+    read_only: bool = Field(
+        default=True, description="只读模式打开（mode=ro，防止误写）"
+    )
 
 
 TypedConnection = Annotated[

--- a/packages/qwenpaw-data-context/tests/test_adapter_framework.py
+++ b/packages/qwenpaw-data-context/tests/test_adapter_framework.py
@@ -1,0 +1,200 @@
+"""SQLite/BigQuery adapters and the UniversalConnector framework."""
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from context_manager.contracts.import_models import SourceConfig
+from context_manager.graph.adapters.base import ConnectorError, ExecResult
+from context_manager.graph.adapters.bigquery_adapter import (
+    BigQueryConnector,
+    _normalize_bq_type,
+    _walk_fields,
+)
+from context_manager.graph.adapters.registry import get_adapter
+from context_manager.graph.adapters.sqlite_adapter import SQLiteConnector
+from context_manager.secrets.schemas import SqliteConnection
+
+
+@pytest.fixture
+def sqlite_db(tmp_path: Path) -> Path:
+    path = tmp_path / "shop.sqlite"
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        """
+        CREATE TABLE orders (
+            id INTEGER PRIMARY KEY,
+            customer_id INTEGER NOT NULL,
+            gmv REAL,
+            ds TEXT,
+            FOREIGN KEY (customer_id) REFERENCES customers(id)
+        );
+        CREATE TABLE customers (id INTEGER PRIMARY KEY, name TEXT);
+        CREATE VIEW big_orders AS SELECT * FROM orders WHERE gmv > 100;
+        INSERT INTO customers VALUES (1, '张三'), (2, '李四');
+        INSERT INTO orders VALUES (1, 1, 250.5, '20260901'), (2, 2, 80.0, '20260901');
+        """
+    )
+    conn.commit()
+    conn.close()
+    return path
+
+
+def _connector(path: Path, **kwargs) -> SQLiteConnector:
+    conn = SqliteConnection(type="sqlite", path=str(path), **kwargs)
+    return SQLiteConnector(conn, db_id="shop")
+
+
+def test_sqlite_test_connection(sqlite_db: Path) -> None:
+    connector = _connector(sqlite_db)
+    result = connector.test_connection()
+    assert result.success
+    assert result.tables_found == 2
+    connector.close()
+
+
+def test_sqlite_missing_file_raises() -> None:
+    with pytest.raises(ConnectorError, match="不存在"):
+        _connector(Path("/nonexistent/nope.sqlite"))
+
+
+def test_sqlite_extract_metadata(sqlite_db: Path) -> None:
+    connector = _connector(sqlite_db)
+    manifest = connector.extract_metadata([])
+
+    assert manifest.db_id == "shop"
+    assert manifest.schema == "main"
+    names = {t.name for t in manifest.tables}
+    assert names == {"orders", "customers", "big_orders"}
+
+    orders = next(t for t in manifest.tables if t.name == "orders")
+    assert orders.key == "tbl:shop.main.orders"
+    assert orders.partition_key == "ds"
+    assert "CREATE TABLE" in orders.ddl
+
+    view = next(t for t in manifest.tables if t.name == "big_orders")
+    assert "SELECT" in view.ddl.upper()
+    assert view.ddl.rstrip().endswith(";")
+
+    id_col = next(
+        c for c in manifest.columns if c.table == "orders" and c.name == "id"
+    )
+    assert id_col.pk is True
+    assert id_col.key == "col:shop.main.orders.id"
+    ds_col = next(
+        c for c in manifest.columns if c.table == "orders" and c.name == "ds"
+    )
+    assert ds_col.is_partition is True
+
+    fk = next(f for f in manifest.fks if f.src_table == "orders")
+    assert (fk.src_col, fk.dst_table, fk.dst_col) == ("customer_id", "customers", "id")
+    connector.close()
+
+
+def test_sqlite_execute_sql_rows_and_truncation(sqlite_db: Path) -> None:
+    connector = _connector(sqlite_db)
+    result = connector.execute_sql("SELECT id, gmv FROM orders ORDER BY id")
+    assert result.error is None
+    assert result.columns == ["id", "gmv"]
+    assert result.rows == [[1, 250.5], [2, 80.0]]
+
+    truncated = connector.execute_sql("SELECT id FROM orders", max_rows=1)
+    assert truncated.truncated is True
+    assert len(truncated.rows) == 1
+
+    failed = connector.execute_sql("SELECT nope FROM missing")
+    assert failed.error is not None
+    connector.close()
+
+
+def test_sqlite_read_only_blocks_writes(sqlite_db: Path) -> None:
+    connector = _connector(sqlite_db)  # read_only defaults True
+    result = connector.execute_sql("DELETE FROM orders")
+    assert result.error is not None
+    # data intact
+    check = connector.execute_sql("SELECT count(*) FROM orders")
+    assert check.rows == [[2]]
+    connector.close()
+
+
+def test_registry_dispatches_sqlite(sqlite_db: Path) -> None:
+    config = SourceConfig.model_validate(
+        {"connection": {"type": "sqlite", "path": str(sqlite_db)}}
+    )
+    adapter = get_adapter(config, "shop")
+    assert isinstance(adapter, SQLiteConnector)
+    assert adapter.test_connection().success
+    adapter.close()
+
+
+def test_bigquery_from_config_rejects_wrong_connection(sqlite_db: Path) -> None:
+    config = SourceConfig.model_validate(
+        {"connection": {"type": "sqlite", "path": str(sqlite_db)}}
+    )
+    with pytest.raises(ConnectorError, match="BigQueryConnection"):
+        BigQueryConnector.from_config(config, "bq")
+
+
+def test_bigquery_missing_dependency_hint() -> None:
+    pytest.importorskip("pydantic")
+    try:
+        import google.cloud.bigquery  # noqa: F401
+
+        pytest.skip("google-cloud-bigquery installed; dependency hint not testable")
+    except ImportError:
+        pass
+    config = SourceConfig.model_validate(
+        {
+            "connection": {
+                "type": "bigquery",
+                "project_id": "proj",
+                "service_account_json": "{}",
+            }
+        }
+    )
+    with pytest.raises(ConnectorError, match="google-cloud-bigquery"):
+        BigQueryConnector.from_config(config, "bq")
+
+
+class _Field:
+    def __init__(self, name, field_type="STRING", mode="NULLABLE", fields=()):
+        self.name = name
+        self.field_type = field_type
+        self.mode = mode
+        self.fields = list(fields)
+        self.description = ""
+
+
+def test_bq_type_normalization_and_record_flattening() -> None:
+    assert _normalize_bq_type(_Field("a", "INTEGER")) == "int64"
+    assert _normalize_bq_type(_Field("a", "FLOAT")) == "float64"
+    assert _normalize_bq_type(_Field("a", "STRING", mode="REPEATED")) == "array<string>"
+
+    nested = _Field(
+        "event_params",
+        "RECORD",
+        fields=[_Field("key"), _Field("value", "RECORD", fields=[_Field("int_value", "INTEGER")])],
+    )
+    names = [name for name, _ in _walk_fields([nested])]
+    assert names == [
+        "event_params",
+        "event_params.key",
+        "event_params.value",
+        "event_params.value.int_value",
+    ]
+
+
+def test_exec_result_to_dict_jsonable() -> None:
+    result = ExecResult(
+        sql="SELECT 1",
+        columns=["d", "n"],
+        rows=[[datetime(2026, 9, 1, 8, 0), Decimal("1.5")]],
+        row_count=1,
+    )
+    dumped = result.to_dict()
+    assert dumped["rows"] == [["2026-09-01T08:00:00", 1.5]]
+    assert "logview_url" not in dumped

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/algo/followup/collector.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/algo/followup/collector.py
@@ -660,7 +660,7 @@ def _clean_name(name: str) -> str:
 def _surface_name(name: str) -> str:
     """Human-facing entity name: drop CM graph-key prefixes when present.
 
-    ``met:postgresql-…:QwenChat:DAU`` and ``met:QwenChat:DAU`` both become
+    ``met:postgresql-…:ShopDemo:DAU`` and ``met:ShopDemo:DAU`` both become
     ``DAU``. Plain display names pass through unchanged.
     """
     cleaned = _clean_name(name)

--- a/packages/qwenpaw-data-host-core/tests/test_followup_collector.py
+++ b/packages/qwenpaw-data-host-core/tests/test_followup_collector.py
@@ -97,17 +97,17 @@ async def test_a_graph_key_is_stripped_to_the_surface_name() -> None:
     entries = [
         *_tool_call(
             "get_metric",
-            {"name": "met:postgresql-70569beb:QwenChat:DAU"},
+            {"name": "met:postgresql-70569beb:ShopDemo:DAU"},
             call_id="c1",
         ),
         *_tool_call(
             "get_dimension",
-            {"name": "dim:postgresql-70569beb:QwenChat:渠道类型"},
+            {"name": "dim:postgresql-70569beb:ShopDemo:渠道类型"},
             call_id="c2",
         ),
         *_tool_call(
             "get_dataset",
-            {"name": "ds:postgresql-70569beb:QwenChat:dau_daily"},
+            {"name": "ds:postgresql-70569beb:ShopDemo:dau_daily"},
             call_id="c3",
         ),
     ]
@@ -130,7 +130,7 @@ async def test_a_graph_key_merges_with_the_surface_name_from_context() -> None:
     context = json.dumps(
         {
             "schema_prompt": (
-                "指标: met:postgresql-70569beb:QwenChat:DAU\n"
+                "指标: met:postgresql-70569beb:ShopDemo:DAU\n"
                 "  可下钻维度: 渠道类型, 页面"
             )
         },
@@ -141,7 +141,7 @@ async def test_a_graph_key_merges_with_the_surface_name_from_context() -> None:
         *_tool_result(context, call_id="c1"),
         *_tool_call(
             "get_metric",
-            {"name": "met:postgresql-70569beb:QwenChat:DAU"},
+            {"name": "met:postgresql-70569beb:ShopDemo:DAU"},
             call_id="c2",
         ),
     ]
@@ -274,7 +274,7 @@ async def test_a_lookup_names_entities_and_only_analysis_marks_them() -> None:
     context = json.dumps(
         {
             "schema_prompt": (
-                "指标: met:holo_test:Bailian:GAAP用户数\n  可下钻维度: 渠道类型, 页面"
+                "指标: met:holo_test:DemoBiz:GAAP用户数\n  可下钻维度: 渠道类型, 页面"
             )
         },
         ensure_ascii=False,
@@ -299,8 +299,8 @@ async def test_a_dimension_is_bound_to_the_metric_it_was_listed_under() -> None:
     context = json.dumps(
         {
             "schema_prompt": (
-                "指标: met:holo_test:Bailian:人均GAAP\n  可下钻维度: 渠道类型\n"
-                "指标: met:holo_test:Bailian:漏斗有效付费用户数\n  可下钻维度: 落地页\n"
+                "指标: met:holo_test:DemoBiz:人均GAAP\n  可下钻维度: 渠道类型\n"
+                "指标: met:holo_test:DemoBiz:漏斗有效付费用户数\n  可下钻维度: 落地页\n"
             )
         },
         ensure_ascii=False,
@@ -322,7 +322,7 @@ def _listed_dimension(name: str, alias: str) -> list[dict[str, Any]]:
         [{"dimension_name": name, "aliases": [alias]}], ensure_ascii=False
     )
     return [
-        *_tool_call("list_dimensions", {"domain": "Bailian"}, call_id="dims"),
+        *_tool_call("list_dimensions", {"domain": "DemoBiz"}, call_id="dims"),
         *_tool_result(body, call_id="dims"),
     ]
 
@@ -401,7 +401,7 @@ async def test_a_dimension_from_a_domain_listing_is_pruned_but_still_real() -> N
     )
     entries = [
         *_tool_call("get_metric", {"name": "人均GAAP"}, call_id="c1"),
-        *_tool_call("list_dimensions", {"domain": "Bailian"}, call_id="c2"),
+        *_tool_call("list_dimensions", {"domain": "DemoBiz"}, call_id="c2"),
         *_tool_result(body, call_id="c2"),
     ]
 
@@ -416,7 +416,7 @@ async def test_the_pruning_budget_is_configurable() -> None:
     context = json.dumps(
         {
             "schema_prompt": (
-                "指标: met:holo_test:Bailian:人均GAAP\n"
+                "指标: met:holo_test:DemoBiz:人均GAAP\n"
                 "  可下钻维度: 渠道类型, 落地页, 地域, 产品"
             )
         },
@@ -540,7 +540,7 @@ async def test_get_priority_metrics_lists_are_domain_dumps() -> None:
         ensure_ascii=False,
     )
     entries = [
-        *_tool_call("get_priority_metrics", {"domain": "QwenChat"}, call_id="c1"),
+        *_tool_call("get_priority_metrics", {"domain": "ShopDemo"}, call_id="c1"),
         *_tool_result(body, call_id="c1"),
     ]
 
@@ -554,7 +554,7 @@ async def test_get_priority_metrics_lists_are_domain_dumps() -> None:
 async def test_get_north_star_metrics_is_the_same_listing() -> None:
     body = json.dumps([{"metric_name": "DAU"}], ensure_ascii=False)
     entries = [
-        *_tool_call("get_north_star_metrics", {"domain": "QwenChat"}, call_id="c1"),
+        *_tool_call("get_north_star_metrics", {"domain": "ShopDemo"}, call_id="c1"),
         *_tool_result(body, call_id="c1"),
     ]
 
@@ -566,7 +566,7 @@ async def test_get_north_star_metrics_is_the_same_listing() -> None:
 async def test_search_context_records_intent_feedback_and_golden_query() -> None:
     context = json.dumps(
         {
-            "schema_prompt": "指标: met:holo_test:Bailian:DAU\n  可下钻维度: 渠道",
+            "schema_prompt": "指标: met:holo_test:DemoBiz:DAU\n  可下钻维度: 渠道",
             "intent_feedback": {
                 "coverage": "insufficient",
                 "gaps": ["无指标命中", "时间不可解析"],

--- a/packages/qwenpaw-data-host-core/tests/test_followup_recommend.py
+++ b/packages/qwenpaw-data-host-core/tests/test_followup_recommend.py
@@ -100,7 +100,7 @@ def _tool_call(
 def _turn() -> list[dict[str, Any]]:
     """A minimal analysis: one metric fetched, one dimension left untouched."""
     context = json.dumps(
-        {"schema_prompt": "指标: met:holo:Bailian:GAAP用户数\n  可下钻维度: 渠道类型, 页面"},
+        {"schema_prompt": "指标: met:holo:DemoBiz:GAAP用户数\n  可下钻维度: 渠道类型, 页面"},
         ensure_ascii=False,
     )
     question = {"content": [{"type": "text", "text": "看下 GAAP用户数"}]}


### PR DESCRIPTION
## Summary
- introduce a common connector contract for datasource discovery, schema inspection, and query execution
- add registry-based connector resolution and normalized connection configuration
- provide SQLite and BigQuery adapters behind the same interface
- extend datasource secret schemas for the new connector types

## Stack
- stacked on #43
- retarget this PR to `main` after the preceding PRs merge

## Test plan
- [x] Run connector contract and adapter tests
- [x] Verify SQLite schema discovery and query execution
- [x] Verify BigQuery configuration and adapter behavior with isolated clients
- [x] Run the full repository test suite as part of the completed stack (`762 passed`)