### PR TITLE
feat(host-core): materialize SQL results as session artifacts

### DIFF
--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/agent/middleware/__init__.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/agent/middleware/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from qwenpaw_data.host.core.agent.middleware.sql_artifact import SqlArtifactMiddleware
 from qwenpaw_data.host.core.agent.middleware.steer import SteerMiddleware
 
-__all__ = ["SteerMiddleware"]
+__all__ = ["SqlArtifactMiddleware", "SteerMiddleware"]

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/agent/middleware/sql_artifact.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/agent/middleware/sql_artifact.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+"""Materialize execute_sql CSV into the session artifact directory."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, AsyncGenerator, Callable
+
+from agentscope.middleware import MiddlewareBase
+from agentscope.tool import ToolResponse
+
+from qwenpaw_data.host.core.cm_sql_artifact import (
+    is_execute_sql_tool,
+    materialize_execute_sql_result,
+)
+
+if TYPE_CHECKING:
+    from agentscope.agent import Agent
+
+
+class SqlArtifactMiddleware(MiddlewareBase):
+    """Copy CM execute_sql CSV into artifact_dir before the result hits context."""
+
+    def __init__(self, *, artifact_dir: Path) -> None:
+        self._artifact_dir = artifact_dir
+
+    async def on_acting(  # type: ignore[override]
+        self,
+        agent: Agent,
+        input_kwargs: dict,
+        next_handler: Callable[..., AsyncGenerator],
+    ) -> AsyncGenerator[Any, None]:
+        name = getattr(input_kwargs["tool_call"], "name", "")
+        prefixes = agent._cm_mcp_tool_prefixes
+        token = getattr(agent, "_request_context", {}).get("access_token")
+        async for chunk in next_handler(**input_kwargs):
+            yield await self._rewrite(name, chunk, prefixes, token)
+
+    async def _rewrite(
+        self,
+        name: str,
+        chunk: Any,
+        prefixes: set[str],
+        token: str | None,
+    ) -> Any:
+        if not isinstance(chunk, ToolResponse) or not is_execute_sql_tool(
+            name, prefixes
+        ):
+            return chunk
+        if not chunk.content:
+            return chunk
+        first = chunk.content[0]
+        text = getattr(first, "text", None)
+        if not isinstance(text, str):
+            return chunk
+        rewritten = await materialize_execute_sql_result(
+            text,
+            artifact_dir=self._artifact_dir,
+            access_token=token,
+        )
+        if rewritten != text:
+            first.text = rewritten
+        return chunk

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/cm_sql_artifact.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/cm_sql_artifact.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+"""Copy CM execute_sql CSV into the current session artifact directory."""
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+from typing import Iterable
+from urllib.parse import urlparse
+
+import httpx
+
+from qwenpaw_data.host.core.cm_client import (
+    API_TOKEN_ENV,
+    CLIENT_API_TOKEN_ENV,
+    _trust_env_for_url,
+    resolve_cm_base_url,
+)
+from qwenpaw_data.host.core.mcp_cm import is_cm_mcp_tool_name
+
+_DOWNLOAD_PATH_RE = re.compile(r"/api/v1/cm/downloads/([A-Za-z0-9_-]+)\.csv$")
+
+
+class SqlArtifactError(RuntimeError):
+    """Raised when Host cannot materialize an execute_sql CSV."""
+
+
+def is_execute_sql_tool(tool_name: str, prefixes: Iterable[str]) -> bool:
+    return (
+        bool(tool_name)
+        and is_cm_mcp_tool_name(tool_name, prefixes)
+        and tool_name.rsplit("__", 1)[-1] == "execute_sql"
+    )
+
+
+def _resolve_token(access_token: str | None) -> str:
+    if access_token is not None:
+        return access_token.strip()
+    return (
+        (os.environ.get(CLIENT_API_TOKEN_ENV) or "").strip()
+        or (os.environ.get(API_TOKEN_ENV) or "").strip()
+    )
+
+
+def _download_id(download_url: str) -> str:
+    match = _DOWNLOAD_PATH_RE.fullmatch(urlparse(download_url).path)
+    if match is None:
+        raise SqlArtifactError(
+            f"execute_sql download_url is not a CM CSV download: {download_url}"
+        )
+    return match.group(1)
+
+
+async def materialize_execute_sql_result(
+    result_text: str,
+    *,
+    artifact_dir: Path | str,
+    access_token: str | None = None,
+    transport: httpx.BaseTransport | None = None,
+) -> str:
+    try:
+        payload = json.loads(result_text)
+    except json.JSONDecodeError:
+        return result_text
+    download_url = payload.get("download_url") if isinstance(payload, dict) else None
+    if not isinstance(download_url, str) or not download_url.strip():
+        return result_text
+
+    token = _resolve_token(access_token)
+    download_id = _download_id(download_url.strip())
+    dest = Path(artifact_dir) / "data" / "raw" / f"{download_id}.csv"
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    url = f"{resolve_cm_base_url()}/api/v1/cm/downloads/{download_id}.csv"
+    headers = {"Authorization": f"Bearer {token}"} if token else {}
+    async with httpx.AsyncClient(
+        timeout=60.0,
+        transport=transport,
+        trust_env=_trust_env_for_url(url),
+    ) as client:
+        try:
+            response = await client.get(url, headers=headers)
+        except httpx.HTTPError as exc:
+            raise SqlArtifactError(f"execute_sql CSV fetch failed: {exc}") from exc
+    if response.status_code >= 400:
+        raise SqlArtifactError(
+            f"execute_sql CSV fetch returned HTTP {response.status_code}"
+        )
+    dest.write_bytes(response.content)
+    payload["file_path"] = str(dest.resolve())
+    del payload["download_url"]
+    return json.dumps(payload, ensure_ascii=False)

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/core.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/core.py
@@ -13,6 +13,7 @@ from agentscope.permission import PermissionMode
 from agentscope.state import AgentState
 
 from .agent import QwenPawDataAgent
+from .agent.middleware.sql_artifact import SqlArtifactMiddleware
 from .agent.toolkit import build_qwenpaw_data_toolkit
 from .model import build_model_from_env
 from .orchestration.dag_store import DAGStore
@@ -235,7 +236,10 @@ class QwenPawDataHost:
             session_id=self.session_id,
             session_trace_writer=append_session_trace,
             confirmation_handler=self.confirmation_handler,
-            middlewares=list(self.extra_middlewares) or None,
+            middlewares=[
+                SqlArtifactMiddleware(artifact_dir=paths.artifact_dir),
+                *self.extra_middlewares,
+            ],
         )
         agent_ref["agent"] = agent
         rs.configure_dag_store(

--- a/packages/qwenpaw-data-host-core/tests/test_sql_artifact.py
+++ b/packages/qwenpaw-data-host-core/tests/test_sql_artifact.py
@@ -1,0 +1,249 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import httpx
+import pytest
+from agentscope.message import TextBlock
+from agentscope.tool import ToolResponse
+
+from qwenpaw_data.host.core.agent.middleware import sql_artifact as mw_mod
+from qwenpaw_data.host.core.agent.middleware.sql_artifact import SqlArtifactMiddleware
+from qwenpaw_data.host.core.cm_sql_artifact import (
+    SqlArtifactError,
+    is_execute_sql_tool,
+    materialize_execute_sql_result,
+)
+
+
+def _sql_result(*, download_url: str | None) -> str:
+    payload: dict = {
+        "exec_status": "success",
+        "sql": "select 1",
+        "rows": [[1]],
+        "preview_row_count": 1,
+        "truncated": False,
+        "total_row_count": 1,
+    }
+    if download_url is not None:
+        payload["download_url"] = download_url
+    return json.dumps(payload)
+
+
+def _handler(
+    captured: list[httpx.Request],
+    *,
+    status: int = 200,
+    body: bytes = b"day,dau\n",
+):
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(status, content=body)
+
+    return handler
+
+
+@pytest.mark.asyncio
+async def test_materialize_writes_csv_and_rewrites_to_file_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("QWENPAW_DATA_CM_BASE_URL", "http://cm.test")
+    captured: list[httpx.Request] = []
+    artifact_dir = tmp_path / "artifacts" / "ses_1"
+
+    rewritten = await materialize_execute_sql_result(
+        _sql_result(download_url="/api/v1/cm/downloads/54814f8b.csv"),
+        artifact_dir=artifact_dir,
+        access_token="tok-user",
+        transport=httpx.MockTransport(_handler(captured)),
+    )
+
+    payload = json.loads(rewritten)
+    dest = artifact_dir / "data" / "raw" / "54814f8b.csv"
+    assert dest.read_bytes() == b"day,dau\n"
+    assert payload["file_path"] == str(dest.resolve())
+    assert "download_url" not in payload
+    assert payload["rows"] == [[1]]
+    assert len(captured) == 1
+    assert str(captured[0].url) == "http://cm.test/api/v1/cm/downloads/54814f8b.csv"
+    assert captured[0].headers["authorization"] == "Bearer tok-user"
+
+
+@pytest.mark.asyncio
+async def test_materialize_uses_env_token_when_no_access_token(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("QWENPAW_DATA_CM_BASE_URL", "http://cm.test")
+    monkeypatch.setenv("QWENPAW_DATA_CLIENT_API_TOKEN", "tok-env")
+    captured: list[httpx.Request] = []
+
+    await materialize_execute_sql_result(
+        _sql_result(download_url="/api/v1/cm/downloads/54814f8b.csv"),
+        artifact_dir=tmp_path,
+        transport=httpx.MockTransport(_handler(captured)),
+    )
+
+    assert captured[0].headers["authorization"] == "Bearer tok-env"
+
+
+@pytest.mark.asyncio
+async def test_materialize_omits_auth_header_without_any_token(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("QWENPAW_DATA_CM_BASE_URL", "http://cm.test")
+    monkeypatch.delenv("QWENPAW_DATA_CLIENT_API_TOKEN", raising=False)
+    monkeypatch.delenv("QWENPAW_DATA_API_TOKEN", raising=False)
+    captured: list[httpx.Request] = []
+
+    await materialize_execute_sql_result(
+        _sql_result(download_url="/api/v1/cm/downloads/54814f8b.csv"),
+        artifact_dir=tmp_path,
+        transport=httpx.MockTransport(_handler(captured)),
+    )
+
+    assert "authorization" not in captured[0].headers
+
+
+@pytest.mark.asyncio
+async def test_materialize_skips_when_no_download_url(tmp_path: Path) -> None:
+    original = _sql_result(download_url=None)
+    rewritten = await materialize_execute_sql_result(
+        original,
+        artifact_dir=tmp_path,
+        access_token="tok-user",
+    )
+    assert rewritten == original
+
+
+@pytest.mark.asyncio
+async def test_materialize_skips_non_json_text(tmp_path: Path) -> None:
+    rewritten = await materialize_execute_sql_result(
+        "not json",
+        artifact_dir=tmp_path,
+    )
+    assert rewritten == "not json"
+
+
+@pytest.mark.asyncio
+async def test_materialize_rejects_foreign_download_url(tmp_path: Path) -> None:
+    with pytest.raises(SqlArtifactError, match="not a CM CSV download"):
+        await materialize_execute_sql_result(
+            _sql_result(download_url="http://evil.test/steal.csv"),
+            artifact_dir=tmp_path,
+            access_token="tok-user",
+        )
+
+
+@pytest.mark.asyncio
+async def test_materialize_fails_on_http_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("QWENPAW_DATA_CM_BASE_URL", "http://cm.test")
+    with pytest.raises(SqlArtifactError, match="HTTP 401"):
+        await materialize_execute_sql_result(
+            _sql_result(
+                download_url="http://127.0.0.1:8080/api/v1/cm/downloads/54814f8b.csv",
+            ),
+            artifact_dir=tmp_path,
+            access_token="tok-user",
+            transport=httpx.MockTransport(_handler([], status=401, body=b"no")),
+        )
+
+
+def test_is_execute_sql_tool_requires_cm_prefix() -> None:
+    prefixes = {"mcp__context-manager__"}
+    assert is_execute_sql_tool("mcp__context-manager__execute_sql", prefixes)
+    assert not is_execute_sql_tool("mcp__other__execute_sql", prefixes)
+    assert not is_execute_sql_tool("mcp__context-manager__search_context", prefixes)
+    assert not is_execute_sql_tool("", prefixes)
+
+
+def _agent() -> SimpleNamespace:
+    return SimpleNamespace(
+        _request_context={"access_token": "tok-user"},
+        _cm_mcp_tool_prefixes={"mcp__context-manager__"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_middleware_skips_non_sql_tools(tmp_path: Path) -> None:
+    response = ToolResponse(
+        content=[TextBlock(type="text", text='{"download_url":"x"}')],
+    )
+
+    async def next_handler(**_kwargs):
+        yield response
+
+    middleware = SqlArtifactMiddleware(artifact_dir=tmp_path)
+    items = [
+        item
+        async for item in middleware.on_acting(
+            _agent(),  # type: ignore[arg-type]
+            {
+                "tool_call": SimpleNamespace(
+                    name="mcp__context-manager__search_context",
+                ),
+            },
+            next_handler,
+        )
+    ]
+    assert items[0] is response
+    assert response.content[0].text == '{"download_url":"x"}'
+
+
+@pytest.mark.asyncio
+async def test_middleware_rewrites_execute_sql_tool_response(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("QWENPAW_DATA_CM_BASE_URL", "http://cm.test")
+    captured: list[httpx.Request] = []
+
+    async def _materialize(result_text: str, **kwargs):
+        return await materialize_execute_sql_result(
+            result_text,
+            **kwargs,
+            transport=httpx.MockTransport(_handler(captured)),
+        )
+
+    monkeypatch.setattr(mw_mod, "materialize_execute_sql_result", _materialize)
+
+    response = ToolResponse(
+        content=[
+            TextBlock(
+                type="text",
+                text=_sql_result(download_url="/api/v1/cm/downloads/54814f8b.csv"),
+            ),
+        ],
+    )
+
+    async def next_handler(**_kwargs):
+        yield response
+
+    middleware = SqlArtifactMiddleware(artifact_dir=tmp_path)
+    items = [
+        item
+        async for item in middleware.on_acting(
+            _agent(),  # type: ignore[arg-type]
+            {
+                "tool_call": SimpleNamespace(
+                    name="mcp__context-manager__execute_sql",
+                ),
+            },
+            next_handler,
+        )
+    ]
+
+    payload = json.loads(items[0].content[0].text)
+    dest = tmp_path / "data" / "raw" / "54814f8b.csv"
+    assert dest.read_bytes() == b"day,dau\n"
+    assert payload["file_path"] == str(dest.resolve())
+    assert "download_url" not in payload
+    assert captured[0].headers["authorization"] == "Bearer tok-user"

--- a/uv.lock
+++ b/uv.lock
@@ -1012,6 +1012,119 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b3/0d/bf0567477f7281d9a3926c582bfef21bff7498fc0ffd3e9de21811896a0b/func_timeout-4.3.5.tar.gz", hash = "sha256:74cd3c428ec94f4edfba81f9b2f14904846d5ffccc27c92433b8b5939b5575dd", size = 44264, upload-time = "2019-08-19T21:32:07.43Z" }
 
 [[package]]
+name = "google-api-core"
+version = "2.34.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "googleapis-common-protos" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7b/7c/9be3903e3d45415e8ca493c75f8990a0f6f579d168015d44c379350d0ab0/google_api_core-2.34.0.tar.gz", hash = "sha256:98a779fe72de956eb1c9c2f47ff4c4432a668ece1a002ec38bed07ec2698ae59", size = 187953, upload-time = "2026-08-06T06:23:58.128Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/c1/a8a92ae1bc4b1a8f804c776d7d3f0c771b78a62c3ad4df1be41b3fd8c767/google_api_core-2.34.0-py3-none-any.whl", hash = "sha256:cdf9c67e7ca2402d86ccbfde5f2503fc83e3cc3f58cc78456ae96cad24a6d2de", size = 180545, upload-time = "2026-08-06T06:22:47.502Z" },
+]
+
+[package.optional-dependencies]
+grpc = [
+    { name = "grpcio" },
+    { name = "grpcio-status" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.57.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/41/64/55f316b729f92a552d26e00aa3b1542b2e149d0a5efe2842afff0cac7af7/google_auth-2.57.0.tar.gz", hash = "sha256:9b4f96d6a1feb5f7201231f47cfb3de08d8f176f8a61f9e461555116e95a8789", size = 370794, upload-time = "2026-08-25T19:18:26.419Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/f3/8508a702c094af5f6e89773f4dfdeee74913df0f41a02c21b5e7dc3d75cd/google_auth-2.57.0-py3-none-any.whl", hash = "sha256:180dafe015cfb62193bea26b677500fab5b9fd51a1e825ebf3ad9b182047ae59", size = 259728, upload-time = "2026-08-24T21:55:08.449Z" },
+]
+
+[package.optional-dependencies]
+pyopenssl = [
+    { name = "cryptography" },
+]
+
+[[package]]
+name = "google-cloud-bigquery"
+version = "3.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core", extra = ["grpc"] },
+    { name = "google-auth", extra = ["pyopenssl"] },
+    { name = "google-cloud-core" },
+    { name = "google-resumable-media" },
+    { name = "packaging" },
+    { name = "python-dateutil" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2f/fb/86d5bfdfbd9d810f6a49eb3e9cc591a2b46d33262338acc244cc79d032c1/google_cloud_bigquery-3.44.0.tar.gz", hash = "sha256:30651ae469b419f450b9c96581fd4942e2e060490df1ac0314bf379f16883215", size = 527575, upload-time = "2026-08-25T19:18:36.317Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/84/af193ca97ce72b56fd05f8ad15776bf7446d99cb0ba1cd2f4880dbc52543/google_cloud_bigquery-3.44.0-py3-none-any.whl", hash = "sha256:ac2f0a6ab61a3c742ba4674dc220fb98461c13e1def96fe7a980ef7d5e0c0285", size = 267691, upload-time = "2026-08-24T21:55:19.249Z" },
+]
+
+[[package]]
+name = "google-cloud-core"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f9/54/790548b190cff9cf07225c811d2668eacd8f2cbf04114475cbe3e5738752/google_cloud_core-2.7.0.tar.gz", hash = "sha256:874aaf89765db87a9b911b7a2ca7c5068554868eed9e75c7766affe342a2913d", size = 36603, upload-time = "2026-08-25T19:18:43.076Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/64/904dbc9bee128e7b87eeb60da67c8fa4d1a8acdc9a45dd2fedca67ef184d/google_cloud_core-2.7.0-py3-none-any.whl", hash = "sha256:c18a250904cfdda021eb3ae8b8238c9f9ca272a4cbbfb5cba946b3fe3022eed1", size = 31046, upload-time = "2026-08-24T21:55:28.36Z" },
+]
+
+[[package]]
+name = "google-crc32c"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/41/4b9c02f99e4c5fb477122cd5437403b552873f014616ac1d19ac8221a58d/google_crc32c-1.8.0.tar.gz", hash = "sha256:a428e25fb7691024de47fecfbff7ff957214da51eddded0da0ae0e0f03a2cf79", size = 14192, upload-time = "2025-12-16T00:35:25.142Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/ef/21ccfaab3d5078d41efe8612e0ed0bfc9ce22475de074162a91a25f7980d/google_crc32c-1.8.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:014a7e68d623e9a4222d663931febc3033c5c7c9730785727de2a81f87d5bab8", size = 31298, upload-time = "2025-12-16T00:20:32.241Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b8/f8413d3f4b676136e965e764ceedec904fe38ae8de0cdc52a12d8eb1096e/google_crc32c-1.8.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:86cfc00fe45a0ac7359e5214a1704e51a99e757d0272554874f419f79838c5f7", size = 30872, upload-time = "2025-12-16T00:33:58.785Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/fd/33aa4ec62b290477181c55bb1c9302c9698c58c0ce9a6ab4874abc8b0d60/google_crc32c-1.8.0-cp311-cp311-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:19b40d637a54cb71e0829179f6cb41835f0fbd9e8eb60552152a8b52c36cbe15", size = 33243, upload-time = "2025-12-16T00:40:21.46Z" },
+    { url = "https://files.pythonhosted.org/packages/71/03/4820b3bd99c9653d1a5210cb32f9ba4da9681619b4d35b6a052432df4773/google_crc32c-1.8.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:17446feb05abddc187e5441a45971b8394ea4c1b6efd88ab0af393fd9e0a156a", size = 33608, upload-time = "2025-12-16T00:40:22.204Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/43/acf61476a11437bf9733fb2f70599b1ced11ec7ed9ea760fdd9a77d0c619/google_crc32c-1.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:71734788a88f551fbd6a97be9668a0020698e07b2bf5b3aa26a36c10cdfb27b2", size = 34439, upload-time = "2025-12-16T00:35:20.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/5f/7307325b1198b59324c0fa9807cafb551afb65e831699f2ce211ad5c8240/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:4b8286b659c1335172e39563ab0a768b8015e88e08329fa5321f774275fc3113", size = 31300, upload-time = "2025-12-16T00:21:56.723Z" },
+    { url = "https://files.pythonhosted.org/packages/21/8e/58c0d5d86e2220e6a37befe7e6a94dd2f6006044b1a33edf1ff6d9f7e319/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:2a3dc3318507de089c5384cc74d54318401410f82aa65b2d9cdde9d297aca7cb", size = 30867, upload-time = "2025-12-16T00:38:31.302Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/a9/a780cc66f86335a6019f557a8aaca8fbb970728f0efd2430d15ff1beae0e/google_crc32c-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:14f87e04d613dfa218d6135e81b78272c3b904e2a7053b841481b38a7d901411", size = 33364, upload-time = "2025-12-16T00:40:22.96Z" },
+    { url = "https://files.pythonhosted.org/packages/21/3f/3457ea803db0198c9aaca2dd373750972ce28a26f00544b6b85088811939/google_crc32c-1.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb5c869c2923d56cb0c8e6bcdd73c009c36ae39b652dbe46a05eb4ef0ad01454", size = 33740, upload-time = "2025-12-16T00:40:23.96Z" },
+    { url = "https://files.pythonhosted.org/packages/df/c0/87c2073e0c72515bb8733d4eef7b21548e8d189f094b5dad20b0ecaf64f6/google_crc32c-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:3cc0c8912038065eafa603b238abf252e204accab2a704c63b9e14837a854962", size = 34437, upload-time = "2025-12-16T00:35:21.395Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/db/000f15b41724589b0e7bc24bc7a8967898d8d3bc8caf64c513d91ef1f6c0/google_crc32c-1.8.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:3ebb04528e83b2634857f43f9bb8ef5b2bbe7f10f140daeb01b58f972d04736b", size = 31297, upload-time = "2025-12-16T00:23:20.709Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/0d/8ebed0c39c53a7e838e2a486da8abb0e52de135f1b376ae2f0b160eb4c1a/google_crc32c-1.8.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:450dc98429d3e33ed2926fc99ee81001928d63460f8538f21a5d6060912a8e27", size = 30867, upload-time = "2025-12-16T00:43:14.628Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/42/b468aec74a0354b34c8cbf748db20d6e350a68a2b0912e128cabee49806c/google_crc32c-1.8.0-cp313-cp313-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3b9776774b24ba76831609ffbabce8cdf6fa2bd5e9df37b594221c7e333a81fa", size = 33344, upload-time = "2025-12-16T00:40:24.742Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/e8/b33784d6fc77fb5062a8a7854e43e1e618b87d5ddf610a88025e4de6226e/google_crc32c-1.8.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:89c17d53d75562edfff86679244830599ee0a48efc216200691de8b02ab6b2b8", size = 33694, upload-time = "2025-12-16T00:40:25.505Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b1/d3cbd4d988afb3d8e4db94ca953df429ed6db7282ed0e700d25e6c7bfc8d/google_crc32c-1.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:57a50a9035b75643996fbf224d6661e386c7162d1dfdab9bc4ca790947d1007f", size = 34435, upload-time = "2025-12-16T00:35:22.107Z" },
+    { url = "https://files.pythonhosted.org/packages/21/88/8ecf3c2b864a490b9e7010c84fd203ec8cf3b280651106a3a74dd1b0ca72/google_crc32c-1.8.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:e6584b12cb06796d285d09e33f63309a09368b9d806a551d8036a4207ea43697", size = 31301, upload-time = "2025-12-16T00:24:48.527Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c6/f7ff6c11f5ca215d9f43d3629163727a272eabc356e5c9b2853df2bfe965/google_crc32c-1.8.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:f4b51844ef67d6cf2e9425983274da75f18b1597bb2c998e1c0a0e8d46f8f651", size = 30868, upload-time = "2025-12-16T00:48:12.163Z" },
+    { url = "https://files.pythonhosted.org/packages/56/15/c25671c7aad70f8179d858c55a6ae8404902abe0cdcf32a29d581792b491/google_crc32c-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b0d1a7afc6e8e4635564ba8aa5c0548e3173e41b6384d7711a9123165f582de2", size = 33381, upload-time = "2025-12-16T00:40:26.268Z" },
+    { url = "https://files.pythonhosted.org/packages/42/fa/f50f51260d7b0ef5d4898af122d8a7ec5a84e2984f676f746445f783705f/google_crc32c-1.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8b3f68782f3cbd1bce027e48768293072813469af6a61a86f6bb4977a4380f21", size = 33734, upload-time = "2025-12-16T00:40:27.028Z" },
+    { url = "https://files.pythonhosted.org/packages/08/a5/7b059810934a09fb3ccb657e0843813c1fee1183d3bc2c8041800374aa2c/google_crc32c-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:d511b3153e7011a27ab6ee6bb3a5404a55b994dc1a7322c0b87b29606d9790e2", size = 34878, upload-time = "2025-12-16T00:35:23.142Z" },
+    { url = "https://files.pythonhosted.org/packages/52/c5/c171e4d8c44fec1422d801a6d2e5d7ddabd733eeda505c79730ee9607f07/google_crc32c-1.8.0-pp311-pypy311_pp73-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:87fa445064e7db928226b2e6f0d5304ab4cd0339e664a4e9a25029f384d9bb93", size = 28615, upload-time = "2025-12-16T00:40:29.298Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/97/7d75fe37a7a6ed171a2cf17117177e7aab7e6e0d115858741b41e9dd4254/google_crc32c-1.8.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f639065ea2042d5c034bf258a9f085eaa7af0cd250667c0635a3118e8f92c69c", size = 28800, upload-time = "2025-12-16T00:40:30.322Z" },
+]
+
+[[package]]
+name = "google-resumable-media"
+version = "2.10.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-crc32c" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/17/4b/44e128cd7b0e72cd26da4a3052cd8a9ef1b5a890be7c611558067ea0b354/google_resumable_media-2.10.2.tar.gz", hash = "sha256:1de441703cd298d75a419bfdc0066e9fc7b0a1de630df96eea8ce8f5c759358c", size = 2164918, upload-time = "2026-08-25T19:19:11.814Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/30/3e976681b5319715ab022363f58f6f8e10f546a1777756fe3ebd918857e4/google_resumable_media-2.10.2-py3-none-any.whl", hash = "sha256:e3cedc827a4ea41e216582d74346f1fb9fceb625a8c3c53912f2ca1d663334d7", size = 81531, upload-time = "2026-08-25T19:18:07.193Z" },
+]
+
+[[package]]
 name = "googleapis-common-protos"
 version = "1.75.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1149,6 +1262,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/df/c6717fef716e00d235ffb96123baf6dce76d6004f6233fa767c502861460/grpcio-1.81.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b427c19380991a4eaab2f6144b64b99b412043314c6bf4ab544f97bb31ee4190", size = 7846681, upload-time = "2026-06-11T12:46:43.013Z" },
     { url = "https://files.pythonhosted.org/packages/36/84/3502e9f210a6a5c4438c8aca3f88edd2e04f6a27f3d41b26cf0a0024b096/grpcio-1.81.1-cp314-cp314-win32.whl", hash = "sha256:61233fe8951e5c85dff81c2458b6528624760166946b5b47ea150a589168411f", size = 4264615, upload-time = "2026-06-11T12:46:45.741Z" },
     { url = "https://files.pythonhosted.org/packages/ff/b0/4af731ff7492c68a96e4c71bfd0f4590acde92b31c6fe4894e6465c10ff6/grpcio-1.81.1-cp314-cp314-win_amd64.whl", hash = "sha256:3768a5ff1b2125e6f552e561b6b2dca0e64982d8949689b4df145cf8b98d7821", size = 5070275, upload-time = "2026-06-11T12:46:48.486Z" },
+]
+
+[[package]]
+name = "grpcio-status"
+version = "1.81.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/32/26/0aa9168c87882381fd810d140c279a2490ed6aee655f0515d6f56c5ca404/grpcio_status-1.81.1.tar.gz", hash = "sha256:9389a03e746017b10f0630c064289201458f3ce01f5d7ef4b0bebc1ef6cf82ad", size = 13923, upload-time = "2026-06-11T12:58:48.636Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/5e/5abfec5f7e89d3b7993d57cfb025ca5f968a2c18656d7fcda2b6919440b9/grpcio_status-1.81.1-py3-none-any.whl", hash = "sha256:08072fa9995f4a95c647fc6f4f85e2411573d00087bcabdf30f260114338f232", size = 14638, upload-time = "2026-06-11T12:58:31.982Z" },
 ]
 
 [[package]]
@@ -2398,6 +2525,18 @@ wheels = [
 ]
 
 [[package]]
+name = "proto-plus"
+version = "1.28.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/a6/4fbadcc2044034449b3f8f0ce82dcf3005d53f37c136642103fd4836a31c/proto_plus-1.28.4.tar.gz", hash = "sha256:5ff7ecad828e032a491fcb86947801768e32237f99dd049b649965b892ae9a63", size = 58679, upload-time = "2026-08-25T19:19:15.102Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/5d/0f04b85dafdc3250ced7f2592efc17dce7f40712e941e9632202481e600d/proto_plus-1.28.4-py3-none-any.whl", hash = "sha256:4b01341272f8a348db3f003b6143109f83ab43091019d5181b3fcdf500ab32aa", size = 50797, upload-time = "2026-08-25T19:18:12.338Z" },
+]
+
+[[package]]
 name = "protobuf"
 version = "6.33.6"
 source = { registry = "https://pypi.org/simple" }
@@ -2529,6 +2668,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/49/942c3b79878ba928324d1e17c274ed84581db8c0a749b24bcf4cbdf15bd3/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d8ddd2768da81d3ee08cfea9b597f4abb4e8e1dc8ae7e204b608d23a0d3ab699", size = 49471890, upload-time = "2026-04-21T10:51:02.439Z" },
     { url = "https://files.pythonhosted.org/packages/76/97/ff71431000a75d84135a1ace5ca4ba11726a231a8007bbb320a4c54075d5/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:61a3d7eaa97a14768b542f3d284dc6400dd2470d9f080708b13cd46b6ae18136", size = 51932250, upload-time = "2026-04-21T10:51:10.576Z" },
     { url = "https://files.pythonhosted.org/packages/51/be/6f79d55816d5c22557cf27533543d5d70dfe692adfbee4b99f2760674f38/pyarrow-24.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:c91d00057f23b8d353039520dc3a6c09d8608164c692e9f59a175a42b2ae0c19", size = 28131282, upload-time = "2026-04-21T10:51:16.815Z" },
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
 ]
 
 [[package]]
@@ -3060,10 +3220,16 @@ dependencies = [
     { name = "python-multipart" },
     { name = "pyyaml" },
     { name = "requests" },
+    { name = "sqlalchemy" },
     { name = "sqlglot" },
     { name = "sse-starlette" },
     { name = "tqdm" },
     { name = "uvicorn", extra = ["standard"] },
+]
+
+[package.optional-dependencies]
+bigquery = [
+    { name = "google-cloud-bigquery" },
 ]
 
 [package.metadata]
@@ -3077,6 +3243,7 @@ requires-dist = [
     { name = "duckdb", specifier = ">=1.5,<2.0" },
     { name = "fastapi", specifier = ">=0.141.1,<1.0" },
     { name = "func-timeout", specifier = ">=4.3,<5.0" },
+    { name = "google-cloud-bigquery", marker = "extra == 'bigquery'", specifier = ">=3.25,<4.0" },
     { name = "httpx", specifier = ">=0.28,<0.29" },
     { name = "jaydebeapi", specifier = ">=1.2,<2.0" },
     { name = "jsonschema", specifier = ">=4.26,<5.0" },
@@ -3095,11 +3262,13 @@ requires-dist = [
     { name = "python-multipart", specifier = ">=0.0.32,<1.0" },
     { name = "pyyaml", specifier = ">=6.0,<7.0" },
     { name = "requests", specifier = ">=2.34.2,<3.0" },
+    { name = "sqlalchemy", specifier = ">=2.0,<3.0" },
     { name = "sqlglot", specifier = ">=30.0,<31.0" },
     { name = "sse-starlette", specifier = ">=3.4,<4.0" },
     { name = "tqdm", specifier = ">=4.68,<5.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.52.1,<1.0" },
 ]
+provides-extras = ["bigquery"]
 
 [[package]]
 name = "qwenpaw-data-host-core"


### PR DESCRIPTION
## Summary
- intercept successful Context Management `execute_sql` tool responses
- download generated CSV results into the session artifact directory
- replace transient download URLs with stable workspace-relative file paths
- resolve service authentication consistently from explicit and environment-provided tokens

## Stack
- stacked on #44
- retarget this PR to `main` after the preceding PRs merge

## Test plan
- [x] Run SQL artifact middleware and download validation tests
- [x] Verify unrelated tools and unsuccessful responses remain unchanged
- [x] Run the full repository test suite as part of the completed stack (`762 passed`)