### PR TITLE
feat(host-core): add BizTrace session analysis pipeline

### DIFF
--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/algo/biztrace/__init__.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/algo/biztrace/__init__.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+from qwenpaw_data.host.core.algo.biztrace.models import BizEvent, FrontendEvent, Segment
+from qwenpaw_data.host.core.algo.biztrace.pipeline import BizTracePipeline, build_pipeline
+from qwenpaw_data.host.core.algo.biztrace.settings import BizTraceSettings
+from qwenpaw_data.host.core.algo.biztrace.transformer import BizTraceTransformer
+
+__all__ = [
+    "BizEvent",
+    "BizTracePipeline",
+    "BizTraceSettings",
+    "BizTraceTransformer",
+    "FrontendEvent",
+    "Segment",
+    "build_pipeline",
+]

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/algo/biztrace/converter.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/algo/biztrace/converter.py
@@ -1,0 +1,900 @@
+# -*- coding: utf-8 -*-
+"""RawTrace to BizTrace conversion.
+
+The converter is a push state machine fed by ``enqueue``: raw AgentScope events
+land in a bounded queue, a worker folds them into business events, and each
+event is written once, as soon as it completes. A tool call and its result stay
+two separate write-once cards, linked by their tool call id.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from datetime import datetime
+from time import time
+from typing import Any
+
+from qwenpaw_data.host.core.algo.biztrace.models import (
+    BizEvent,
+    BizEventKind,
+    OrchestrationCategory,
+    OrchestrationInfo,
+    Presentation,
+    SubtaskState,
+)
+from qwenpaw_data.host.core.algo.biztrace.presentation import CAPTIONS, PresentationBuilder
+from qwenpaw_data.host.core.algo.biztrace.settings import CONVERTER_QUEUE_SIZE
+from qwenpaw_data.host.core.algo.biztrace.tools import canonical_tool_name
+
+logger = logging.getLogger(__name__)
+
+ORCHESTRATION_CATEGORIES: dict[str, OrchestrationCategory] = {
+    "PlanCreate": "PlanCreate",
+    "PlanUpdate": "PlanUpdate",
+    "TaskStateUpdate": "TaskStateUpdate",
+}
+# Exact TaskStateUpdate.state values from the host plan tools.
+VALID_SUBTASK_STATES: frozenset[str] = frozenset(
+    {"pending", "in_progress", "completed"}
+)
+
+# ToolResultEndEvent.state values that end a call without a usable result.
+_FAILED_STATES: dict[str, str] = {
+    "error": "failed_note",
+    "interrupted": "interrupted_note",
+    "denied": "denied_note",
+}
+
+# Agent-produced HintBlocks are wrapped so the LLM does not treat them as user text.
+_SYSTEM_REMINDER_RE = re.compile(
+    r"\A\s*<system-reminder>\s*(.*?)\s*</system-reminder>\s*\Z",
+    re.DOTALL | re.IGNORECASE,
+)
+
+RowSink = Callable[[BizEvent], Awaitable[None]]
+EventSink = Callable[[BizEvent], Awaitable[None]]
+
+
+@dataclass(slots=True)
+class _PendingRow:
+    """A row waiting for its card before it can be written."""
+
+    event: BizEvent
+    card: asyncio.Task[Presentation]
+    first_row: bool
+
+
+@dataclass(slots=True)
+class _BlockBuffer:
+    """Accumulates one streaming text or thinking block."""
+
+    kind: BizEventKind
+    reply_id: str
+    block_id: str
+    parts: list[str] = field(default_factory=list)
+    started_at: float = 0.0
+
+
+@dataclass(slots=True)
+class _PendingTool:
+    """A tool call awaiting the result event that closes it."""
+
+    tool_call_id: str
+    tool_name: str
+    reply_id: str | None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    parts: list[str] = field(default_factory=list)
+    tool_input: Any = None
+    orchestration: OrchestrationInfo | None = None
+    card: asyncio.Task[Presentation] | None = None
+    started_at: float = 0.0
+    ended_at: float = 0.0
+    output_parts: list[str] = field(default_factory=list)
+    output_blocks: dict[str, dict[str, Any]] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class _SubagentTool:
+    event_id: str
+    tool_name: str
+    tool_input: Any
+    card: asyncio.Task[Presentation] | None
+    started_at: float
+
+
+@dataclass(slots=True)
+class _SubagentState:
+    """Live nesting state for one ``spawn_subagent`` call."""
+
+    parent_tool_call_id: str
+    reply_id: str | None = None
+    counter: int = 0
+    thinking_id: str | None = None
+    thinking_text: str = ""
+    thinking_at: float = 0.0
+    last_call_key: tuple[str, str] | None = None
+    open_tools: list[_SubagentTool] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class ConversionStats:
+    """Counters describing one conversion run."""
+
+    rows: int = 0
+    events: int = 0
+    main_events: int = 0
+    subagent_events: int = 0
+    tool_calls: int = 0
+    error_tools: int = 0
+    orphan_results: int = 0
+    unclosed_tools: int = 0
+    subagent_chunks: int = 0
+    orchestration_events: int = 0
+    orchestration_unparsed: int = 0
+    dropped_entries: int = 0
+
+
+class BizTraceConverter:
+    """Convert a raw AgentScope event flow into BizTrace rows.
+
+    Args:
+        presenter: Builds the presentation card of each emitted row.
+        on_row: Writes one finished row; called in emission order.
+        on_event: Post-emit hook. Receives only first-write main-channel
+            events, matching the outward-facing view Trace2Segment consumes.
+        lang: Language of the rule-based notes.
+    """
+
+    def __init__(
+        self,
+        *,
+        presenter: PresentationBuilder,
+        on_row: RowSink,
+        on_event: EventSink | None = None,
+        lang: str = "zh",
+        queue_size: int = CONVERTER_QUEUE_SIZE,
+    ) -> None:
+        self.presenter = presenter
+        self.on_row = on_row
+        self.on_event = on_event
+        self.words = CAPTIONS["en" if lang == "en" else "zh"]
+        self.stats = ConversionStats()
+
+        self._entries: asyncio.Queue[dict[str, Any] | None] = asyncio.Queue(
+            maxsize=queue_size
+        )
+        self._rows: asyncio.Queue[_PendingRow | None] = asyncio.Queue()
+        self._consumer: asyncio.Task[None] | None = None
+        self._writer: asyncio.Task[None] | None = None
+        self._closed = False
+
+        self._seq = 0
+        self._seq_by_event: dict[str, int] = {}
+        self._blocks: dict[tuple[str, str], _BlockBuffer] = {}
+        self._tools: dict[str, _PendingTool] = {}
+        self._subagents: dict[str, _SubagentState] = {}
+        self._plan_nodes: dict[str, str] = {}
+        self._graph_id: str | None = None
+
+    # -- lifecycle --------------------------------------------------------- #
+
+    def start(self) -> None:
+        """Spin up the conversion worker and the ordered row writer."""
+        if self._consumer is None:
+            self._consumer = asyncio.create_task(self._consume_loop())
+        if self._writer is None:
+            self._writer = asyncio.create_task(self._write_loop())
+
+    def enqueue(self, entry: dict[str, Any]) -> None:
+        """Take one raw entry. Synchronous, non-blocking, never raises."""
+        if self._closed:
+            return
+        try:
+            self._entries.put_nowait(entry)
+        except asyncio.QueueFull:
+            self.stats.dropped_entries += 1
+            logger.warning(
+                "BizTrace queue is full; dropped one raw entry (total %d)",
+                self.stats.dropped_entries,
+            )
+        except Exception:
+            logger.exception("Failed to enqueue a raw trace entry")
+
+    async def aclose(self) -> None:
+        """Drain the queue, reconcile unclosed tools, and stop the workers."""
+        if self._closed:
+            return
+        self._closed = True
+        self._entries.put_nowait(None)
+        if self._consumer is not None:
+            await self._consumer
+            self._consumer = None
+        self._reconcile_unclosed()
+        self._rows.put_nowait(None)
+        if self._writer is not None:
+            await self._writer
+            self._writer = None
+
+    async def _consume_loop(self) -> None:
+        while True:
+            entry = await self._entries.get()
+            if entry is None:
+                return
+            try:
+                self._feed(entry)
+            except Exception:
+                logger.exception("Failed to convert a raw trace entry")
+
+    async def _write_loop(self) -> None:
+        while True:
+            pending = await self._rows.get()
+            if pending is None:
+                return
+            try:
+                card = await pending.card
+            except Exception:
+                logger.exception("Presentation task failed; writing a bare row")
+                card = None
+            event = pending.event.model_copy(update={"presentation": card})
+            try:
+                await self.on_row(event)
+            except Exception:
+                logger.exception("BizEvent sink failed for %s", event.event_id)
+            if not pending.first_row:
+                # Reconciliation rewrites a row downstream already consumed.
+                continue
+            if self.on_event is not None and event.channel == "main":
+                try:
+                    await self.on_event(event)
+                except Exception:
+                    logger.exception(
+                        "Post-emit hook failed for %s", event.event_id
+                    )
+
+    # -- ingestion --------------------------------------------------------- #
+
+    def _feed(self, entry: dict[str, Any]) -> None:
+        payload = entry.get("payload")
+        if not isinstance(payload, dict):
+            return
+        if entry.get("kind") == "user_input":
+            self._on_user_message(payload)
+            return
+
+        event_type = str(payload.get("type") or "")
+        at = _event_time(payload)
+        if event_type in ("THINKING_BLOCK_START", "TEXT_BLOCK_START"):
+            kind: BizEventKind = (
+                "assistant_thinking"
+                if event_type == "THINKING_BLOCK_START"
+                else "assistant_text"
+            )
+            self._on_block_start(payload, kind, at)
+        elif event_type in ("THINKING_BLOCK_DELTA", "TEXT_BLOCK_DELTA"):
+            self._on_block_delta(payload)
+        elif event_type in ("THINKING_BLOCK_END", "TEXT_BLOCK_END"):
+            self._on_block_end(payload, at)
+        elif event_type == "HINT_BLOCK":
+            self._on_hint(payload, at)
+        elif event_type == "TOOL_CALL_START":
+            self._on_tool_call_start(payload, at)
+        elif event_type == "TOOL_CALL_DELTA":
+            self._on_tool_call_delta(payload)
+        elif event_type == "TOOL_CALL_END":
+            self._on_tool_call_end(payload, at)
+        elif event_type == "TOOL_RESULT_START":
+            self._on_tool_result_start(payload, at)
+        elif event_type == "TOOL_RESULT_TEXT_DELTA":
+            self._on_tool_result_text_delta(payload, at)
+        elif event_type == "TOOL_RESULT_DATA_DELTA":
+            self._on_tool_result_data_delta(payload)
+        elif event_type == "TOOL_RESULT_END":
+            self._on_tool_result_end(payload, at)
+
+    # -- user, text and hint ----------------------------------------------- #
+
+    def _on_user_message(self, payload: dict[str, Any]) -> None:
+        message_id = str(payload.get("id") or "")
+        blocks = [
+            block
+            for block in payload.get("content") or []
+            if isinstance(block, dict) and block.get("type") == "text"
+        ]
+        text = "\n".join(str(block.get("text") or "") for block in blocks)
+        block_id = next(
+            (str(block["id"]) for block in blocks if block.get("id")), ""
+        )
+        event_id = block_id or f"{message_id}:0"
+        at = _timestamp(payload.get("timestamp")) or time()
+        self._emit(
+            BizEvent(
+                event_id=event_id,
+                kind="user",
+                parent_msg_id=message_id or None,
+                block_id=event_id,
+                content=text,
+                started_at=at,
+                ended_at=at,
+            )
+        )
+
+    def _on_block_start(
+        self, payload: dict[str, Any], kind: BizEventKind, at: float
+    ) -> None:
+        key = _block_key(payload)
+        self._blocks[key] = _BlockBuffer(
+            kind=kind, reply_id=key[0], block_id=key[1], started_at=at
+        )
+
+    def _on_block_delta(self, payload: dict[str, Any]) -> None:
+        buffer = self._blocks.get(_block_key(payload))
+        if buffer is not None:
+            buffer.parts.append(str(payload.get("delta") or ""))
+
+    def _on_block_end(self, payload: dict[str, Any], at: float) -> None:
+        buffer = self._blocks.pop(_block_key(payload), None)
+        if buffer is None:
+            return
+        self._emit(
+            BizEvent(
+                event_id=buffer.block_id,
+                kind=buffer.kind,
+                parent_msg_id=buffer.reply_id or None,
+                block_id=buffer.block_id,
+                content="".join(buffer.parts),
+                started_at=buffer.started_at,
+                ended_at=at,
+            )
+        )
+
+    def _on_hint(self, payload: dict[str, Any], at: float) -> None:
+        """A hint arrives complete in one event, so it is written immediately.
+
+        Only Host steer (``source="steer"``) is user guidance. Every other
+        HintBlock is an agent reminder and lands as ordinary assistant text.
+        """
+        block_id = str(payload.get("block_id") or "")
+        hint = payload.get("hint")
+        source = _as_str(payload.get("source"))
+        content = _hint_text(hint)
+        if source == "steer":
+            event = BizEvent(
+                event_id=block_id or f"hint:{payload.get('id')}",
+                kind="hint",
+                parent_msg_id=_as_str(payload.get("reply_id")),
+                block_id=block_id or None,
+                content=content,
+                source=source,
+                started_at=at,
+                ended_at=at,
+            )
+            self._emit(event, self._card(event, hint=hint))
+            return
+        event = BizEvent(
+            event_id=block_id or f"hint:{payload.get('id')}",
+            kind="assistant_text",
+            parent_msg_id=_as_str(payload.get("reply_id")),
+            block_id=block_id or None,
+            content=_unwrap_system_reminder(content),
+            source=source,
+            started_at=at,
+            ended_at=at,
+        )
+        self._emit(event)
+
+    # -- tool calls -------------------------------------------------------- #
+
+    def _on_tool_call_start(self, payload: dict[str, Any], at: float) -> None:
+        tool_call_id = str(payload.get("tool_call_id") or "")
+        if not tool_call_id:
+            return
+        # TOOL_CALL_END carries no name, so it is remembered from the start.
+        self._tools[tool_call_id] = _PendingTool(
+            tool_call_id=tool_call_id,
+            tool_name=str(payload.get("tool_call_name") or "unknown_tool"),
+            reply_id=_as_str(payload.get("reply_id")),
+            metadata=payload.get("metadata") or {},
+            started_at=at,
+        )
+
+    def _on_tool_call_delta(self, payload: dict[str, Any]) -> None:
+        pending = self._tools.get(str(payload.get("tool_call_id") or ""))
+        if pending is not None:
+            pending.parts.append(str(payload.get("delta") or ""))
+
+    def _on_tool_call_end(self, payload: dict[str, Any], at: float) -> None:
+        """Arguments are complete here, so the call event is final."""
+        pending = self._tools.get(str(payload.get("tool_call_id") or ""))
+        if pending is None:
+            return
+        pending.tool_input = _parse_input("".join(pending.parts))
+        pending.orchestration = self._parse_orchestration(pending)
+        pending.ended_at = at
+        call = self._tool_use_event(pending, status="done")
+        pending.card = self._card(call)
+        self.stats.tool_calls += 1
+        self._emit(call, pending.card)
+
+    def _on_tool_result_start(self, payload: dict[str, Any], at: float) -> None:
+        tool_call_id = str(payload.get("tool_call_id") or "")
+        pending = self._tools.get(tool_call_id)
+        if pending is None and tool_call_id:
+            # A result without a call: keep the name so the card still reads.
+            pending = _PendingTool(
+                tool_call_id=tool_call_id,
+                tool_name=str(payload.get("tool_call_name") or "unknown_tool"),
+                reply_id=_as_str(payload.get("reply_id")),
+                started_at=at,
+            )
+            self._tools[tool_call_id] = pending
+
+    def _on_tool_result_text_delta(
+        self, payload: dict[str, Any], at: float
+    ) -> None:
+        metadata = payload.get("metadata") or {}
+        subagent_event = metadata.get("subagent_event")
+        if subagent_event:
+            self.stats.subagent_chunks += 1
+            self._on_subagent_chunk(
+                parent_tool_call_id=str(payload.get("tool_call_id") or ""),
+                subagent_event=str(subagent_event),
+                text=str(payload.get("delta") or ""),
+                tool_name=metadata.get("subagent_tool_name"),
+                at=at,
+            )
+            return
+        pending = self._tools.get(str(payload.get("tool_call_id") or ""))
+        if pending is not None:
+            pending.output_parts.append(str(payload.get("delta") or ""))
+
+    def _on_tool_result_data_delta(self, payload: dict[str, Any]) -> None:
+        pending = self._tools.get(str(payload.get("tool_call_id") or ""))
+        if pending is None:
+            return
+        block_id = str(payload.get("block_id") or "")
+        media_type = str(payload.get("media_type") or "")
+        block = pending.output_blocks.setdefault(
+            block_id, {"type": "data", "source": {"media_type": media_type}}
+        )
+        url = payload.get("url")
+        if isinstance(url, str) and url:
+            block["source"]["url"] = url
+            return
+        chunk = payload.get("data")
+        if isinstance(chunk, str) and chunk:
+            source = block["source"]
+            source["data"] = str(source.get("data") or "") + chunk
+
+    def _on_tool_result_end(self, payload: dict[str, Any], at: float) -> None:
+        """The result is its own event, linked to the call by their tool id."""
+        tool_call_id = str(payload.get("tool_call_id") or "")
+        pending = self._tools.pop(tool_call_id, None)
+        subagent = self._subagents.pop(tool_call_id, None)
+        if subagent is not None:
+            self._close_subagent(subagent)
+        if pending is None:
+            self.stats.orphan_results += 1
+            logger.warning("tool result without a matching call: %s", tool_call_id)
+
+        raw_state = str(payload.get("state") or "success").lower()
+        note_key = _FAILED_STATES.get(raw_state)
+        if note_key is not None:
+            self.stats.error_tools += 1
+        result = BizEvent(
+            event_id=f"{tool_call_id}:result",
+            kind="tool_result",
+            parent_msg_id=_as_str(payload.get("reply_id")),
+            block_id=tool_call_id or None,
+            status="error" if note_key else "done",
+            tool_name=str(
+                payload.get("tool_call_name")
+                or (pending.tool_name if pending else "unknown_tool")
+            ),
+            output=_tool_output(pending),
+            started_at=pending.started_at if pending else at,
+            ended_at=at,
+        )
+        call_card = pending.card if pending is not None else None
+        # "error" already reads as a failure on the card; the other two states
+        # do not, so their reason is spelled out.
+        note = (
+            self.words[note_key]
+            if note_key is not None and raw_state != "error"
+            else None
+        )
+        self._emit(result, self._card(result, call_card=call_card, note=note))
+
+    def _tool_use_event(self, pending: _PendingTool, *, status: str) -> BizEvent:
+        return BizEvent(
+            event_id=pending.tool_call_id,
+            kind="tool_use",
+            parent_msg_id=pending.reply_id,
+            block_id=pending.tool_call_id,
+            status=status,  # type: ignore[arg-type]
+            tool_name=pending.tool_name,
+            input=pending.tool_input,
+            orchestration=pending.orchestration,
+            started_at=pending.started_at,
+            ended_at=pending.ended_at or pending.started_at,
+        )
+
+    def _reconcile_unclosed(self) -> None:
+        """Rewrite calls whose result never arrived so none reads as fine."""
+        for subagent in list(self._subagents.values()):
+            self._close_subagent(subagent)
+        self._subagents.clear()
+
+        for pending in list(self._tools.values()):
+            if pending.card is None:
+                # The call event itself never completed; nothing was written.
+                continue
+            self.stats.unclosed_tools += 1
+            event = self._tool_use_event(pending, status="error")
+            self._emit(
+                event,
+                self._card(
+                    event,
+                    call_card=pending.card,
+                    note=self.words["unclosed_note"],
+                ),
+            )
+        self._tools.clear()
+
+    # -- orchestration ----------------------------------------------------- #
+
+    def _parse_orchestration(
+        self, pending: _PendingTool
+    ) -> OrchestrationInfo | None:
+        category = ORCHESTRATION_CATEGORIES.get(
+            canonical_tool_name(pending.tool_name)
+        )
+        if category is None:
+            return None
+        self.stats.orchestration_events += 1
+        payload = pending.tool_input if isinstance(pending.tool_input, dict) else {}
+        if category in ("PlanCreate", "PlanUpdate"):
+            self._register_plan_nodes(payload)
+        # Host plan tools do not carry a graph id; keep the field for older rows.
+        graph_id = (
+            _as_str(payload.get("graph_id"))
+            or _as_str(pending.metadata.get("graph_id"))
+            or self._graph_id
+        )
+        if graph_id:
+            self._graph_id = graph_id
+        node_id = (
+            _as_str(payload.get("task_id"))
+            or _as_str(payload.get("node_id"))
+            or _as_str(pending.metadata.get("node_id"))
+        )
+        info = OrchestrationInfo(
+            category=category,
+            graph_id=graph_id,
+            node_id=node_id,
+            node_name=self._plan_nodes.get(node_id or ""),
+            summary=_as_str(payload.get("summary"))
+            or _as_str(payload.get("outcome")),
+        )
+        if category != "TaskStateUpdate":
+            return info
+        state = _as_str(payload.get("state"))
+        if state not in VALID_SUBTASK_STATES:
+            self.stats.orchestration_unparsed += 1
+            logger.warning(
+                "unparseable subtask state for %s: %r",
+                pending.tool_name,
+                payload.get("state"),
+            )
+            return None
+        subtask_state: SubtaskState = state  # type: ignore[assignment]
+        return info.model_copy(update={"subtask_state": subtask_state})
+
+    def _register_plan_nodes(self, payload: dict[str, Any]) -> None:
+        """Remember task_id → subject so later TaskStateUpdate cards can be named."""
+        for task in payload.get("tasks") or []:
+            if not isinstance(task, dict):
+                continue
+            task_id = _as_str(task.get("id")) or _as_str(task.get("task_id"))
+            name = _as_str(task.get("subject")) or _as_str(task.get("name"))
+            if task_id and name:
+                self._plan_nodes[task_id] = name
+        for change in payload.get("changes") or []:
+            if not isinstance(change, dict):
+                continue
+            task_id = _as_str(change.get("task_id")) or _as_str(change.get("node_id"))
+            task = change.get("task") or change.get("node")
+            if task_id and isinstance(task, dict):
+                name = _as_str(task.get("subject")) or _as_str(task.get("name"))
+                if name:
+                    self._plan_nodes[task_id] = name
+            elif task_id and change.get("action") == "delete":
+                self._plan_nodes.pop(task_id, None)
+
+    # -- sub-agent live nesting -------------------------------------------- #
+
+    def _on_subagent_chunk(
+        self,
+        *,
+        parent_tool_call_id: str,
+        subagent_event: str,
+        text: str,
+        tool_name: Any,
+        at: float,
+    ) -> None:
+        state = self._subagents.get(parent_tool_call_id)
+        if state is None:
+            parent = self._tools.get(parent_tool_call_id)
+            state = _SubagentState(
+                parent_tool_call_id=parent_tool_call_id,
+                reply_id=parent.reply_id if parent is not None else None,
+            )
+            self._subagents[parent_tool_call_id] = state
+        if subagent_event == "thinking":
+            self._on_subagent_thinking(state, text, at)
+        elif subagent_event == "tool_call":
+            self._on_subagent_tool_call(
+                state, str(tool_name or "unknown_tool"), text, at
+            )
+        elif subagent_event == "tool_result":
+            self._on_subagent_tool_result(
+                state, str(tool_name or "unknown_tool"), text, at
+            )
+        elif subagent_event == "summary":
+            self._flush_subagent_thinking(state)
+
+    def _on_subagent_thinking(
+        self, state: _SubagentState, text: str, at: float
+    ) -> None:
+        """Accumulate one reasoning segment; chunks re-emit it as it grows."""
+        if state.thinking_id is not None and text.startswith(state.thinking_text):
+            state.thinking_text = text
+            return
+        self._flush_subagent_thinking(state)
+        state.thinking_id = self._next_subagent_id(state)
+        state.thinking_text = text
+        state.thinking_at = at
+
+    def _flush_subagent_thinking(self, state: _SubagentState) -> None:
+        if state.thinking_id is None:
+            return
+        self._emit(
+            BizEvent(
+                event_id=state.thinking_id,
+                kind="assistant_thinking",
+                channel="subagent",
+                parent_msg_id=state.reply_id,
+                block_id=state.parent_tool_call_id,
+                content=state.thinking_text,
+                started_at=state.thinking_at,
+                ended_at=state.thinking_at,
+            )
+        )
+        state.thinking_id = None
+        state.thinking_text = ""
+
+    def _on_subagent_tool_call(
+        self, state: _SubagentState, tool_name: str, text: str, at: float
+    ) -> None:
+        payload = _parse_subagent_call_input(text)
+        key = (tool_name, payload)
+        if state.last_call_key == key:
+            return
+        state.last_call_key = key
+        # Acting ends the reasoning segment, so ids follow emission order.
+        self._flush_subagent_thinking(state)
+        event_id = self._next_subagent_id(state)
+        event = BizEvent(
+            event_id=event_id,
+            kind="tool_use",
+            channel="subagent",
+            parent_msg_id=state.reply_id,
+            block_id=event_id,
+            tool_name=tool_name,
+            input=_parse_input(payload),
+            started_at=at,
+            ended_at=at,
+        )
+        card = self._card(event)
+        state.open_tools.append(
+            _SubagentTool(
+                event_id=event.event_id,
+                tool_name=tool_name,
+                tool_input=event.input,
+                card=card,
+                started_at=at,
+            )
+        )
+        self._emit(event, card)
+
+    def _on_subagent_tool_result(
+        self, state: _SubagentState, tool_name: str, text: str, at: float
+    ) -> None:
+        self._flush_subagent_thinking(state)
+        state.last_call_key = None
+        pending = next(
+            (
+                tool
+                for tool in reversed(state.open_tools)
+                if tool.tool_name == tool_name
+            ),
+            None,
+        )
+        if pending is None:
+            self.stats.orphan_results += 1
+            return
+        state.open_tools.remove(pending)
+        # Sub-agent chunks carry no error flag, so a closed call reads as done.
+        event = BizEvent(
+            event_id=f"{pending.event_id}:result",
+            kind="tool_result",
+            channel="subagent",
+            parent_msg_id=state.reply_id,
+            block_id=pending.event_id,
+            tool_name=pending.tool_name,
+            output=text,
+            started_at=at,
+            ended_at=at,
+        )
+        call_card = pending.card
+        self._emit(event, self._card(event, call_card=call_card))
+
+    def _close_subagent(self, state: _SubagentState) -> None:
+        self._flush_subagent_thinking(state)
+        for pending in state.open_tools:
+            event = BizEvent(
+                event_id=pending.event_id,
+                kind="tool_use",
+                channel="subagent",
+                parent_msg_id=state.reply_id,
+                block_id=pending.event_id,
+                status="error",
+                tool_name=pending.tool_name,
+                input=pending.tool_input,
+                started_at=pending.started_at,
+                ended_at=pending.started_at,
+            )
+            self._emit(
+                event,
+                self._card(
+                    event,
+                    call_card=pending.card,
+                    note=self.words["unclosed_note"],
+                ),
+            )
+        state.open_tools.clear()
+
+    def _next_subagent_id(self, state: _SubagentState) -> str:
+        state.counter += 1
+        return f"{state.parent_tool_call_id}:{state.counter}"
+
+    # -- emission ---------------------------------------------------------- #
+
+    def _card(
+        self,
+        event: BizEvent,
+        *,
+        call_card: asyncio.Task[Presentation] | None = None,
+        note: str | None = None,
+        hint: Any = None,
+    ) -> asyncio.Task[Presentation]:
+        """Schedule the card so independent cards are produced in parallel."""
+
+        async def build() -> Presentation:
+            base = await call_card if call_card is not None else None
+            return await self.presenter.build(
+                event, call_card=base, note=note, hint=hint
+            )
+
+        return asyncio.create_task(build())
+
+    def _emit(
+        self, event: BizEvent, card: asyncio.Task[Presentation] | None = None
+    ) -> None:
+        previous_seq = self._seq_by_event.get(event.event_id)
+        first_row = previous_seq is None
+        if first_row:
+            self._seq += 1
+            self._seq_by_event[event.event_id] = self._seq
+            seq = self._seq
+        else:
+            # A rewrite keeps its original slot so cards never move.
+            seq = previous_seq  # type: ignore[assignment]
+        event = event.model_copy(update={"seq": seq})
+
+        self.stats.rows += 1
+        if first_row:
+            self.stats.events += 1
+            if event.channel == "subagent":
+                self.stats.subagent_events += 1
+            else:
+                self.stats.main_events += 1
+
+        self._rows.put_nowait(
+            _PendingRow(
+                event=event,
+                card=card if card is not None else self._card(event),
+                first_row=first_row,
+            )
+        )
+
+
+def _block_key(payload: dict[str, Any]) -> tuple[str, str]:
+    return str(payload.get("reply_id") or ""), str(payload.get("block_id") or "")
+
+
+def _hint_text(hint: Any) -> str:
+    """Text view of a hint; DataBlocks stay out and land on the card only."""
+    if isinstance(hint, str):
+        return hint
+    if not isinstance(hint, list):
+        return ""
+    return "\n\n".join(
+        str(block.get("text") or "")
+        for block in hint
+        if isinstance(block, dict) and block.get("type") == "text"
+    )
+
+
+def _unwrap_system_reminder(text: str) -> str:
+    """Drop ``<system-reminder>`` tags when an agent hint was wrapped for the LLM."""
+    match = _SYSTEM_REMINDER_RE.match(text)
+    return match.group(1).strip() if match else text
+
+
+def _tool_output(pending: _PendingTool | None) -> Any:
+    """Assemble the accumulated result payload of one tool call."""
+    if pending is None:
+        return None
+    text = "".join(pending.output_parts)
+    if not pending.output_blocks:
+        return text
+    blocks: list[dict[str, Any]] = list(pending.output_blocks.values())
+    if text:
+        blocks.append({"type": "text", "text": text})
+    return blocks
+
+
+def _parse_input(text: str) -> Any:
+    """Decode aggregated tool arguments, keeping the raw text when invalid."""
+    stripped = text.strip()
+    if not stripped:
+        return {}
+    try:
+        return json.loads(stripped)
+    except json.JSONDecodeError:
+        return stripped
+
+
+def _parse_subagent_call_input(text: str) -> str:
+    """Extract the payload from a ``[tool_call] name(payload)`` chunk."""
+    start = text.find("(")
+    if start == -1 or not text.endswith(")"):
+        return text
+    return text[start + 1 : -1]
+
+
+def _event_time(payload: dict[str, Any]) -> float:
+    return _timestamp(payload.get("created_at")) or time()
+
+
+def _timestamp(value: Any) -> float | None:
+    if isinstance(value, (int, float)):
+        return float(value)
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value).timestamp()
+    except ValueError:
+        return None
+
+
+def _as_str(value: Any) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+__all__ = ["BizTraceConverter", "ConversionStats"]

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/algo/biztrace/formatting.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/algo/biztrace/formatting.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+"""Shared text helpers for card bodies and window rendering."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def compact(value: Any) -> str:
+    """Render any tool payload as one compact line of text."""
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    try:
+        return json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+    except (TypeError, ValueError):
+        return str(value)
+
+
+def output_text(value: Any) -> str:
+    """Flatten a tool output into text, keeping only human-readable parts."""
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        parts: list[str] = []
+        for block in value:
+            if isinstance(block, str):
+                parts.append(block)
+            elif isinstance(block, dict):
+                text = block.get("text")
+                parts.append(text if isinstance(text, str) else compact(block))
+            else:
+                parts.append(str(block))
+        return "\n".join(part for part in parts if part)
+    return compact(value)
+
+
+def truncate(text: str, cap: int) -> str:
+    """Trim to ``cap`` characters, marking the cut with an ellipsis."""
+    text = text.strip()
+    if len(text) <= cap:
+        return text
+    return text[: cap - 3] + "..."
+
+
+def join_sections(*parts: str) -> str:
+    """Join non-empty markdown sections with a blank line between them."""
+    return "\n\n".join(part for part in parts if part)
+
+
+def first_str(payload: Any, keys: tuple[str, ...]) -> str | None:
+    """Return the first non-empty string value among ``keys``."""
+    if not isinstance(payload, dict):
+        return None
+    for key in keys:
+        value = payload.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+__all__ = [
+    "compact",
+    "first_str",
+    "join_sections",
+    "output_text",
+    "truncate",
+]

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/algo/biztrace/linking.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/algo/biztrace/linking.py
@@ -1,0 +1,281 @@
+# -*- coding: utf-8 -*-
+"""Entity linking: turn business terms in a card body into markdown links.
+
+Runs entirely in memory after a card body is generated. Captions are left
+alone, and the substitution happens once per card, so a written card's links
+never change afterwards.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from urllib.parse import urlencode
+
+from qwenpaw_data.host.core.algo.biztrace.semantic_vocab import (
+    SemanticVocabulary,
+    VocabEntry,
+)
+from qwenpaw_data.host.core.algo.biztrace.settings import BizTraceSettings, resolve_link_base_url
+from qwenpaw_data.host.core.cm_client import resolve_cm_base_url
+
+logger = logging.getLogger(__name__)
+
+ENTITY_ROUTES: dict[str, tuple[str, str | None]] = {
+    "biz_domain": ("business-domain", None),
+    "dimension": ("dimension", "dimension_id"),
+    "metric": ("metric-lib", "metric_id"),
+    "dataset": ("data-set", "dataset_id"),
+}
+
+# Regions where a substitution would break rendering or nest a link.
+# Inline code stays protected in the main scan: a link nested inside
+# backticks is not clickable. Exact `` `term` `` / `` **term** `` spans are
+# handled separately by ``_link_marked_terms`` before this pass.
+_PROTECTED_RE = re.compile(
+    r"```.*?```"  # fenced code
+    r"|`[^`\n]*`"  # inline code
+    r"|!?\[[^\]\n]*\]\([^)\n]*\)"  # markdown link or image
+    # Autolink or raw tag, attributes included: segment fields carry
+    # <span class="..."> around key numbers, and a link inside a tag's
+    # attributes would render as literal markdown.
+    r"|<[^>\n]*>"
+    r"|\bhttps?://\S+",  # bare URL
+    re.DOTALL,
+)
+# Emphasis / code wrappers the model often puts around entity names.
+_MARKED_TERM_RE = re.compile(
+    r"`([^`\n]+)`"
+    r"|\*\*([^*]+)\*\*"
+    r"|__([^_]+)__",
+)
+_WORD_CHAR_RE = re.compile(r"[0-9A-Za-z_]")
+
+
+def build_entity_url(
+    entry: VocabEntry, *, base_url: str, datasource_id: str | None
+) -> str | None:
+    """Render the Context frontend URL an entry points at."""
+    route = ENTITY_ROUTES.get(entry.entity_type)
+    if route is None:
+        return None
+    page, id_param = route
+    params: list[tuple[str, str]] = []
+    if datasource_id:
+        params.append(("datasource_id", datasource_id))
+    if entry.domain_id:
+        params.append(("domain_id", entry.domain_id))
+    if id_param and entry.entity_id:
+        params.append((id_param, entry.entity_id))
+    query = urlencode(params)
+    return f"{base_url}/{page}?{query}" if query else f"{base_url}/{page}"
+
+
+class EntityLinker:
+    """Longest-first exact matcher that injects inline markdown links."""
+
+    def __init__(
+        self,
+        *,
+        terms: dict[str, VocabEntry],
+        base_url: str,
+        datasource_id: str | None,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.datasource_id = datasource_id
+        self._urls: dict[str, str] = {}
+        for term, entry in terms.items():
+            url = build_entity_url(
+                entry, base_url=self.base_url, datasource_id=datasource_id
+            )
+            if url is not None:
+                self._urls[term] = url
+        self._lengths = sorted({len(term) for term in self._urls}, reverse=True)
+
+    def __bool__(self) -> bool:
+        return bool(self._urls)
+
+    def link(self, body: str) -> str:
+        """Link every occurrence of every known term outside protected spans."""
+        if not body or not self._urls:
+            return body
+        body = self._link_marked_terms(body)
+        protected = [match.span() for match in _PROTECTED_RE.finditer(body)]
+        out: list[str] = []
+        index = 0
+        length = len(body)
+        while index < length:
+            skip_to = _protected_end(protected, index)
+            if skip_to is not None:
+                out.append(body[index:skip_to])
+                index = skip_to
+                continue
+            term = self._match_at(body, index)
+            if term is None:
+                out.append(body[index])
+                index += 1
+                continue
+            out.append(f"[{term}]({self._urls[term]})")
+            index += len(term)
+        return "".join(out)
+
+    def _link_marked_terms(self, body: str) -> str:
+        """Turn exact `` `term` `` / `` **term** `` / `` __term__ `` into links.
+
+        Wrappers are dropped so the markdown link is clickable. Keeping
+        backticks in the label (`` [`term`](url) ``) is not usable here: the
+        chat Markdown ``code`` component is a fenced CodeHighlighter and does
+        not render nested inline code inside links.
+        """
+
+        def replace(match: re.Match[str]) -> str:
+            term = match.group(1) or match.group(2) or match.group(3) or ""
+            if not term or term not in self._urls:
+                return match.group(0)
+            return f"[{term}]({self._urls[term]})"
+
+        return _MARKED_TERM_RE.sub(replace, body)
+
+    def _match_at(self, body: str, index: int) -> str | None:
+        for size in self._lengths:
+            end = index + size
+            if end > len(body):
+                continue
+            candidate = body[index:end]
+            if candidate not in self._urls:
+                continue
+            if _breaks_word(body, index, end):
+                continue
+            return candidate
+        return None
+
+
+def _protected_end(protected: list[tuple[int, int]], index: int) -> int | None:
+    for start, end in protected:
+        if start <= index < end:
+            return end
+        if start > index:
+            break
+    return None
+
+
+def _breaks_word(body: str, start: int, end: int) -> bool:
+    """Reject a match that is only part of a longer ASCII identifier."""
+    if _WORD_CHAR_RE.match(body[start]) and start > 0:
+        if _WORD_CHAR_RE.match(body[start - 1]):
+            return True
+    if _WORD_CHAR_RE.match(body[end - 1]) and end < len(body):
+        if _WORD_CHAR_RE.match(body[end]):
+            return True
+    return False
+
+
+class VocabularyLinker:
+    """Link against the shared vocabulary, picking up its refreshes.
+
+    The matcher is rebuilt whenever the vocabulary swaps its term index, so a
+    chat that started before the first fetch landed still links its later
+    cards. Until then ``link`` is the identity function.
+    """
+
+    def __init__(
+        self,
+        vocabulary: SemanticVocabulary,
+        *,
+        base_url: str,
+        datasource_id: str | None,
+    ) -> None:
+        self.vocabulary = vocabulary
+        self.base_url = base_url
+        self.datasource_id = datasource_id
+        self._terms: dict[str, VocabEntry] | None = None
+        self._linker: EntityLinker | None = None
+
+    def link(self, body: str) -> str:
+        terms = self.vocabulary.terms
+        if terms is not self._terms:
+            self._terms = terms
+            self._linker = (
+                EntityLinker(
+                    terms=terms,
+                    base_url=self.base_url,
+                    datasource_id=self.datasource_id,
+                )
+                if terms
+                else None
+            )
+        return self._linker.link(body) if self._linker is not None else body
+
+
+_VOCABULARIES: dict[tuple[str, str | None], SemanticVocabulary] = {}
+_REFRESHES: set[asyncio.Task[None]] = set()
+
+
+def build_linker(
+    settings: BizTraceSettings,
+    *,
+    datasource_id: str | None,
+    access_token: str | None = None,
+) -> VocabularyLinker | None:
+    """Return a linker over the shared vocabulary, or None if disabled.
+
+    Synchronous on purpose: this runs while the agent is starting, so it only
+    kicks off the fetch. Vocabularies are shared per ``(cm_base_url,
+    datasource_id)``; markdown hrefs use the Context frontend origin. The
+    latest chat's access token is used for subsequent CM refreshes.
+    """
+
+    if not settings.biz_link_enabled:
+        return None
+    resolved = (settings.biz_link_datasource_id or datasource_id or "").strip()
+    token = (access_token or "").strip() or None
+    # 空串表示同源相对路径（/metrics?...），不能当 falsy 跳过。
+    link_base_url = resolve_link_base_url(settings)
+    api_base_url = resolve_cm_base_url()
+    if not api_base_url:
+        return None
+    key = (api_base_url, resolved or None)
+    vocabulary = _VOCABULARIES.get(key)
+    if vocabulary is None:
+        vocabulary = SemanticVocabulary(
+            base_url=api_base_url,
+            datasource_id=resolved or None,
+            access_token=token,
+            ttl=settings.biz_link_ttl,
+        )
+        _VOCABULARIES[key] = vocabulary
+    else:
+        # Keep the shared cache, but refresh with the newest chat's credentials.
+        vocabulary.access_token = token
+    _refresh(vocabulary)
+    return VocabularyLinker(
+        vocabulary, base_url=link_base_url, datasource_id=resolved or None
+    )
+
+
+def _refresh(vocabulary: SemanticVocabulary) -> None:
+    """Kick off a TTL refresh in the background; ``ensure_fresh`` never raises."""
+    task = asyncio.create_task(vocabulary.ensure_fresh())
+    _REFRESHES.add(task)
+    task.add_done_callback(_REFRESHES.discard)
+
+
+async def shutdown_vocabularies() -> None:
+    """Close the shared vocabulary clients at application shutdown."""
+    for task in list(_REFRESHES):
+        task.cancel()
+    _REFRESHES.clear()
+    for vocabulary in list(_VOCABULARIES.values()):
+        await vocabulary.aclose()
+    _VOCABULARIES.clear()
+
+
+__all__ = [
+    "ENTITY_ROUTES",
+    "EntityLinker",
+    "VocabularyLinker",
+    "build_entity_url",
+    "build_linker",
+    "shutdown_vocabularies",
+]

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/algo/biztrace/llm.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/algo/biztrace/llm.py
@@ -1,0 +1,206 @@
+# -*- coding: utf-8 -*-
+"""Structured JSON-schema calls on the chat model the host builds for us."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import random
+from typing import TYPE_CHECKING, Any
+
+from agentscope.message import SystemMsg, UserMsg
+
+if TYPE_CHECKING:
+    from agentscope.model import ChatModelBase
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_ATTEMPTS = 2
+_BACKOFF_BASE_SECONDS = 0.4
+_CONTAINER_TYPES = frozenset({"array", "object"})
+_ERROR_CHAR_CAP = 600
+_REPAIR_HINT = (
+    "Your previous tool call did not match the schema and was rejected:\n\n"
+    "{error}\n\n"
+    "Answer again, as one call to the same tool. Emit every nested array and "
+    "object as real JSON, never as a string, and keep every other field the "
+    "type the schema declares."
+)
+# Thinking is off on purpose, not by luck: reasoning tokens earn nothing against
+# a strict schema, DashScope rejects a non-streaming call while thinking is on,
+# and it also costs the forced tool call that carries the structured answer.
+_CALL_PROFILE: dict[str, Any] = {"thinking_enable": False, "temperature": 0.0}
+
+
+class StructuredLLMError(RuntimeError):
+    """Raised when the model cannot produce a schema-conforming payload."""
+
+
+def for_structured_calls(model: ChatModelBase) -> ChatModelBase:
+    """Retune a model the host built for the agent into one for extraction.
+
+    Every call here asks for one JSON object, so streaming buys nothing and the
+    non-streaming path is both cheaper and the one that keeps the schema tool
+    call intact. Only knobs the provider declares are touched, so an API
+    without them cannot fail the turn.
+    """
+
+    model.stream = False
+    fields = type(model.parameters).model_fields
+    update = {key: value for key, value in _CALL_PROFILE.items() if key in fields}
+    if update:
+        model.parameters = model.parameters.model_copy(update=update)
+    return model
+
+
+def _declared_types(spec: Any) -> set[str]:
+    """Return the JSON types a property schema declares."""
+    if not isinstance(spec, dict):
+        return set()
+    raw = spec.get("type")
+    if isinstance(raw, str):
+        return {raw}
+    if isinstance(raw, list):
+        return {item for item in raw if isinstance(item, str)}
+    return set()
+
+
+def _tolerant_schema(schema: dict[str, Any]) -> dict[str, Any]:
+    """Let a container property also arrive as the JSON text of that container.
+
+    A small model routinely fills a nested array into the tool call as a
+    string, which the transport would otherwise reject before we ever see the
+    payload. Only the accepted types widen, and only in the copy handed to the
+    provider; callers still validate against the strict schema they passed.
+    """
+
+    properties = schema.get("properties")
+    if not isinstance(properties, dict):
+        return schema
+    widened = {
+        name: {**spec, "type": sorted(types | {"string"})}
+        if (types := _declared_types(spec)) & _CONTAINER_TYPES
+        else spec
+        for name, spec in properties.items()
+    }
+    if widened == properties:
+        return schema
+    return {**schema, "properties": widened}
+
+
+def _decode_containers(
+    payload: dict[str, Any], schema: dict[str, Any]
+) -> dict[str, Any]:
+    """Undo the encoding ``_tolerant_schema`` allows, losslessly."""
+    properties = schema.get("properties")
+    if not isinstance(properties, dict):
+        return payload
+    decoded = dict(payload)
+    for name, spec in properties.items():
+        value = decoded.get(name)
+        types = _declared_types(spec)
+        if not isinstance(value, str) or not types & _CONTAINER_TYPES:
+            continue
+        try:
+            parsed = json.loads(value)
+        except ValueError:
+            continue
+        if isinstance(parsed, list | dict):
+            logger.info("decoded %s from a JSON string into a container", name)
+            decoded[name] = parsed
+    return decoded
+
+
+class StructuredLLM:
+    """Ask one chat model for a schema-conforming object, within a budget."""
+
+    def __init__(
+        self,
+        model: ChatModelBase,
+        *,
+        timeout: float,
+        attempts: int = DEFAULT_ATTEMPTS,
+        concurrency: int = 8,
+    ) -> None:
+        self.model = model
+        self.timeout = timeout
+        self.attempts = max(1, attempts)
+        self._semaphore = asyncio.Semaphore(max(1, concurrency))
+        self.failures = 0
+
+    async def complete(
+        self,
+        *,
+        system: str,
+        user: str,
+        schema: dict[str, Any],
+        schema_name: str,
+    ) -> dict[str, Any]:
+        """Return the parsed object, raising StructuredLLMError on failure."""
+
+        messages = [
+            SystemMsg(name="system", content=system),
+            UserMsg(name="user", content=user),
+        ]
+        async with self._semaphore:
+            last_error: Exception | None = None
+            for attempt in range(self.attempts):
+                try:
+                    return await self._call(messages, schema, schema_name)
+                # The transport is provider SDK code now, and a small model
+                # missing the schema is not an exception type worth naming:
+                # anything short of cancellation is one failed attempt.
+                except Exception as exc:  # noqa: BLE001
+                    last_error = exc
+                if attempt + 1 < self.attempts:
+                    # Temperature is zero, so asking the same question again
+                    # earns the same malformed answer; the model has to be told
+                    # what was rejected.
+                    messages = [
+                        *messages,
+                        UserMsg(
+                            name="user",
+                            content=_REPAIR_HINT.format(
+                                error=str(last_error)[:_ERROR_CHAR_CAP]
+                            ),
+                        ),
+                    ]
+                    await asyncio.sleep(
+                        _BACKOFF_BASE_SECONDS * (2**attempt) + random.random() * 0.1
+                    )
+            self.failures += 1
+            raise StructuredLLMError(
+                f"{schema_name} generation failed: {last_error}"
+            ) from last_error
+
+    async def _call(
+        self,
+        messages: list[Any],
+        schema: dict[str, Any],
+        schema_name: str,
+    ) -> dict[str, Any]:
+        """One attempt, capped by this step's own budget.
+
+        The model retries the calls its provider considers retryable, so the
+        cap is what keeps a stalled step from outliving the turn it belongs to.
+        """
+
+        response = await asyncio.wait_for(
+            self.model.generate_structured_output(
+                messages=messages,
+                structured_model=_tolerant_schema(schema),
+            ),
+            timeout=self.timeout,
+        )
+        payload = response.content
+        if not isinstance(payload, dict):
+            raise StructuredLLMError(f"{schema_name} response is not a JSON object")
+        return _decode_containers(payload, schema)
+
+
+__all__ = [
+    "StructuredLLM",
+    "StructuredLLMError",
+    "for_structured_calls",
+]

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/algo/biztrace/models.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/algo/biztrace/models.py
@@ -1,0 +1,286 @@
+# -*- coding: utf-8 -*-
+"""Data models for the BizTrace event stream and its Trace2Segment summaries."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel
+
+BizEventKind = Literal[
+    "user",
+    "assistant_text",
+    "assistant_thinking",
+    "hint",
+    "tool_use",
+    "tool_result",
+]
+BizEventStatus = Literal["done", "error"]
+BizChannel = Literal["main", "subagent"]
+CardType = Literal["user", "thinking", "text", "hint", "tool"]
+
+SegmentStatus = Literal["extracting", "done", "failed"]
+BoundaryReason = Literal[
+    "natural",
+    "TaskStateUpdate",
+    "PlanUpdate",
+    "user_message",
+    "ask_user_question",
+    "max_span",
+    "session_end",
+]
+ArtifactKind = Literal["query_script", "dataset", "report", "dashboard", "other"]
+ArtifactRole = Literal["intermediate", "final", "supporting"]
+# Host TaskStateUpdate states; pending never forces a segment boundary.
+SubtaskState = Literal["pending", "in_progress", "completed"]
+OrchestrationCategory = Literal["PlanCreate", "PlanUpdate", "TaskStateUpdate"]
+
+
+class Presentation(BaseModel):
+    """Backend-rendered card the frontend displays without protocol decisions."""
+
+    card_type: CardType
+    caption: str
+    body: str = ""
+
+
+class OrchestrationInfo(BaseModel):
+    """Structured semantics of an orchestration tool call; None elsewhere."""
+
+    category: OrchestrationCategory
+    subtask_state: SubtaskState | None = None
+    graph_id: str | None = None
+    node_id: str | None = None
+    node_name: str | None = None
+    summary: str | None = None
+
+
+class BizEvent(BaseModel):
+    """One persisted business event, written once per RawTrace event."""
+
+    event_id: str
+    kind: BizEventKind
+    channel: BizChannel = "main"
+    parent_msg_id: str | None = None
+    block_id: str | None = None
+    seq: int = 0
+
+    status: BizEventStatus = "done"
+
+    tool_name: str | None = None
+    input: Any = None
+    output: Any = None
+    content: str | None = None
+    source: str | None = None
+    orchestration: OrchestrationInfo | None = None
+    presentation: Presentation | None = None
+
+    started_at: float = 0.0
+    ended_at: float | None = None
+
+
+class FrontendEvent(BaseModel):
+    """Frontend contract: the keys ``Envelope.send_biz_event`` accepts.
+
+    The dump is splatted straight into ``BizEventRepository.upsert``, so an
+    extra field is a TypeError rather than a silently ignored one. Chat and
+    message level keys are absent by design: the Envelope owns that routing,
+    and the frontend aligns on ``block_id`` alone.
+    """
+
+    event_id: str
+    seq: int
+    channel: BizChannel
+    block_id: str | None
+    status: BizEventStatus
+    presentation: Presentation | None
+    started_at: float
+    ended_at: float | None
+
+    @classmethod
+    def of(cls, event: BizEvent) -> FrontendEvent:
+        return cls(
+            event_id=event.event_id,
+            seq=event.seq,
+            channel=event.channel,
+            block_id=event.block_id,
+            status=event.status,
+            presentation=event.presentation,
+            started_at=event.started_at,
+            ended_at=event.ended_at,
+        )
+
+
+class BizTrace(BaseModel):
+    """Read-side logical view of one session's business trace."""
+
+    session_id: str
+    events: list[BizEvent] = []
+
+    def public_events(self) -> list[BizEvent]:
+        """Externally visible view: sub-agent detail stays server-side."""
+        return [event for event in self.events if event.channel != "subagent"]
+
+    def frontend_events(self) -> list[FrontendEvent]:
+        return [FrontendEvent.of(event) for event in self.public_events()]
+
+    @classmethod
+    def from_rows(cls, rows: list[dict[str, Any]], *, session_id: str) -> BizTrace:
+        """Merge JSONL rows by event_id; the first row fixes seq and ordering."""
+        merged: dict[str, BizEvent] = {}
+        order: dict[str, int] = {}
+        for row in rows:
+            payload = row.get("event")
+            if not isinstance(payload, dict):
+                continue
+            event = BizEvent.model_validate(payload)
+            first = merged.get(event.event_id)
+            if first is not None:
+                event.seq = first.seq
+            else:
+                order[event.event_id] = event.seq
+            merged[event.event_id] = event
+        events = sorted(merged.values(), key=lambda e: order[e.event_id])
+        return cls(session_id=session_id, events=events)
+
+
+class Artifact(BaseModel):
+    """A file the segment saved to the workspace; verified to exist on disk.
+
+    ``kind`` and ``role`` are how the segmenter decides which files deserve a
+    card — a query script always does, another file only as a final product —
+    and stay on this side of the host boundary.
+    """
+
+    name: str
+    description: str
+    relative_path: str
+    kind: ArtifactKind = "other"
+    role: ArtifactRole = "supporting"
+
+
+class SubtaskScope(BaseModel):
+    """Plan task the segment belongs to, from TaskStateUpdate(in_progress)."""
+
+    node_id: str
+    node_name: str
+    # Host plan tools have no plan-graph id; kept optional for older rows.
+    graph_id: str | None = None
+
+
+class Coverage(BaseModel):
+    """BizTrace range a segment covers; the interval folds frontend cards."""
+
+    start_seq: int
+    end_seq: int
+    event_ids: list[str] = []
+
+
+class Segment(BaseModel):
+    segment_id: str
+    session_id: str
+    status: SegmentStatus = "extracting"
+
+    title: str | None = None
+    input: str | None = None
+    behavior: str | None = None
+    conclusion: str | None = None
+    artifact: list[Artifact] | None = None
+
+    coverage: Coverage
+    subtask: SubtaskScope | None = None
+    boundary_reason: BoundaryReason
+    forced_complete: bool = False
+
+    started_at: float | None = None
+    ended_at: float | None = None
+    created_at: str = ""
+    updated_at: str = ""
+
+
+class FrontendCoverage(BaseModel):
+    """Frontend folding key: the seq interval only."""
+
+    start_seq: int
+    end_seq: int
+
+
+class FrontendArtifact(BaseModel):
+    """Artifact contract the host stores: a name, a caption and a path.
+
+    ``kind`` and ``role`` are left behind on purpose — they are how the
+    segmenter picked these files, not something the host or the frontend acts
+    on, and the host's segment schema rejects fields it does not know.
+    """
+
+    name: str
+    description: str
+    relative_path: str
+
+
+class FrontendSegment(BaseModel):
+    """Frontend contract, projected from done segments only."""
+
+    segment_id: str
+    title: str
+    input: str | None
+    behavior: str
+    conclusion: str
+    artifact: list[FrontendArtifact] | None
+    coverage: FrontendCoverage
+    started_at: float | None
+    ended_at: float | None
+
+    @classmethod
+    def of(cls, segment: Segment) -> FrontendSegment | None:
+        """Project a done segment; extracting / failed ones are not delivered."""
+        if segment.status != "done":
+            return None
+        artifacts = [
+            FrontendArtifact(
+                name=item.name,
+                description=item.description,
+                relative_path=item.relative_path,
+            )
+            for item in segment.artifact or ()
+        ]
+        return cls(
+            segment_id=segment.segment_id,
+            title=segment.title or "",
+            input=segment.input,
+            behavior=segment.behavior or "",
+            conclusion=segment.conclusion or "",
+            artifact=artifacts or None,
+            coverage=FrontendCoverage(
+                start_seq=segment.coverage.start_seq,
+                end_seq=segment.coverage.end_seq,
+            ),
+            started_at=segment.started_at,
+            ended_at=segment.ended_at,
+        )
+
+
+__all__ = [
+    "Artifact",
+    "ArtifactKind",
+    "ArtifactRole",
+    "BizChannel",
+    "BizEvent",
+    "BizEventKind",
+    "BizEventStatus",
+    "BizTrace",
+    "BoundaryReason",
+    "CardType",
+    "Coverage",
+    "FrontendArtifact",
+    "FrontendCoverage",
+    "FrontendEvent",
+    "FrontendSegment",
+    "OrchestrationCategory",
+    "OrchestrationInfo",
+    "Presentation",
+    "Segment",
+    "SegmentStatus",
+    "SubtaskScope",
+    "SubtaskState",
+]

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/algo/biztrace/pipeline.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/algo/biztrace/pipeline.py
@@ -1,0 +1,394 @@
+# -*- coding: utf-8 -*-
+"""One BizTrace + Trace2Segment pipeline per Chat.
+
+The pipeline owns everything the algorithm side needs for a single run: the
+converter, the segment assembler, their models and the JSONL store. The host
+only calls ``on_trace_event`` for every raw event, and ``aclose`` once the run
+ends.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, Any
+
+from qwenpaw_data.host.core.algo.biztrace.converter import BizTraceConverter
+from qwenpaw_data.host.core.algo.biztrace.linking import build_linker
+from qwenpaw_data.host.core.algo.biztrace.llm import StructuredLLM
+from qwenpaw_data.host.core.algo.biztrace.models import (
+    BizEvent,
+    FrontendEvent,
+    FrontendSegment,
+    Segment,
+)
+from qwenpaw_data.host.core.algo.biztrace.presentation import Linker, PresentationBuilder
+from qwenpaw_data.host.core.algo.biztrace.segmentation import (
+    ContinuityJudge,
+    SegmentAssembler,
+    SegmentExtractor,
+)
+from qwenpaw_data.host.core.algo.biztrace.settings import (
+    EXTRACT_TIMEOUT_SECONDS,
+    FLUSH_BUDGET_SECONDS,
+    JUDGE_TIMEOUT_SECONDS,
+    PRESENTATION_TIMEOUT_SECONDS,
+    SEGMENT_QUEUE_SIZE,
+    BizTraceSettings,
+)
+from qwenpaw_data.host.core.algo.biztrace.store import BizTraceStore, build_store_paths
+from qwenpaw_data.host.core.algo.biztrace.workspace_index import (
+    ArtifactVerifier,
+    WorkspaceLister,
+)
+
+if TYPE_CHECKING:
+    from agentscope.model import ChatModelBase
+
+logger = logging.getLogger(__name__)
+
+BizEventCallback = Callable[[dict[str, Any]], Awaitable[None]]
+SegmentCallback = Callable[[dict[str, Any]], Awaitable[None]]
+
+
+class ArtifactFileIndex:
+    """Pair host ``artifact_delta`` batches with the next tool_result seq.
+
+    Host order is delta then ``TOOL_RESULT_END``. Pending files are bound to
+    that call id at enqueue time (before conversion assigns a seq), then stamped
+    with the result seq when the BizEvent is written. Productions are kept as a
+    list so a later rewrite does not hide an earlier segment's candidates.
+    """
+
+    def __init__(self) -> None:
+        self._pending: dict[str, str] = {}
+        self._by_call: dict[str, dict[str, str]] = {}
+        self._files: list[tuple[str, str, int]] = []
+
+    def note_delta(self, files: dict[str, Any]) -> None:
+        for name, path in files.items():
+            if name and path:
+                self._pending[str(name)] = str(path)
+
+    def bind_pending(self, tool_call_id: str) -> None:
+        if not tool_call_id or not self._pending:
+            return
+        self._by_call[tool_call_id] = self._pending
+        self._pending = {}
+
+    def assign_seq(self, tool_call_id: str | None, seq: int) -> None:
+        if not tool_call_id:
+            return
+        files = self._by_call.pop(tool_call_id, None)
+        if not files:
+            return
+        for name, path in files.items():
+            self._files.append((name, path, seq))
+
+    def files_in(self, start_seq: int, end_seq: int) -> dict[str, str]:
+        out: dict[str, str] = {}
+        for name, path, seq in self._files:
+            if start_seq <= seq <= end_seq:
+                out[name] = path
+        return out
+
+
+def _tool_result_call_id(payload: dict[str, Any]) -> str | None:
+    evt_type = payload.get("type")
+    if hasattr(evt_type, "value"):
+        evt_type = evt_type.value
+    if evt_type != "TOOL_RESULT_END":
+        return None
+    call_id = str(payload.get("tool_call_id") or "").strip()
+    return call_id or None
+
+
+class BizTracePipeline:
+    """Wire a converter and an assembler onto one Chat's raw event flow."""
+
+    def __init__(
+        self,
+        *,
+        session_id: str,
+        store: BizTraceStore,
+        presenter: PresentationBuilder,
+        settings: BizTraceSettings,
+        judge_llm: StructuredLLM | None = None,
+        extract_llm: StructuredLLM | None = None,
+        lister: WorkspaceLister | None = None,
+        linker: Linker | None = None,
+        biz_event_callback: BizEventCallback | None = None,
+        segment_callback: SegmentCallback | None = None,
+    ) -> None:
+        self.session_id = session_id
+        self.store = store
+        self.settings = settings
+        self.biz_event_callback = biz_event_callback
+        self.segment_callback = segment_callback
+        self._artifacts = ArtifactFileIndex()
+
+        self.converter = BizTraceConverter(
+            presenter=presenter,
+            on_row=self._write_event,
+            on_event=self._forward_event,
+            lang=settings.segment_prompt_lang,
+        )
+        self.assembler = (
+            self._build_assembler(
+                judge_llm=judge_llm,
+                extract_llm=extract_llm,
+                lister=lister,
+                linker=linker,
+            )
+            if settings.trace2segment_enabled
+            else None
+        )
+
+        self._segments: asyncio.Queue[BizEvent | None] = asyncio.Queue(
+            maxsize=SEGMENT_QUEUE_SIZE
+        )
+        self._segment_worker: asyncio.Task[None] | None = None
+        self._closed = False
+
+    def _build_assembler(
+        self,
+        *,
+        judge_llm: StructuredLLM | None,
+        extract_llm: StructuredLLM | None,
+        lister: WorkspaceLister | None,
+        linker: Linker | None,
+    ) -> SegmentAssembler:
+        return SegmentAssembler(
+            session_id=self.session_id,
+            judge=ContinuityJudge(
+                llm=judge_llm, lang=self.settings.segment_prompt_lang
+            ),
+            extractor=SegmentExtractor(
+                llm=extract_llm,
+                lang=self.settings.segment_prompt_lang,
+                verifier=ArtifactVerifier(lister),
+                linker=linker,
+            ),
+            on_row=self._write_segment,
+            on_segment=self._publish_segment,
+            on_judge_log=self.store.append_judge,
+            max_span=self.settings.segment_max_span,
+            concurrency=self.settings.segment_extract_concurrency,
+            artifact_files=self.agent_files,
+        )
+
+    # -- lifecycle --------------------------------------------------------- #
+
+    def start(self) -> None:
+        """Spin up the converter workers and the segmentation worker."""
+        self.converter.start()
+        if self.assembler is not None and self._segment_worker is None:
+            self._segment_worker = asyncio.create_task(self._segment_loop())
+
+    def agent_files(self, start_seq: int, end_seq: int) -> dict[str, str]:
+        """Files whose producing tool_result seq falls in ``[start_seq, end_seq]``."""
+        return self._artifacts.files_in(start_seq, end_seq)
+
+    def on_trace_event(self, entry: dict[str, Any]) -> None:
+        """Algorithm entry point: take one raw entry, never block, never raise."""
+        kind = entry.get("kind")
+        if kind == "artifact_delta":
+            files = (entry.get("payload") or {}).get("files") or {}
+            if isinstance(files, dict):
+                self._artifacts.note_delta(files)
+            return
+        if kind == "agent_event":
+            payload = entry.get("payload")
+            if isinstance(payload, dict):
+                call_id = _tool_result_call_id(payload)
+                if call_id is not None:
+                    self._artifacts.bind_pending(call_id)
+        self.converter.enqueue(entry)
+
+    async def aclose(self) -> None:
+        """Flush conversion first, then segmentation.
+
+        Nothing to close after that: the model opens its provider client per
+        call, so the pipeline holds no connection of its own.
+        """
+
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            await self.converter.aclose()
+        except Exception:
+            logger.exception("BizTrace conversion failed to flush")
+        await self._close_segments()
+
+    async def _close_segments(self) -> None:
+        if self.assembler is None:
+            return
+        self._segments.put_nowait(None)
+        if self._segment_worker is not None:
+            await self._segment_worker
+            self._segment_worker = None
+        try:
+            await self.assembler.aclose(budget=FLUSH_BUDGET_SECONDS)
+        except Exception:
+            logger.exception("Trace2Segment failed to flush")
+
+    # -- sinks ------------------------------------------------------------- #
+
+    async def _write_event(self, event: BizEvent) -> None:
+        """Persist one row, then hand the frontend projection to the host."""
+        if event.kind == "tool_result":
+            self._artifacts.assign_seq(event.block_id, event.seq)
+        await self.store.append_event(
+            seq=event.seq, event=event.model_dump(mode="json")
+        )
+        # Sub-agent rows stay server-side: they are detail of the spawning call.
+        if self.biz_event_callback is None or event.channel == "subagent":
+            return
+        try:
+            await self.biz_event_callback(
+                FrontendEvent.of(event).model_dump(mode="json")
+            )
+        except Exception:
+            logger.exception("biz_event_callback failed for %s", event.event_id)
+
+    async def _forward_event(self, event: BizEvent) -> None:
+        """Queue an emitted event for segmentation.
+
+        Segmentation sits behind its own queue so its judgement calls can never
+        stall the BizEvent writer.
+        """
+
+        if self.assembler is None:
+            return
+        try:
+            self._segments.put_nowait(event)
+        except asyncio.QueueFull:
+            logger.warning("segmentation queue is full; dropped %s", event.event_id)
+
+    async def _write_segment(self, segment: Segment) -> None:
+        await self.store.append_segment(
+            seq=segment.coverage.start_seq,
+            segment=segment.model_dump(mode="json"),
+        )
+
+    async def _publish_segment(self, segment: Segment) -> None:
+        """Deliver a finished summary; placeholder rows are never published."""
+        projection = FrontendSegment.of(segment)
+        if self.segment_callback is None or projection is None:
+            return
+        try:
+            await self.segment_callback(projection.model_dump(mode="json"))
+        except Exception:
+            logger.exception(
+                "segment_finish_callback failed for %s", segment.segment_id
+            )
+
+    async def _segment_loop(self) -> None:
+        assembler = self.assembler
+        if assembler is None:
+            return
+        while True:
+            event = await self._segments.get()
+            if event is None:
+                return
+            try:
+                await assembler.feed(event)
+            except Exception:
+                logger.exception("Trace2Segment failed on %s", event.event_id)
+
+
+def build_pipeline(
+    *,
+    session_id: str,
+    datasource_id: str | None = None,
+    access_token: str | None = None,
+    biz_event_callback: BizEventCallback | None = None,
+    segment_callback: SegmentCallback | None = None,
+    settings: BizTraceSettings | None = None,
+    lister: WorkspaceLister | None = None,
+    chat_model: ChatModelBase | None = None,
+) -> BizTracePipeline | None:
+    """Assemble a started pipeline, or None when BizTrace is switched off.
+
+    Synchronous: the Transformer's ``start`` must return fast, so nothing here
+    waits on I/O. The vocabulary fetch and every model call happen later, on
+    the pipeline's own workers.
+    """
+
+    config = settings if settings is not None else BizTraceSettings()
+    if not config.biz_trace_enabled:
+        return None
+
+    if chat_model is None:
+        logger.warning("No LLM configured for BizTrace; using rule-based cards only")
+
+    # One linker for cards and segments alike: they share its vocabulary cache
+    # and TTL refresh, and the feature switch turns both off together.
+    linker = _linker(
+        config,
+        datasource_id=datasource_id,
+        access_token=access_token,
+    )
+    presenter = PresentationBuilder(
+        llm=_client(chat_model, timeout=PRESENTATION_TIMEOUT_SECONDS),
+        lang=config.segment_prompt_lang,
+        linker=linker,
+    )
+    pipeline = BizTracePipeline(
+        session_id=session_id,
+        store=BizTraceStore(
+            build_store_paths(session_id=session_id, log_dir=config.biz_trace_log_dir)
+        ),
+        presenter=presenter,
+        settings=config,
+        judge_llm=_client(chat_model, timeout=JUDGE_TIMEOUT_SECONDS),
+        extract_llm=_client(chat_model, timeout=EXTRACT_TIMEOUT_SECONDS),
+        lister=lister,
+        linker=linker,
+        biz_event_callback=biz_event_callback,
+        segment_callback=segment_callback,
+    )
+    pipeline.start()
+    return pipeline
+
+
+def _client(model: ChatModelBase | None, *, timeout: float) -> StructuredLLM | None:
+    """Give one step its own budget on the model every step shares.
+
+    A caption and a segment summary are not the same size of job, so the
+    timeout is all that differs. None all the way through: a run without a
+    model leaves every step on its rule-based path rather than failing the turn.
+    """
+
+    if model is None:
+        return None
+    return StructuredLLM(model, timeout=timeout)
+
+
+def _linker(
+    settings: BizTraceSettings,
+    *,
+    datasource_id: str | None,
+    access_token: str | None = None,
+) -> Linker | None:
+    try:
+        linker = build_linker(
+            settings,
+            datasource_id=datasource_id,
+            access_token=access_token,
+        )
+    except Exception:
+        logger.exception("Entity linking vocabulary is unavailable")
+        return None
+    return linker.link if linker is not None else None
+
+
+__all__ = [
+    "ArtifactFileIndex",
+    "BizEventCallback",
+    "BizTracePipeline",
+    "SegmentCallback",
+    "build_pipeline",
+]

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/algo/biztrace/presentation.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/algo/biztrace/presentation.py
@@ -1,0 +1,611 @@
+# -*- coding: utf-8 -*-
+"""Presentation cards for BizEvents.
+
+A tool call and its result are separate events, so they get separate cards: the
+call card carries the caption, what the tool does and its input description; the
+result card reuses that caption and describes the output, reading the call card
+as the context the output answers.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from qwenpaw_data.host.core.algo.biztrace.formatting import (
+    compact,
+    first_str,
+    join_sections,
+    output_text,
+    truncate,
+)
+from qwenpaw_data.host.core.algo.biztrace.llm import StructuredLLM, StructuredLLMError
+from qwenpaw_data.host.core.algo.biztrace.models import BizEvent, Presentation
+from qwenpaw_data.host.core.algo.biztrace.prompts import (
+    DEFAULT_PROMPT_LANG,
+    PresentationTask,
+    PromptLang,
+    build_presentation_summary_prompt,
+    build_tool_output_prompt,
+    build_tool_running_prompt,
+    get_presentation_system_prompt,
+    get_thinking_presentation_system_prompt,
+    get_tool_output_presentation_system_prompt,
+    get_tool_presentation_system_prompt,
+)
+from qwenpaw_data.host.core.algo.biztrace.tools import (
+    NOTE_ONLY_RESULT_TOOLS,
+    PLAN_SUMMARY_TOOLS,
+    SKILL_VIEWER,
+    SPAWN_SUBAGENT,
+    canonical_tool_name,
+)
+from qwenpaw_data.host.core.utils.skill import discover_builtin_skills
+
+logger = logging.getLogger(__name__)
+
+DESCRIPTION_CHAR_CAP = 200
+SUMMARY_SOURCE_CAP = 4_000
+THINKING_CHAR_CAP = 2_000
+THINKING_SOURCE_CAP = 130_000
+TOOL_PAYLOAD_CAP = 2_000
+HINT_BODY_CAP = 4_000
+
+_SKILL_PATH_RE = re.compile(r"(?:^|/)skills/([^/]+)/SKILL\.md$")
+_FRONTMATTER_RE = re.compile(r"\A---\s*\n(.*?)\n---\s*(?:\n|\Z)", re.DOTALL)
+_DESCRIPTION_RE = re.compile(
+    r"^description:\s*(.*?)(?=^\w[\w-]*:|\Z)", re.MULTILINE | re.DOTALL
+)
+
+_FILE_PATH_KEYS = ("file_path", "path", "filename", "target_file")
+
+CAPTIONS: dict[str, dict[str, str]] = {
+    "zh": {
+        "user": "用户输入",
+        "thinking": "模型思考",
+        "text": "模型回复",
+        "hint": "用户引导",
+        "read_file": "读取文件",
+        "read_skill": "读取「{name}」技能",
+        "PlanCreate": "创建计划",
+        "PlanUpdate": "修改计划",
+        "TaskStateUpdate": "更新子任务状态",
+        "spawn_subagent": "发起「{name}」Sub-Agent",
+        "fallback": "调用 {name}",
+        "skill_body": "## 技能描述\n\n{description}",
+        "path_body": "## 文件路径\n\n{path}",
+        "input_heading": "## Input",
+        "output_heading": "## Output",
+        "source_heading": "## 来源",
+        "TaskStateUpdate_body": "将子任务「{node}」的状态更新为 {state}。",
+        "TaskStateUpdate_body_plain": "更新计划中子任务的执行状态。",
+        "subagent_unknown": "子",
+        "done_note": "调用完成。",
+        "failed_note": "调用失败。",
+        "unclosed_note": "工具未正常结束。",
+        "interrupted_note": "调用被用户打断。",
+        "denied_note": "调用被拒绝执行。",
+    },
+    "en": {
+        "user": "User input",
+        "thinking": "Model thinking",
+        "text": "Model reply",
+        "hint": "User guidance",
+        "read_file": "Read file",
+        "read_skill": 'Load the "{name}" skill',
+        "PlanCreate": "Create plan",
+        "PlanUpdate": "Revise plan",
+        "TaskStateUpdate": "Update sub-task state",
+        "spawn_subagent": 'Spawn the "{name}" sub-agent',
+        "fallback": "Call {name}",
+        "skill_body": "## Skill description\n\n{description}",
+        "path_body": "## File path\n\n{path}",
+        "input_heading": "## Input",
+        "output_heading": "## Output",
+        "source_heading": "## Source",
+        "TaskStateUpdate_body": 'Sets sub-task "{node}" to {state}.',
+        "TaskStateUpdate_body_plain": "Updates a plan sub-task's execution state.",
+        "subagent_unknown": "sub",
+        "done_note": "The call completed.",
+        "failed_note": "The call failed.",
+        "unclosed_note": "The tool never finished.",
+        "interrupted_note": "The call was interrupted by the user.",
+        "denied_note": "The call was denied.",
+    },
+}
+
+_SUMMARY_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "additionalProperties": False,
+    "properties": {"body": {"type": "string"}},
+    "required": ["body"],
+}
+
+_TOOL_RUNNING_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "additionalProperties": False,
+    "properties": {
+        "caption": {"type": "string"},
+        "purpose": {"type": "string"},
+        "input_summary": {"type": "string"},
+    },
+    "required": ["caption", "purpose", "input_summary"],
+}
+
+_TOOL_OUTPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "additionalProperties": False,
+    "properties": {"output_summary": {"type": "string"}},
+    "required": ["output_summary"],
+}
+
+Linker = Callable[[str], str]
+
+
+class PresentationBuilder:
+    """Build the card for each BizEvent; never returns None.
+
+    An in-process cache collapses repeated identical requests, which matters
+    for sub-agent chunk streams that re-emit the same reasoning segment.
+    """
+
+    def __init__(
+        self,
+        *,
+        llm: StructuredLLM | None = None,
+        lang: PromptLang = DEFAULT_PROMPT_LANG,
+        linker: Linker | None = None,
+    ) -> None:
+        self.llm = llm
+        self.lang = lang
+        self.words = CAPTIONS["en" if lang == "en" else "zh"]
+        self.linker = linker
+        self.cache: dict[tuple[Any, ...], dict[str, Any]] = {}
+        self.llm_calls = 0
+        self.llm_failures = 0
+        self.cache_hits = 0
+
+    async def build(
+        self,
+        event: BizEvent,
+        *,
+        call_card: Presentation | None = None,
+        note: str | None = None,
+        hint: Any = None,
+    ) -> Presentation:
+        """Return the card for ``event``.
+
+        Args:
+            event: The event being emitted.
+            call_card: The call card, when emitting a tool result event.
+            note: Appended verbatim to the body, used for reconciliation and
+                for non-error terminal states the frontend must still see.
+            hint: Raw HintBlock payload, for ``kind == "hint"`` only.
+        """
+
+        card = await self._build(event, call_card, hint)
+        if note:
+            card = card.model_copy(update={"body": f"{card.body}\n\n{note}".strip()})
+        return self._link(card)
+
+    async def _build(
+        self,
+        event: BizEvent,
+        call_card: Presentation | None,
+        hint: Any,
+    ) -> Presentation:
+        if event.kind == "user":
+            return Presentation(
+                card_type="user",
+                caption=self.words["user"],
+                body=event.content or "",
+            )
+        if event.kind == "assistant_thinking":
+            return await self._thinking_card(event.content)
+        if event.kind == "assistant_text":
+            return self._text_card(event.content)
+        if event.kind == "hint":
+            return self._hint_card(event, hint)
+        if event.kind == "tool_result":
+            return await self._tool_result_card(event, call_card)
+        return await self._tool_call_card(event)
+
+    def _link(self, card: Presentation) -> Presentation:
+        """Inject entity links into the body; captions stay untouched."""
+        if self.linker is None or not card.body:
+            return card
+        try:
+            linked = self.linker(card.body)
+        except Exception:
+            logger.exception("Entity linking failed; emitting the raw body")
+            return card
+        if linked == card.body:
+            return card
+        return card.model_copy(update={"body": linked})
+
+    # -- text cards -------------------------------------------------------- #
+
+    def _text_card(self, content: str | None) -> Presentation:
+        """Reply cards keep the model text as-is; no LLM summary."""
+        return Presentation(
+            card_type="text",
+            caption=self.words["text"],
+            body=content or "",
+        )
+
+    async def _thinking_card(self, content: str | None) -> Presentation:
+        source = content or ""
+        body = await self._summarize(
+            "thinking",
+            source,
+            source_cap=THINKING_SOURCE_CAP,
+            system=get_thinking_presentation_system_prompt(self.lang),
+        ) or truncate(source, THINKING_CHAR_CAP)
+        return Presentation(
+            card_type="thinking",
+            caption=self.words["thinking"],
+            body=body,
+        )
+
+    async def _summarize(
+        self,
+        task: PresentationTask,
+        content: str,
+        *,
+        source_cap: int = SUMMARY_SOURCE_CAP,
+        system: str | None = None,
+    ) -> str | None:
+        source = content.strip()
+        if not source or self.llm is None:
+            return None
+        clipped = source[:source_cap]
+        data = await self._call(
+            ("summary", task, clipped),
+            system=system or get_presentation_system_prompt(self.lang),
+            user=build_presentation_summary_prompt(
+                task=task, content=clipped, lang=self.lang
+            ),
+            schema_name="presentation_body",
+            schema=_SUMMARY_SCHEMA,
+        )
+        body = str(data.get("body") or "").strip() if data else ""
+        return body or None
+
+    def _hint_card(self, event: BizEvent, hint: Any) -> Presentation:
+        """Fill the guidance card by rule; hints never reach the LLM."""
+        body = truncate(self._hint_body(event, hint), HINT_BODY_CAP)
+        if event.source:
+            body = join_sections(
+                body, self.words["source_heading"], event.source.strip()
+            )
+        return Presentation(
+            card_type="hint", caption=self.words["hint"], body=body
+        )
+
+    def _hint_body(self, event: BizEvent, hint: Any) -> str:
+        if isinstance(hint, str):
+            return hint
+        if isinstance(hint, list):
+            return "\n\n".join(
+                part for part in (_hint_block(block) for block in hint) if part
+            )
+        return event.content or ""
+
+    # -- tool cards -------------------------------------------------------- #
+
+    async def _tool_call_card(self, event: BizEvent) -> Presentation:
+        tool = canonical_tool_name(event.tool_name) or "unknown_tool"
+        if tool == "read_file":
+            return self._read_file_card(event)
+        if tool == SKILL_VIEWER:
+            return self._skill_viewer_card(event)
+        if tool == "TaskStateUpdate":
+            return self._subtask_card(event)
+        if tool in PLAN_SUMMARY_TOOLS:
+            return await self._plan_card(event, tool)
+        if tool == SPAWN_SUBAGENT:
+            return await self._subagent_card(event)
+        return await self._fallback_call_card(event, tool)
+
+    def _read_file_card(self, event: BizEvent) -> Presentation:
+        path = first_str(event.input, _FILE_PATH_KEYS)
+        skill = _skill_name(path)
+        if skill:
+            # The description lives in the file body, so it lands on the result.
+            return self._skill_call_card(skill)
+        return Presentation(
+            card_type="tool",
+            caption=self.words["read_file"],
+            body=self.words["path_body"].format(path=path or "-"),
+        )
+
+    def _skill_viewer_card(self, event: BizEvent) -> Presentation:
+        """Same card shape as reading ``skills/<name>/SKILL.md`` via read_file."""
+        name = first_str(event.input, ("skill", "name")) or "-"
+        return self._skill_call_card(name)
+
+    def _skill_call_card(self, name: str) -> Presentation:
+        return Presentation(
+            card_type="tool",
+            caption=self.words["read_skill"].format(name=name),
+            body="",
+        )
+
+    def _subtask_card(self, event: BizEvent) -> Presentation:
+        info = event.orchestration
+        if info is None or not (info.node_name or info.node_id):
+            body = self.words["TaskStateUpdate_body_plain"]
+        else:
+            body = self.words["TaskStateUpdate_body"].format(
+                node=info.node_name or info.node_id,
+                state=info.subtask_state or "-",
+            )
+        return Presentation(
+            card_type="tool", caption=self.words["TaskStateUpdate"], body=body
+        )
+
+    async def _plan_card(self, event: BizEvent, tool: str) -> Presentation:
+        task: PresentationTask = "PlanCreate" if tool == "PlanCreate" else "PlanUpdate"
+        payload = compact(event.input)
+        body = await self._summarize(task, payload) or truncate(
+            payload, DESCRIPTION_CHAR_CAP
+        )
+        return Presentation(card_type="tool", caption=self.words[tool], body=body)
+
+    async def _subagent_card(self, event: BizEvent) -> Presentation:
+        role = first_str(event.input, ("role", "name", "agent_name"))
+        payload = compact(event.input)
+        body = await self._summarize("spawn_subagent", payload) or truncate(
+            payload, DESCRIPTION_CHAR_CAP
+        )
+        return Presentation(
+            card_type="tool",
+            caption=self.words["spawn_subagent"].format(
+                name=role or self.words["subagent_unknown"]
+            ),
+            body=body,
+        )
+
+    async def _fallback_call_card(
+        self, event: BizEvent, tool: str
+    ) -> Presentation:
+        payload = compact(event.input)[:TOOL_PAYLOAD_CAP]
+        data = await self._call(
+            ("tool_running", tool, payload),
+            system=get_tool_presentation_system_prompt(self.lang),
+            user=build_tool_running_prompt(
+                tool_name=tool, tool_input=payload, lang=self.lang
+            ),
+            schema_name="tool_presentation",
+            schema=_TOOL_RUNNING_SCHEMA,
+        )
+        if data:
+            caption = str(data.get("caption") or "").strip()
+            purpose = str(data.get("purpose") or "").strip()
+            input_summary = str(data.get("input_summary") or "").strip()
+        else:
+            caption = purpose = input_summary = ""
+        return Presentation(
+            card_type="tool",
+            caption=caption or self.words["fallback"].format(name=tool),
+            body=join_sections(
+                truncate(purpose, DESCRIPTION_CHAR_CAP),
+                self.words["input_heading"],
+                truncate(input_summary or payload, DESCRIPTION_CHAR_CAP),
+            ),
+        )
+
+    async def _tool_result_card(
+        self, event: BizEvent, call_card: Presentation | None
+    ) -> Presentation:
+        """Describe one result, using its call card as the context it answers."""
+        tool = canonical_tool_name(event.tool_name) or "unknown_tool"
+        caption = (
+            call_card.caption
+            if call_card is not None
+            else self.words["fallback"].format(name=tool)
+        )
+        failed = event.status == "error"
+        if tool in ("read_file", SKILL_VIEWER):
+            body = self._skill_result_body(event, failed)
+        elif tool in NOTE_ONLY_RESULT_TOOLS:
+            body = self.words["failed_note" if failed else "done_note"]
+        else:
+            body = await self._output_summary(event, tool, caption, call_card, failed)
+        return Presentation(card_type="tool", caption=caption, body=body)
+
+    def _skill_result_body(self, event: BizEvent, failed: bool) -> str:
+        """Build the skill card body from frontmatter or a local skill lookup.
+
+        ``read_file`` of ``SKILL.md`` still carries YAML frontmatter in the
+        tool output. AgentScope's ``Skill`` viewer returns body-only markdown
+        (``Skill.markdown``), so its description is recovered from the shipped
+        skill files by the name in ``event.input``.
+        """
+        description = _skill_description(output_text(event.output))
+        if description is None:
+            name = first_str(event.input, ("skill", "name"))
+            description = _lookup_skill_description(name) if name else None
+        if description is None:
+            return self.words["failed_note" if failed else "done_note"]
+        return self.words["skill_body"].format(description=description)
+
+    async def _output_summary(
+        self,
+        event: BizEvent,
+        tool: str,
+        caption: str,
+        call_card: Presentation | None,
+        failed: bool,
+    ) -> str:
+        payload = output_text(event.output)[:TOOL_PAYLOAD_CAP]
+        context = call_card.body if call_card is not None else ""
+        data = await self._call(
+            ("tool_output", tool, context, payload, failed),
+            system=get_tool_output_presentation_system_prompt(self.lang),
+            user=build_tool_output_prompt(
+                tool_name=tool,
+                purpose=caption,
+                call_context=context,
+                tool_output=payload,
+                failed=failed,
+                lang=self.lang,
+            ),
+            schema_name="tool_output_presentation",
+            schema=_TOOL_OUTPUT_SCHEMA,
+        )
+        summary = str(data.get("output_summary") or "").strip() if data else ""
+        summary = _clean_output_summary(summary) or payload
+        if not summary:
+            return self.words["failed_note" if failed else "done_note"]
+        return join_sections(
+            self.words["output_heading"], truncate(summary, DESCRIPTION_CHAR_CAP)
+        )
+
+    # -- LLM plumbing ------------------------------------------------------ #
+
+    async def _call(
+        self,
+        cache_key: tuple[Any, ...],
+        *,
+        system: str,
+        user: str,
+        schema_name: str,
+        schema: dict[str, Any],
+    ) -> dict[str, Any] | None:
+        cached = self.cache.get(cache_key)
+        if cached is not None:
+            self.cache_hits += 1
+            return cached
+        if self.llm is None:
+            return None
+        self.llm_calls += 1
+        try:
+            data = await self.llm.complete(
+                system=system,
+                user=user,
+                schema_name=schema_name,
+                schema=schema,
+            )
+        except StructuredLLMError as exc:
+            self.llm_failures += 1
+            logger.warning(
+                "presentation %s fell back to template: %s", schema_name, exc
+            )
+            return None
+        self.cache[cache_key] = data
+        return data
+
+
+def _hint_block(block: Any) -> str:
+    """Render one hint block; binary payloads become a link, never base64."""
+    if isinstance(block, str):
+        return block
+    if not isinstance(block, dict):
+        return str(block)
+    if block.get("type") == "text":
+        text = block.get("text")
+        return text if isinstance(text, str) else ""
+    source = block.get("source")
+    source = source if isinstance(source, dict) else {}
+    media_type = str(source.get("media_type") or block.get("media_type") or "data")
+    url = source.get("url")
+    if isinstance(url, str) and url:
+        return f"[{media_type}]({url})"
+    name = block.get("name")
+    label = f"{media_type} · {name}" if name else media_type
+    return f"`[{label}]`"
+
+
+# Models sometimes dump the call-card schema back into output_summary.
+_ECHOED_CARD_FIELD_RE = re.compile(
+    r"^(卡片小标题|目的|输入摘要|输出摘要|caption|purpose|input_summary|"
+    r"output_summary)\s*[:：]\s*(.*)$",
+    re.IGNORECASE,
+)
+
+
+def _clean_output_summary(summary: str) -> str:
+    """Drop echoed call-card fields if the model stuffed them into the summary."""
+    text = summary.strip()
+    if not text or "：" not in text and ":" not in text:
+        return text
+
+    preferred: str | None = None
+    kept: list[str] = []
+    saw_label = False
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        match = _ECHOED_CARD_FIELD_RE.match(stripped)
+        if match is None:
+            kept.append(stripped)
+            continue
+        saw_label = True
+        label, value = match.group(1), match.group(2).strip()
+        if label.lower() in {"输出摘要", "output_summary"} and value:
+            preferred = value
+    if preferred:
+        return preferred
+    if saw_label:
+        return "\n".join(kept).strip()
+    return text
+
+
+def _skill_name(path: str | None) -> str | None:
+    """Return the skill name when a read targets ``skills/<name>/SKILL.md``."""
+    if not path:
+        return None
+    match = _SKILL_PATH_RE.search(path.replace("\\", "/"))
+    return match.group(1) if match else None
+
+
+def _skill_description(text: str) -> str | None:
+    """Pull ``description`` out of a SKILL.md YAML frontmatter block."""
+    front = _FRONTMATTER_RE.match(text)
+    if not front:
+        return None
+    match = _DESCRIPTION_RE.search(front.group(1))
+    if not match:
+        return None
+    description = " ".join(match.group(1).split())
+    return description or None
+
+
+_NAME_RE = re.compile(r"^name:\s*(.+)$", re.MULTILINE)
+_skill_description_by_name: dict[str, str] | None = None
+
+
+def _skill_description_index() -> dict[str, str]:
+    """Map skill folder / frontmatter names to their SKILL.md descriptions."""
+    global _skill_description_by_name
+    if _skill_description_by_name is not None:
+        return _skill_description_by_name
+    index: dict[str, str] = {}
+    for skill in discover_builtin_skills():
+        description = skill.description.strip() or None
+        if description is None:
+            continue
+        # Keep one-line card text consistent with previous frontmatter parsing.
+        index[skill.name] = description
+        index[skill.src_dir.name] = description
+    _skill_description_by_name = index
+    return index
+
+
+def _lookup_skill_description(name: str) -> str | None:
+    """Resolve a skill description when the tool result has no frontmatter."""
+    return _skill_description_index().get(name)
+
+
+__all__ = [
+    "CAPTIONS",
+    "DESCRIPTION_CHAR_CAP",
+    "THINKING_CHAR_CAP",
+    "Linker",
+    "PresentationBuilder",
+]

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/algo/biztrace/prompts.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/algo/biztrace/prompts.py
@@ -1,0 +1,686 @@
+# -*- coding: utf-8 -*-
+"""Prompts for presentation cards and the two Trace2Segment judge steps.
+
+The response object is never described here. Every call goes out as a forced
+tool call whose parameters *are* the JSON schema, so keys, types, enums and
+which of them may be null are already stated where the provider enforces them;
+restating that in the prompt only buys input tokens. What these prompts carry
+is the part a schema cannot express: what each field should say.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+PromptLang = Literal["zh", "en"]
+DEFAULT_PROMPT_LANG: PromptLang = "zh"
+
+PresentationTask = Literal[
+    "thinking",
+    "text",
+    "PlanCreate",
+    "PlanUpdate",
+    "spawn_subagent",
+]
+
+
+# --------------------------------------------------------------------------- #
+# BizTrace presentation cards
+# --------------------------------------------------------------------------- #
+
+PRESENTATION_SYSTEM_PROMPT_ZH = """\
+你是一名业务轨迹卡片撰写者。你的任务是把 Agent 轨迹中的一段原始内容改写成面向业务\
+用户的简短说明，供前端卡片直接展示。
+
+写作要求：
+
+- 用简洁的自然语言陈述，不要使用列表符号、标题或代码块；
+- 只描述给定内容中确实发生的事，不臆测、不补充外部信息；
+- 不要复述原文，要概括其要点；
+- 控制在 2 句以内，避免技术黑话，业务用户能看懂；
+- 使用中文。
+"""
+
+PRESENTATION_SYSTEM_PROMPT_EN = """\
+You write business-facing trace cards. Rewrite a raw slice of an agent trajectory \
+into a short description that a frontend card can render directly.
+
+Requirements:
+
+- plain concise prose; no bullet lists, headings, or code blocks;
+- describe only what the given content actually shows; never speculate or add \
+outside information;
+- summarize rather than restate;
+- at most 2 sentences, understandable by a business user without jargon.
+"""
+
+THINKING_PRESENTATION_SYSTEM_PROMPT_ZH = """\
+你是一名业务轨迹卡片撰写者。把 Agent 的一段思考改写成面向业务用户的说明，\
+供前端卡片直接展示。
+
+写作要求：
+
+- 用自然语言陈述，可以分几句或短段落，不要使用代码块；
+- 只描述给定内容中确实出现的信息，不臆测、不补充外部信息；
+- 必须保留思考中的关键信息：错误或失败原因、关键决策与取舍、下一步打算；
+- 不要为了短而丢掉上述关键信息，不必压到两句以内；
+- 避免无信息量的过程描写（如「正在思考」）；
+- 使用中文。
+"""
+
+THINKING_PRESENTATION_SYSTEM_PROMPT_EN = """\
+You write business-facing trace cards. Rewrite a slice of the agent's reasoning \
+into a description a frontend card can render directly.
+
+Requirements:
+
+- plain natural language; a few sentences or a short paragraph is fine; no code \
+blocks;
+- describe only what the given content actually shows; never speculate or add \
+outside information;
+- keep the key information: error or failure analysis, important decisions and \
+trade-offs, and what the agent plans to do next;
+- do not drop those details to stay short; do not force a two-sentence limit;
+- skip empty process talk such as "still thinking".
+"""
+
+_PRESENTATION_TASK_ZH: dict[str, str] = {
+    "thinking": (
+        "概括这段思考：它发现了什么问题、做了哪些关键判断、接下来准备怎么做。"
+        "错误分析、关键决策和取舍必须保留。"
+    ),
+    "text": "概括 Agent 这段回复告诉了用户什么。",
+    "PlanCreate": "用自然语言简述这个计划：目标是什么、拆成了哪几步。",
+    "PlanUpdate": "用自然语言描述这次计划改动：改了什么、为什么改。",
+    "spawn_subagent": "概括这次子代理调用的任务与背景：要它做什么、给了什么前提。",
+}
+
+_PRESENTATION_TASK_EN: dict[str, str] = {
+    "thinking": (
+        "Summarize this reasoning: what problem it found, which decisions it "
+        "made, and what it plans to do next. Keep error analysis, key "
+        "decisions, and trade-offs."
+    ),
+    "text": "Summarize what this reply tells the user.",
+    "PlanCreate": "Describe this plan in plain language: its goal and the steps "
+    "it breaks into.",
+    "PlanUpdate": "Describe this plan revision: what changed and why.",
+    "spawn_subagent": "Summarize this sub-agent call: the task it was given and "
+    "the context supplied.",
+}
+
+TOOL_PRESENTATION_SYSTEM_PROMPT_ZH = """\
+你是一名业务轨迹卡片撰写者，负责为 Agent 的工具调用生成卡片文案，供业务用户阅读。
+
+写作要求：
+
+- caption 是卡片小标题，一句短语概括这次调用在做什么，不超过 20 字，不要以句号结尾；
+- purpose 用一句话说明这个工具在做什么；
+- input_summary 概括入参要点，不超过 200 字；
+- 只描述给定内容中确实存在的信息，不臆测；
+- 不使用列表符号、标题或代码块，使用中文。
+"""
+
+TOOL_PRESENTATION_SYSTEM_PROMPT_EN = """\
+You write business-facing trace cards for an agent's tool calls.
+
+Requirements:
+
+- caption is the card title: one short phrase naming what this call does, under \
+20 words, no trailing period;
+- purpose is one sentence on what the tool does;
+- input_summary summarizes the arguments, at most 200 characters;
+- describe only information actually present; never speculate;
+- no bullet lists, headings, or code blocks.
+"""
+
+TOOL_OUTPUT_PRESENTATION_SYSTEM_PROMPT_ZH = """\
+你是一名业务轨迹卡片撰写者，只负责概括工具调用的出参或失败原因。
+
+写作要求：
+
+- 只填写 output_summary：一句或一段话概括结果（成功）或错误原因（失败），不超过 200 字；
+- 调用信息、卡片标题、目的、入参已在卡片其他位置展示，禁止在 output_summary 中重复，\
+也禁止写出「卡片小标题」「目的」「输入摘要」「输出摘要」等字段名；
+- 只描述出参 / 错误中确实存在的信息，不臆测；
+- 不使用列表符号、标题或代码块，使用中文。
+"""
+
+TOOL_OUTPUT_PRESENTATION_SYSTEM_PROMPT_EN = """\
+You write the result section of a business-facing tool card.
+
+Requirements:
+
+- Fill only output_summary: one short paragraph on the result (success) or the \
+error (failure), at most 200 characters;
+- Caption, purpose, and input are already shown elsewhere on the card — do not \
+repeat them, and do not write field labels such as "caption", "purpose", \
+"input_summary", or "output_summary";
+- describe only information actually present in the result; never speculate;
+- no bullet lists, headings, or code blocks.
+"""
+
+
+def get_presentation_system_prompt(lang: PromptLang = DEFAULT_PROMPT_LANG) -> str:
+    """System prompt for free-text presentation bodies (plans, sub-agents)."""
+    if lang == "en":
+        return PRESENTATION_SYSTEM_PROMPT_EN
+    return PRESENTATION_SYSTEM_PROMPT_ZH
+
+
+def get_thinking_presentation_system_prompt(
+    lang: PromptLang = DEFAULT_PROMPT_LANG,
+) -> str:
+    """System prompt for assistant-thinking cards; keeps key decisions."""
+    if lang == "en":
+        return THINKING_PRESENTATION_SYSTEM_PROMPT_EN
+    return THINKING_PRESENTATION_SYSTEM_PROMPT_ZH
+
+
+def get_tool_presentation_system_prompt(
+    lang: PromptLang = DEFAULT_PROMPT_LANG,
+) -> str:
+    """System prompt for the call-card template (caption / purpose / input)."""
+    if lang == "en":
+        return TOOL_PRESENTATION_SYSTEM_PROMPT_EN
+    return TOOL_PRESENTATION_SYSTEM_PROMPT_ZH
+
+
+def get_tool_output_presentation_system_prompt(
+    lang: PromptLang = DEFAULT_PROMPT_LANG,
+) -> str:
+    """System prompt for the result-card template (output_summary only)."""
+    if lang == "en":
+        return TOOL_OUTPUT_PRESENTATION_SYSTEM_PROMPT_EN
+    return TOOL_OUTPUT_PRESENTATION_SYSTEM_PROMPT_ZH
+
+
+def build_presentation_summary_prompt(
+    *,
+    task: PresentationTask,
+    content: str,
+    lang: PromptLang = DEFAULT_PROMPT_LANG,
+) -> str:
+    """Build the user prompt asking for one summarized presentation body."""
+    if lang == "en":
+        return (
+            f"## Instruction\n\n{_PRESENTATION_TASK_EN[task]}\n\n"
+            f"## Content\n\n{content}\n"
+        )
+    return f"## 任务\n\n{_PRESENTATION_TASK_ZH[task]}\n\n## 内容\n\n{content}\n"
+
+
+def build_tool_running_prompt(
+    *,
+    tool_name: str,
+    tool_input: str,
+    lang: PromptLang = DEFAULT_PROMPT_LANG,
+) -> str:
+    """Build the user prompt for a call card's caption, purpose and input."""
+    if lang == "en":
+        return f"## Tool\n\n{tool_name}\n\n## Arguments\n\n{tool_input}\n"
+    return f"## 工具\n\n{tool_name}\n\n## 入参\n\n{tool_input}\n"
+
+
+def build_tool_output_prompt(
+    *,
+    tool_name: str,
+    purpose: str,
+    call_context: str,
+    tool_output: str,
+    failed: bool,
+    lang: PromptLang = DEFAULT_PROMPT_LANG,
+) -> str:
+    """Build the user prompt for a result card's output summary.
+
+    ``call_context`` is the call card's body: background only. The model must
+    still write solely about the result / error, never restate that context.
+    """
+
+    if lang == "en":
+        state = (
+            "The call FAILED; summarize only the error from the Result."
+            if failed
+            else "The call succeeded; summarize only the Result."
+        )
+        return (
+            f"## Instruction\n\nWrite output_summary only. Do not restate the "
+            f"tool name, purpose, or The call section.\n\n"
+            f"## Tool\n\n{tool_name} — {purpose}\n\n"
+            f"## The call (context only; do not repeat)\n\n"
+            f"{call_context or '-'}\n\n"
+            f"## Outcome\n\n{state}\n\n"
+            f"## Result\n\n{tool_output}\n"
+        )
+    state = (
+        "本次调用失败，请只概括「出参」中的错误原因。"
+        if failed
+        else "本次调用成功，请只概括「出参」中的结果要点。"
+    )
+    return (
+        f"## 任务\n\n只填写 output_summary。"
+        f"不要重复工具名、目的或「调用信息」中的内容，也不要输出字段名。\n\n"
+        f"## 工具\n\n{tool_name} — {purpose}\n\n"
+        f"## 调用信息（仅供参考，勿重复）\n\n{call_context or '-'}\n\n"
+        f"## 结果状态\n\n{state}\n\n"
+        f"## 出参\n\n{tool_output}\n"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Trace2Segment step 1: ContinuityJudge
+# --------------------------------------------------------------------------- #
+
+CONTINUITY_SYSTEM_PROMPT_ZH = """\
+你是一名轨迹分段判定官。给定一个候选窗口和一个前瞻节点，只判断前瞻节点是否与窗口\
+属于同一个子任务。你不需要写摘要。
+
+## 子任务的定义
+
+子任务是最小的、语义完整的工作单元，其目标应能脱离上下文被独立理解。
+
+一个子任务不应只由一句收尾汇报、交付确认或状态确认构成；这类内容归入它所总结的\
+那段工作。
+
+## 节点粒度
+
+前瞻节点默认对应一整条 AgentScope 消息气泡（同一次回复内的思考、文本、工具调用与\
+结果已按时间序展开在同一个节点里）；若该气泡内出现了硬边界，节点则是它的一个片段。
+
+## 判定准则
+
+判断依据是**窗口的局部行为**，而不是全局任务是否完成——不要因为「整个任务还没做完」\
+就倾向 continues=true。
+
+也不要仅因为窗口「看起来已经做完」就切断：窗口内出现任务 completed、任务归档、\
+文件已交付等完成信号，本身不构成边界。
+
+窗口若以 `user`、`hint` 或向用户提问的节点开头，那些节点只提供动机与上下文，说明\
+这个窗口在为什么服务；它们本身不是已完成的工作，判定前瞻节点时以其中的诉求为准。
+
+**收尾发言属于它所总结的那段工作。** 前瞻节点若是对窗口内刚完成工作的汇报、交付\
+确认、结果总结或状态确认，一律 continues=true：先有工作、后有交代，交代不是新子\
+任务的开端。新子任务从「开始做下一件事」起算，而不是从「说完上一件事」起算。
+
+典型 continues=true：
+
+- 前瞻与窗口围绕**同一工件**展开（生成 → 校验 → 修改 → 交付）；
+- 失败后的重试、修补；
+- 同一目标下的连续推理或紧随其后的同类操作；
+- 同一交付物的收尾（向用户汇报、交付确认、结果总结）紧接在产出之后；
+- 仅工具名发生变化（如 write_file → edit_file），目标未变。
+
+典型 continues=false：
+
+- 局部目标切换：开始处理新的数据源、新的问题；
+- 计划节点切换，且目标不同；
+- 离开窗口的主要工件，转向另一段产物。
+
+reason 用一句中文说明判定理由。
+"""
+
+CONTINUITY_SYSTEM_PROMPT_EN = """\
+You are a trajectory segmentation judge. Given a candidate window and one peek \
+node, decide only whether the peek belongs to the same sub-task as the window. \
+You do not write summaries.
+
+## What a sub-task is
+
+A sub-task is the smallest semantically complete unit of work; its goal should be \
+understandable on its own, without surrounding context. A sub-task must never \
+consist only of a closing report, delivery confirmation, or status check; such \
+content belongs to the work it wraps up.
+
+## Node granularity
+
+The peek node is by default one whole AgentScope message bubble: the thinking, \
+text, tool calls and tool results of a single reply, expanded in time order \
+inside that node. When a hard boundary occurred inside that bubble, the node is \
+one fragment of it instead.
+
+## Decision criteria
+
+Judge by the **local behavior of the window**, not by whether the overall task is \
+finished — do not lean toward continues=true merely because the global task is \
+still incomplete.
+
+Nor should you cut merely because the window already looks finished: completion \
+signals inside the window — task completed, task archived, file delivered — are \
+not boundaries by themselves.
+
+When the window opens with a `user`, `hint`, or ask-the-user node, those nodes \
+supply motivation and context rather than completed work; judge the peek against \
+the request they state.
+
+**A closing remark belongs to the work it closes.** When the peek reports on, \
+confirms delivery of, summarizes, or acknowledges completion of work just done in \
+the window, always set continues=true: the account of the work is not the start of \
+the next sub-task. A new sub-task begins when the next thing is started, not when \
+the last thing is described.
+
+Typical continues=true:
+
+- peek and window revolve around the **same artifact** (produce, verify, revise, \
+deliver);
+- retries or fixes after a failure;
+- continued reasoning or a back-to-back action under the same goal;
+- closeout of the same deliverable (reporting back, delivery confirmation, result \
+summary) immediately after producing it;
+- only the tool name changed (e.g. write_file to edit_file) while the goal did not.
+
+Typical continues=false:
+
+- the local goal switches: a new data source or a new question begins;
+- a plan-node switch with a different objective;
+- the window's primary artifact is left behind for a different product.
+
+Justify the decision in one sentence.
+"""
+
+
+def get_continuity_system_prompt(lang: PromptLang = DEFAULT_PROMPT_LANG) -> str:
+    """System prompt for the two-field continuity judge."""
+    if lang == "en":
+        return CONTINUITY_SYSTEM_PROMPT_EN
+    return CONTINUITY_SYSTEM_PROMPT_ZH
+
+
+def build_continuity_user_prompt(
+    *,
+    query: str,
+    scope: str | None,
+    start_index: int,
+    end_index: int,
+    rendered_window: str,
+    peek_index: int,
+    rendered_peek: str,
+    lang: PromptLang = DEFAULT_PROMPT_LANG,
+) -> str:
+    """Build the continuity judge's user prompt."""
+    if lang == "en":
+        scope_section = f"## Current sub-task scope\n\n{scope}\n\n" if scope else ""
+        return (
+            f"## Global query (background only)\n\n{query}\n\n"
+            f"{scope_section}"
+            f"## Candidate window\n\nChain indices [{start_index}, {end_index}] "
+            f"(inclusive)\n\n{rendered_window}\n\n"
+            f"## Node awaiting judgment (peek)\n\nChain index [{peek_index}]\n\n"
+            f"{rendered_peek}\n"
+        )
+    scope_section = f"## 当前子任务作用域\n\n{scope}\n\n" if scope else ""
+    return (
+        f"## 全局 query（仅作背景）\n\n{query}\n\n"
+        f"{scope_section}"
+        f"## 候选窗口\n\n链内下标 [{start_index}, {end_index}]（含两端）\n\n"
+        f"{rendered_window}\n\n"
+        f"## 待判定节点（peek）\n\n链内下标 [{peek_index}]\n\n{rendered_peek}\n"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Trace2Segment step 2: SegmentExtractor
+# --------------------------------------------------------------------------- #
+
+EXTRACTOR_SYSTEM_PROMPT_ZH = """\
+你是一名子轨迹归纳者。给定一段已经定界的子轨迹，抽取它的元数据摘要。你不做任何\
+边界判断——边界已经确定。只描述子轨迹中确实发生的事，使用中文；title / behavior /\
+ conclusion 必须非空。
+
+## 字段写作规范
+
+- title：约 10 个词，描述这一小段的**局部业务目标**。**禁止**照抄全局 query，\
+禁止「路由 / 委托 / 调用工具」等编排口吻。
+- input：该段**消费**的关键输入的 **markdown**（推荐无序列表）——用户口径、业务/\
+ODPS 表、**前序段落已有**的上游产物。有工作区文件时写成「简述 + 文件名」\
+（如「6 月 GAAP 明细 `june_gaap.csv`」），只写文件名，**禁止**完整路径；没有\
+文件名可写时用口径/表名简述亦可。确实没有输入则填 null。不要写 skill 路径或\
+工具名。
+  - 已作答的 `ask_user_question`：用户选择（选项标签、补充文本）必须写入，不得\
+因没有表或文件而填 null。
+  - **禁止**把本段产出写进 input：候选列表里的文件、本段将写入或刚写出的结果 \
+CSV / SQL / 报告 / 看板一律只进 artifact；本段若只有取数/生成、没有真正的上游\
+文件输入，input 就填 null，不要用结果文件「凑」一项。
+- behavior：回答「业务上数据/指标如何被处理」的 **markdown**（推荐有序步骤）。\
+主语是业务过程，不是 Agent。**禁止**出现工具名、子 Agent 名、skill 路径。
+- conclusion：回答「得出了什么」——数据发现、校验结果或决策——的 **markdown**\
+（短段落）。关键数字按下方「单位」与「数字颜色」规范书写。不得与 behavior 重复。\
+若本段在等待用户补齐信息或材料，须写明已确认事项与当前阻塞的下一步。
+- artifact：对本段**候选文件列表**打标（候选由系统给出，见用户提示）。候选即本段\
+写入的文件，与 input 互斥。
+  - **一项只写一个文件**；name 必须是候选列表中的**确切文件名**，不得发明候选\
+之外的名字，不得并列多个文件。
+  - description：一句话说清这个文件是什么，**不超过 25 个字**，不要复述文件名。
+  - kind：`query_script`（SQL/查询脚本）/ `dataset`（CSV 等数据）/ `report` /
+    `dashboard` / `other`（探测文件、生成脚本等）。
+  - role：`final`（面向用户的最终产物）/ `intermediate`（中间结果）/
+    `supporting`（支撑/探测）。
+  - 无 workspace 路径的 ODPS 临时表、仅下载 URL、任务图、计划、口径结论不是文件，\
+不要写入 artifact。
+  - artifact 是真正的 JSON 数组，不要写成一个装着 JSON 的字符串。
+
+## 单位
+
+- 贡献度、占比、渗透率、环比/WoW 等比率类数字，按数据文件原样加 `%`。
+- 人数、金额及其变动**不加**百分号。
+- `pt` 只用于「率值从 A% 变到 B%」的差值；不要把 `%` 改写成 `pt`。
+- 禁用模糊词（如「显著增长」「大幅下降」「略有波动」「基本稳定」），必须给出\
+具体数值；禁止未经证实的推测。
+
+## 数字颜色（仅允许下列 span）
+
+对结论与行为中的关键数字使用 HTML `<span>` 着色（class 必须逐字一致）：
+
+- 关键数值：`<span class="text-blue-600 font-bold">…</span>`
+- 下降/负面：`<span class="text-red-500 font-bold">…</span>`
+- 上升/正面：`<span class="text-green-600 font-bold">…</span>`
+
+禁止其他 HTML 标签或 class。文件名仍用行内代码，不要包进 span。
+
+## Markdown 约束
+
+input / behavior / conclusion 各写成**一个字符串**，列表用换行书写（如 \
+`1. …\\n2. …` 或 `- …`），**禁止**做成 JSON 数组。使用 GFM 子集：标题、列表、\
+加粗、行内代码、表格；除上文允许的数字着色 `<span>` 外，禁止其他裸 HTML。
+
+## 开头的上下文节点
+
+窗口若以 `user`、`hint`（系统注入的用户引导）开头，这些节点只提供动机与上下文，\
+不属于本段覆盖的工作：据它们理解这一段要做什么、input 是什么，但 behavior 与 \
+conclusion 只概括其后真正被覆盖的业务处理与结论。已作答的 `ask_user_question` \
+是本段输入，不按上下文节点忽略。
+"""
+
+EXTRACTOR_SYSTEM_PROMPT_EN = """\
+You summarize a delimited sub-trajectory into structured metadata. You make no \
+boundary decisions — the boundary is already fixed. Describe only what actually \
+happened; title, behavior and conclusion must be non-empty.
+
+## Field rules
+
+- title: ~10 words naming the **local business goal**. Never copy the global \
+query; never use orchestration phrasing ("routed", "delegated", "called a tool").
+- input: **markdown** (prefer a bullet list) for what this segment **consumed** — \
+user criteria, business/ODPS tables, or **upstream** products from earlier \
+segments. When naming a workspace file, write "short gloss + filename" \
+(e.g. "June GAAP detail `june_gaap.csv`"); filenames only — **never** full \
+paths. Non-file inputs (criteria, table names) are fine. Null when there \
+genuinely are none. No skill paths or tool names.
+  - An answered `ask_user_question` must go into input (option labels and any \
+custom text); do not set null for lack of tables or files.
+  - **Never** put this segment's outputs in input: candidate files and anything \
+this window writes (result CSVs, SQL, reports, dashboards) belong only in \
+artifact. If the segment only fetches or generates and has no real upstream file \
+input, set input to null — do not pad it with the result filename.
+- behavior: **markdown** (prefer a numbered list) answering how data / metrics \
+were processed. The subject is the business process, not the agent. Never name \
+tools, sub-agents, or skill paths.
+- conclusion: **markdown** answering what was concluded — a data finding, \
+verification result, or decision (short paragraph). Key numbers follow the \
+Units and Number colors rules below. Must not repeat behavior. If this \
+segment is waiting on the user, state what was confirmed and the blocked next step.
+- artifact: label the **candidate files** supplied in the user prompt. Candidates \
+are files this segment wrote; they are mutually exclusive with input.
+  - **one file per entry**; name must be an exact filename from the candidate \
+list — never invent names outside it, never join files.
+  - description: one short clause, **15 words at most**, never a restatement of \
+the filename.
+  - kind: `query_script` (SQL or query script) / `dataset` (CSV and the like) / \
+`report` / `dashboard` / `other` (probe files, generator scripts).
+  - role: `final` (user-facing product) / `intermediate` / `supporting`.
+  - ODPS temp tables without a workspace path, bare download URLs, task graphs, \
+plans, and conclusions are not files — leave them out.
+  - emit artifact as a real JSON array, never as a string containing JSON.
+
+## Units
+
+- Ratio metrics (contribution, share, penetration, WoW/MoM, etc.) keep `%` as in \
+the data file.
+- Headcounts, amounts, and their deltas do **not** take a percent sign.
+- Use `pt` only for the difference when a rate moves from A% to B%; never rewrite \
+`%` as `pt`.
+- No vague wording ("grew significantly", "dropped sharply", "mostly stable"); \
+always give concrete numbers. Never speculate beyond the sub-trajectory.
+
+## Number colors (only these spans)
+
+Wrap key numbers in HTML `<span>` tags (class strings must match exactly):
+
+- key value: `<span class="text-blue-600 font-bold">…</span>`
+- down / negative: `<span class="text-red-500 font-bold">…</span>`
+- up / positive: `<span class="text-green-600 font-bold">…</span>`
+
+No other HTML tags or classes. Filenames stay in inline code, not spans.
+
+## Markdown constraints
+
+Write input / behavior / conclusion as **one string** each, with list steps as \
+newlines (e.g. `1. …\\n2. …` or `- …`); never emit a JSON array of steps. Use a \
+GFM subset: headings, lists, bold, inline code, tables; aside from the \
+number-color `<span>` tags above, no raw HTML.
+
+## Leading context nodes
+
+When the window opens with a `user` node or a `hint` (system-injected guidance), \
+those nodes supply motivation and context, not work this segment covers. Read \
+the local goal and the input from them, but let behavior and conclusion \
+describe only the business processing and findings afterwards. An answered \
+`ask_user_question` is this segment's input — do not ignore it as context.
+"""
+
+_BOUNDARY_NOTE_ZH = {
+    "natural": "自然切段：本段边界由连续性判定确认，内容应当完整。",
+    "TaskStateUpdate": "强制截断：本段在子任务状态切换处被切断，可能不完整，请如实\
+概括已经发生的部分。",
+    "PlanUpdate": "强制截断：本段在计划被修订处被切断，可能不完整，请如实概括已经\
+发生的部分。",
+    "user_message": "强制截断：本段在用户下达新指令处被切断，可能不完整，请如实概括\
+已经发生的部分。",
+    "ask_user_question": "强制截断：本段止于向用户提问，可能不完整，请如实概括提问\
+之前已经发生的部分。",
+    "max_span": "强制截断：本段因长度上限被切断，可能不完整，请如实概括已经发生的\
+部分。",
+    "session_end": "强制截断：本段在会话结束处收尾，可能不完整，请如实概括已经发生\
+的部分。",
+}
+
+_BOUNDARY_NOTE_EN = {
+    "natural": "Natural boundary: confirmed by continuity judgment; the segment "
+    "should be complete.",
+    "TaskStateUpdate": "Forced cut at a sub-task state switch; the segment may "
+    "be incomplete — describe faithfully what did happen.",
+    "PlanUpdate": "Forced cut where the plan was revised; the segment may be "
+    "incomplete — describe faithfully what did happen.",
+    "user_message": "Forced cut where the user sent a new instruction; the "
+    "segment may be incomplete — describe faithfully what did happen.",
+    "ask_user_question": "Forced cut where the agent asked the user a question; "
+    "the segment may be incomplete — describe faithfully what happened before "
+    "the question.",
+    "max_span": "Forced cut at the length cap; the segment may be incomplete — "
+    "describe faithfully what did happen.",
+    "session_end": "Forced cut at session end; the segment may be incomplete — "
+    "describe faithfully what did happen.",
+}
+
+
+def get_extractor_system_prompt(lang: PromptLang = DEFAULT_PROMPT_LANG) -> str:
+    """System prompt for segment metadata extraction."""
+    if lang == "en":
+        return EXTRACTOR_SYSTEM_PROMPT_EN
+    return EXTRACTOR_SYSTEM_PROMPT_ZH
+
+
+def build_extractor_user_prompt(
+    *,
+    query: str,
+    scope: str | None,
+    boundary_reason: str,
+    rendered_window: str,
+    candidate_files: list[str] | None = None,
+    lang: PromptLang = DEFAULT_PROMPT_LANG,
+) -> str:
+    """Build the segment extractor's user prompt over a frozen window snapshot.
+
+    Args:
+        query: Global user query, background only.
+        scope: Sub-task scope description, when a plan is active.
+        boundary_reason: Why the window was cut.
+        rendered_window: Rendered snapshot of the delimited window.
+        candidate_files: Filenames the segment actually saved; the model may
+            only label names from this list.
+        lang: Prompt language.
+    """
+
+    names = sorted(candidate_files or [])
+    if lang == "en":
+        scope_section = f"## Sub-task scope\n\n{scope}\n\n" if scope else ""
+        note = _BOUNDARY_NOTE_EN.get(boundary_reason, "")
+        if names:
+            listed = "\n".join(f"- `{name}`" for name in names)
+            candidates = (
+                "## Candidate workspace files (label only these exact names)\n\n"
+                f"{listed}\n\n"
+            )
+        else:
+            candidates = (
+                "## Candidate workspace files\n\nNone — set artifact to null.\n\n"
+            )
+        return (
+            f"## Global query (background only — do not copy into title)\n\n"
+            f"{query}\n\n"
+            f"{scope_section}"
+            f"## Boundary\n\n{note}\n\n"
+            f"{candidates}"
+            f"## Sub-trajectory\n\n{rendered_window}\n"
+        )
+    scope_section = f"## 子任务作用域\n\n{scope}\n\n" if scope else ""
+    note = _BOUNDARY_NOTE_ZH.get(boundary_reason, "")
+    if names:
+        listed = "\n".join(f"- `{name}`" for name in names)
+        candidates = f"## 候选工作区文件（只能标注这些确切文件名）\n\n{listed}\n\n"
+    else:
+        candidates = "## 候选工作区文件\n\n无 — artifact 填 null。\n\n"
+    return (
+        f"## 全局 query（仅作背景，勿抄入 title）\n\n{query}\n\n"
+        f"{scope_section}"
+        f"## 定界原因\n\n{note}\n\n"
+        f"{candidates}"
+        f"## 子轨迹\n\n{rendered_window}\n"
+    )
+
+
+__all__ = [
+    "DEFAULT_PROMPT_LANG",
+    "PresentationTask",
+    "PromptLang",
+    "build_continuity_user_prompt",
+    "build_extractor_user_prompt",
+    "build_presentation_summary_prompt",
+    "build_tool_output_prompt",
+    "build_tool_running_prompt",
+    "get_continuity_system_prompt",
+    "get_extractor_system_prompt",
+    "get_presentation_system_prompt",
+    "get_thinking_presentation_system_prompt",
+    "get_tool_output_presentation_system_prompt",
+    "get_tool_presentation_system_prompt",
+]

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/algo/biztrace/segmentation.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/algo/biztrace/segmentation.py
@@ -1,0 +1,1071 @@
+# -*- coding: utf-8 -*-
+"""Online segmentation of a BizTrace.
+
+Main-channel BizEvents are folded into chain nodes — one per assistant message
+by default, split apart at hard boundaries — a sliding window accumulates them,
+a first LLM step decides continuity, and a second step extracts the metadata of
+each delimited window.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from collections.abc import Awaitable, Callable, Iterable, Iterator
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+from qwenpaw_data.host.core.algo.biztrace.formatting import compact, output_text, truncate
+from qwenpaw_data.host.core.algo.biztrace.llm import StructuredLLM, StructuredLLMError
+from qwenpaw_data.host.core.algo.biztrace.models import (
+    BizEvent,
+    BoundaryReason,
+    Coverage,
+    Segment,
+    SubtaskScope,
+)
+from qwenpaw_data.host.core.algo.biztrace.presentation import Linker
+from qwenpaw_data.host.core.algo.biztrace.prompts import (
+    DEFAULT_PROMPT_LANG,
+    PromptLang,
+    build_continuity_user_prompt,
+    build_extractor_user_prompt,
+    get_continuity_system_prompt,
+    get_extractor_system_prompt,
+)
+from qwenpaw_data.host.core.algo.biztrace.settings import FLUSH_BUDGET_SECONDS
+from qwenpaw_data.host.core.algo.biztrace.tools import (
+    ASK_USER_QUESTION,
+    canonical_tool_name,
+)
+from qwenpaw_data.host.core.algo.biztrace.workspace_index import (
+    ArtifactProposal,
+    ArtifactVerifier,
+)
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MAX_SPAN = 100
+TITLE_CHAR_CAP = 200
+# Tail of the tool id shown in a window, enough to pair a call with its result.
+CALL_KEY_CHARS = 6
+
+TEXT_CHAR_CAP = 1_500
+THINKING_CHAR_CAP = 400
+HINT_CHAR_CAP = 800
+TOOL_INPUT_CHAR_CAP = 1_200
+TOOL_OUTPUT_CHAR_CAP = 2_000
+WINDOW_CHAR_CAP = 24_000
+WINDOW_TRUNCATION_MARK = "\n\n...[window truncated for length]...\n\n"
+
+_LIST_MARKER_RE = re.compile(r"^(?:[-*]|\d+\.)\s+")
+
+NodeKind = Literal["normal", "user", "hint", "ask", "orchestration"]
+NodeRole = Literal["user", "assistant", "hint"]
+
+# Host TaskStateUpdate states that force a boundary; "pending" is bookkeeping.
+BOUNDARY_SUBTASK_STATES = frozenset({"in_progress", "completed"})
+
+_CONTINUITY_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "additionalProperties": False,
+    "properties": {
+        "continues": {"type": "boolean"},
+        "reason": {"type": "string", "minLength": 1},
+    },
+    "required": ["continues", "reason"],
+}
+
+_EXTRACTION_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "additionalProperties": False,
+    "properties": {
+        "title": {"type": "string"},
+        "input": {"type": ["string", "null"]},
+        "behavior": {"type": "string"},
+        "conclusion": {"type": "string"},
+        "artifact": {
+            "type": ["array", "null"],
+            "items": {
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {
+                    "name": {"type": "string", "minLength": 1},
+                    "description": {"type": "string", "minLength": 1},
+                    "kind": {
+                        "type": "string",
+                        "enum": [
+                            "query_script",
+                            "dataset",
+                            "report",
+                            "dashboard",
+                            "other",
+                        ],
+                    },
+                    "role": {
+                        "type": "string",
+                        "enum": ["intermediate", "final", "supporting"],
+                    },
+                },
+                "required": ["name", "description", "kind", "role"],
+            },
+        },
+    },
+    # The nullable two are asked for in the prompt but not required here: a small
+    # model that drops a key it would have set to null is answering correctly,
+    # and the transport validates the schema strictly enough to fail the segment
+    # over it.
+    "required": ["title", "behavior", "conclusion"],
+}
+
+SegmentSink = Callable[[Segment], Awaitable[None]]
+JudgeLogSink = Callable[[dict[str, Any]], Awaitable[None]]
+
+# Files produced inside a coverage seq range (from host artifact_delta).
+# Declared here rather than imported from the host runtime to avoid a cycle.
+ArtifactFiles = Callable[[int, int], dict[str, str]]
+
+
+def no_artifact_files(start_seq: int = 0, end_seq: int = 0) -> dict[str, str]:
+    """Stand in when a pipeline has no host file feed."""
+    _ = (start_seq, end_seq)
+    return {}
+
+
+# --------------------------------------------------------------------------- #
+# Chain building
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(slots=True)
+class SegmentChainNode:
+    """One judgment unit: a whole message bubble, or a fragment of one."""
+
+    index: int
+    kind: NodeKind
+    role: NodeRole
+    parent_msg_id: str | None
+    covered: bool
+    content: list[dict[str, Any]] = field(default_factory=list)
+    event_ids: list[str] = field(default_factory=list)
+    seqs: list[int] = field(default_factory=list)
+    started_at: float = 0.0
+    ended_at: float = 0.0
+    orchestration: dict[str, Any] | None = None
+
+
+class ChainBuilder:
+    """Fold BizEvents into chain nodes: aggregate by message, split at boundaries.
+
+    Events stream in, so a node is only complete once an event from another
+    message arrives or a hard boundary interrupts it; ``push`` therefore
+    returns the nodes it closed, and ``flush`` releases the last one.
+    """
+
+    def __init__(self) -> None:
+        self._open: SegmentChainNode | None = None
+        self._pending_ask: SegmentChainNode | None = None
+        # Boundary TaskStateUpdate nodes stay mutable so their tool_result can
+        # join the same covered node (FE hides by seq range).
+        self._pending_task_state: SegmentChainNode | None = None
+        self._index = 0
+
+    def push(self, event: BizEvent) -> list[SegmentChainNode]:
+        """Add one main-channel BizEvent, returning the nodes it closed."""
+        tool = canonical_tool_name(event.tool_name)
+
+        if event.kind == "tool_use" and tool == ASK_USER_QUESTION:
+            closed = self._close_open()
+            # Uncovered until the user answers, so an unanswered question cannot
+            # emit a segment. The node is released now but stays open for the
+            # result that marks it covered.
+            node = self._new_node(kind="ask", role="assistant", covered=False)
+            self._add(node, event)
+            self._pending_ask = node
+            self._pending_task_state = None
+            return [*closed, node]
+
+        if (
+            event.kind == "tool_result"
+            and tool == ASK_USER_QUESTION
+            and self._pending_ask is not None
+        ):
+            self._add(self._pending_ask, event)
+            self._pending_ask.covered = True
+            return []
+
+        if (
+            event.kind == "tool_result"
+            and tool == "TaskStateUpdate"
+            and self._pending_task_state is not None
+        ):
+            # Release only once the result is attached so coverage seqs include
+            # both ends of the tool pair (FE folds by seq range).
+            self._add(self._pending_task_state, event)
+            node = self._pending_task_state
+            self._pending_task_state = None
+            return [node]
+
+        split = _split_kind(event)
+        if split is not None:
+            self._pending_ask = None
+            closed = self._close_open()
+            # TaskStateUpdate is covered so FE can fold it under a segment, but
+            # the assembler keeps it out of judge/extractor prompts. Hold the
+            # node until its tool_result (or flush) so both seqs are covered.
+            node = self._new_node(
+                kind=split,
+                role="hint" if split == "hint" else "assistant",
+                covered=split != "hint",
+            )
+            self._add(node, event)
+            if split == "orchestration" and event.orchestration is not None:
+                node.orchestration = event.orchestration.model_dump(mode="json")
+                if event.orchestration.category == "TaskStateUpdate":
+                    self._pending_task_state = node
+                    return closed
+            self._pending_task_state = None
+            return [*closed, node]
+
+        if event.kind == "user":
+            self._pending_ask = None
+            self._pending_task_state = None
+            closed = self._close_open()
+            node = self._new_node(kind="user", role="user", covered=False)
+            self._add(node, event)
+            return [*closed, node]
+
+        if _event_block(event) is None:
+            return []
+        self._pending_ask = None
+        self._pending_task_state = None
+        switched: list[SegmentChainNode] = []
+        if self._open is not None and event.parent_msg_id != self._open.parent_msg_id:
+            switched = self._close_open()
+        if self._open is None:
+            self._open = self._new_node(
+                kind="normal", role="assistant", covered=True
+            )
+        self._add(self._open, event)
+        return switched
+
+    def flush(self) -> list[SegmentChainNode]:
+        """Release whatever is still accumulating."""
+        self._pending_ask = None
+        pending = self._pending_task_state
+        self._pending_task_state = None
+        closed = self._close_open()
+        return [*closed, pending] if pending is not None else closed
+
+    def _close_open(self) -> list[SegmentChainNode]:
+        node = self._open
+        self._open = None
+        return [node] if node is not None else []
+
+    def _new_node(
+        self, *, kind: NodeKind, role: NodeRole, covered: bool
+    ) -> SegmentChainNode:
+        node = SegmentChainNode(
+            index=self._index,
+            kind=kind,
+            role=role,
+            parent_msg_id=None,
+            covered=covered,
+        )
+        self._index += 1
+        return node
+
+    def _add(self, node: SegmentChainNode, event: BizEvent) -> None:
+        block = _event_block(event)
+        if block is not None:
+            node.content.append(block)
+        if node.parent_msg_id is None:
+            node.parent_msg_id = event.parent_msg_id
+        node.event_ids.append(event.event_id)
+        node.seqs.append(event.seq)
+        if not node.started_at:
+            node.started_at = event.started_at
+        node.ended_at = event.ended_at or event.started_at
+
+
+def _split_kind(event: BizEvent) -> Literal["hint", "orchestration"] | None:
+    """Return the hard-boundary kind this event triggers, if any."""
+    if event.kind == "hint":
+        return "hint"
+    if event.kind != "tool_use" or event.orchestration is None:
+        return None
+    category = event.orchestration.category
+    if category == "PlanUpdate":
+        return "orchestration"
+    if category == "TaskStateUpdate":
+        state = event.orchestration.subtask_state
+        return "orchestration" if state in BOUNDARY_SUBTASK_STATES else None
+    return None
+
+
+def _event_block(event: BizEvent) -> dict[str, Any] | None:
+    """Map one BizEvent to a chain content block, or None to drop it."""
+    if event.kind in ("tool_use", "tool_result"):
+        name = canonical_tool_name(event.tool_name) or "unknown_tool"
+        # A call and its result are separate events, so the tool id pairs them
+        # back up in the rendered window.
+        call = (event.block_id or "")[-CALL_KEY_CHARS:]
+        if event.kind == "tool_result":
+            return {
+                "type": "tool_result",
+                "name": name,
+                "call": call,
+                "output": event.output,
+                "status": event.status,
+            }
+        block: dict[str, Any] = {
+            "type": "tool_use",
+            "name": name,
+            "call": call,
+            "input": event.input,
+        }
+        if event.orchestration is not None:
+            block["orchestration"] = event.orchestration.model_dump(mode="json")
+        return block
+    text = (event.content or "").strip()
+    if event.kind == "hint":
+        # A hint clears the window even when it carries no readable text.
+        return {"type": "hint", "text": text}
+    if not text:
+        return None
+    if event.kind == "assistant_thinking":
+        return {"type": "thinking", "text": text}
+    return {"type": "text", "text": text}
+
+
+# --------------------------------------------------------------------------- #
+# Window rendering
+# --------------------------------------------------------------------------- #
+
+
+def render_window(nodes: list[SegmentChainNode]) -> str:
+    """Render a contiguous window as the two LLM steps read it."""
+    parts = [
+        "\n".join(
+            [
+                f"[{node.index}] {node.role}",
+                *(line for line in map(render_block, node.content) if line),
+            ]
+        )
+        for node in nodes
+    ]
+    return _cap_window("\n\n".join(parts))
+
+
+def render_block(block: dict[str, Any]) -> str:
+    """Render one content block as a single capped line."""
+    block_type = block.get("type")
+    if block_type == "text":
+        return f"text: {truncate(str(block.get('text') or ''), TEXT_CHAR_CAP)}"
+    if block_type == "thinking":
+        return (
+            f"thinking: {truncate(str(block.get('text') or ''), THINKING_CHAR_CAP)}"
+        )
+    if block_type == "hint":
+        return f"hint: {truncate(str(block.get('text') or ''), HINT_CHAR_CAP)}"
+    label = _tool_label(block)
+    if block_type == "tool_use":
+        payload = truncate(compact(block.get("input")), TOOL_INPUT_CHAR_CAP)
+        return f"tool_use {label}: {payload}"
+    if block_type == "tool_result":
+        payload = truncate(output_text(block.get("output")), TOOL_OUTPUT_CHAR_CAP)
+        suffix = " [error]" if block.get("status") == "error" else ""
+        return f"tool_result {label}: {payload}{suffix}"
+    return f"{block_type or 'unknown'}: {truncate(compact(block), TEXT_CHAR_CAP)}"
+
+
+def _tool_label(block: dict[str, Any]) -> str:
+    name = str(block.get("name") or "unknown_tool")
+    call = block.get("call")
+    return f"{name}#{call}" if call else name
+
+
+def _cap_window(rendered: str) -> str:
+    """Keep the head and tail of an over-budget rendering, marking the cut."""
+    if len(rendered) <= WINDOW_CHAR_CAP:
+        return rendered
+    keep = max(WINDOW_CHAR_CAP // 2 - 40, 200)
+    return rendered[:keep] + WINDOW_TRUNCATION_MARK + rendered[-keep:]
+
+
+# --------------------------------------------------------------------------- #
+# Step 1: ContinuityJudge
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(slots=True)
+class ContinuityDecision:
+    continues: bool
+    reason: str
+
+
+class ContinuityJudge:
+    """Decide whether a peek node continues the current window."""
+
+    def __init__(
+        self,
+        *,
+        llm: StructuredLLM | None = None,
+        lang: PromptLang = DEFAULT_PROMPT_LANG,
+    ) -> None:
+        self.llm = llm
+        self.lang = lang
+        self.query = ""
+        self.degraded = 0
+
+    async def judge(
+        self,
+        window: list[SegmentChainNode],
+        peek: SegmentChainNode,
+        *,
+        scope: SubtaskScope | None,
+    ) -> ContinuityDecision:
+        """Return the decision, degrading to "continues" on any failure.
+
+        A failed call keeps the window accumulating so ``max_span`` remains
+        the backstop; cutting on failure would shred the trace instead.
+        """
+
+        if self.llm is not None:
+            user = build_continuity_user_prompt(
+                query=self.query,
+                scope=_scope_text(scope),
+                start_index=window[0].index,
+                end_index=window[-1].index,
+                rendered_window=render_window(window),
+                peek_index=peek.index,
+                rendered_peek=render_window([peek]),
+                lang=self.lang,
+            )
+            try:
+                data = await self.llm.complete(
+                    system=get_continuity_system_prompt(self.lang),
+                    user=user,
+                    schema_name="continuity_decision",
+                    schema=_CONTINUITY_SCHEMA,
+                )
+                reason = str(data.get("reason") or "").strip()
+                return ContinuityDecision(
+                    continues=bool(data.get("continues")), reason=reason
+                )
+            except (StructuredLLMError, ValueError) as exc:
+                logger.warning("continuity judgment degraded to continue: %s", exc)
+        self.degraded += 1
+        return ContinuityDecision(
+            continues=True, reason="judge unavailable; degraded"
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Step 2: SegmentExtractor
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(slots=True)
+class ExtractionOutcome:
+    """Outcome of one metadata extraction attempt."""
+
+    ok: bool
+    fields: dict[str, Any] = field(default_factory=dict)
+
+    def log_fields(self) -> dict[str, Any]:
+        payload = dict(self.fields)
+        artifacts = payload.get("artifact")
+        if artifacts:
+            payload["artifact"] = [item.model_dump(mode="json") for item in artifacts]
+        return payload
+
+
+class SegmentExtractor:
+    """Extract title / input / behavior / conclusion / artifact for a window."""
+
+    def __init__(
+        self,
+        *,
+        llm: StructuredLLM | None = None,
+        lang: PromptLang = DEFAULT_PROMPT_LANG,
+        verifier: ArtifactVerifier | None = None,
+        linker: Linker | None = None,
+    ) -> None:
+        self.llm = llm
+        self.lang = lang
+        self.verifier = verifier if verifier is not None else ArtifactVerifier()
+        self.linker = linker
+        self.query = ""
+        self.failures = 0
+
+    async def extract(
+        self,
+        window: list[SegmentChainNode],
+        *,
+        scope: SubtaskScope | None,
+        boundary_reason: BoundaryReason,
+        files: dict[str, str],
+    ) -> ExtractionOutcome:
+        """Summarize a frozen window snapshot into segment metadata."""
+        if self.llm is None:
+            self.failures += 1
+            return ExtractionOutcome(ok=False)
+        user = build_extractor_user_prompt(
+            query=self.query,
+            scope=_scope_text(scope),
+            boundary_reason=boundary_reason,
+            rendered_window=render_window(window),
+            candidate_files=list(files),
+            lang=self.lang,
+        )
+        try:
+            data = await self.llm.complete(
+                system=get_extractor_system_prompt(self.lang),
+                user=user,
+                schema_name="segment_metadata",
+                schema=_EXTRACTION_SCHEMA,
+            )
+        except StructuredLLMError as exc:
+            self.failures += 1
+            logger.warning("segment extraction failed: %s", exc)
+            return ExtractionOutcome(ok=False)
+
+        behavior = _text_field(data.get("behavior"))
+        conclusion = _text_field(data.get("conclusion"))
+        if not behavior or not conclusion:
+            self.failures += 1
+            logger.warning("segment extraction missing required fields")
+            return ExtractionOutcome(ok=False)
+        artifacts = self.verifier.verify(
+            _artifact_proposals(data.get("artifact")), files=files
+        )
+        # Strip every in-window candidate filename from input — not only the
+        # verified artifact names. Models pad input with outputs even when they
+        # omit those files from the artifact array.
+        produced = set(files) | {
+            item.name for item in (artifacts or []) if item.name
+        }
+        return ExtractionOutcome(
+            ok=True,
+            fields={
+                # Titles and artifact names stay literal; only the three prose
+                # fields carry entity links.
+                "title": _text_field(data.get("title")) or _title_from(behavior),
+                "input": self._link(
+                    _strip_artifact_names_from_input(
+                        _text_field(data.get("input")), produced
+                    )
+                ),
+                "behavior": self._link(behavior),
+                "conclusion": self._link(conclusion),
+                "artifact": artifacts,
+            },
+        )
+
+    def _link(self, text: str | None) -> str | None:
+        """Inject entity links, falling back to the raw text on any failure."""
+        if self.linker is None or not text:
+            return text
+        try:
+            return self.linker(text)
+        except Exception:
+            logger.exception("Entity linking failed; keeping the raw field")
+            return text
+
+
+def _artifact_proposals(raw: Any) -> Iterator[ArtifactProposal]:
+    """Yield the model's artifact entries; the verifier decides which are real."""
+    if not isinstance(raw, list):
+        return
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        name = _clean(item.get("name"))
+        if not name:
+            continue
+        yield ArtifactProposal(
+            name=name,
+            description=_clean(item.get("description")) or "",
+            kind=_clean(item.get("kind")) or "",
+            role=_clean(item.get("role")) or "",
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Sliding window state machine
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(slots=True)
+class SegmentStats:
+    """Counters describing one segmentation run."""
+
+    rows: int = 0
+    segments: int = 0
+    chain_nodes: int = 0
+    judge_calls: int = 0
+    degraded: int = 0
+    failed: int = 0
+    cleared_by_hint: int = 0
+    boundaries: dict[str, int] = field(default_factory=dict)
+
+
+class SegmentAssembler:
+    """Consume BizEvents and write two-phase segment rows.
+
+    Args:
+        session_id: Session the segments belong to.
+        judge: Step-one continuity judge.
+        extractor: Step-two metadata extractor.
+        on_row: Writes every segment row, both phases.
+        on_segment: Delivers a finished segment to the host; done rows only.
+        on_judge_log: Receives continuity and extraction log lines.
+        max_span: Window size, in chain nodes, that forces a cut.
+        artifact_files: ``(start_seq, end_seq) ->`` files produced in that range.
+    """
+
+    def __init__(
+        self,
+        *,
+        session_id: str,
+        judge: ContinuityJudge,
+        extractor: SegmentExtractor,
+        on_row: SegmentSink,
+        on_segment: SegmentSink | None = None,
+        on_judge_log: JudgeLogSink | None = None,
+        max_span: int = DEFAULT_MAX_SPAN,
+        concurrency: int = 2,
+        artifact_files: ArtifactFiles | None = None,
+    ) -> None:
+        self.session_id = session_id
+        self.judge = judge
+        self.extractor = extractor
+        self.on_row = on_row
+        self.on_segment = on_segment
+        self.on_judge_log = on_judge_log
+        self.max_span = max(1, max_span)
+        self.artifact_files = (
+            artifact_files if artifact_files is not None else no_artifact_files
+        )
+        self.stats = SegmentStats()
+
+        self._chain = ChainBuilder()
+        self._window: list[SegmentChainNode] = []
+        self._scope: SubtaskScope | None = None
+        self._seq = 0
+        self._segment_no = 0
+        self._seen_node = False
+        self._extractions: dict[asyncio.Task[None], Segment] = {}
+        self._slots = asyncio.Semaphore(max(1, concurrency))
+
+    async def feed(self, event: BizEvent) -> None:
+        """Consume one main-channel BizEvent."""
+        for node in self._chain.push(event):
+            await self._on_node(node)
+
+    async def aclose(self, *, budget: float = FLUSH_BUDGET_SECONDS) -> None:
+        """Flush the chain, delimit the remainder and wait out the extractions."""
+        for node in self._chain.flush():
+            await self._on_node(node)
+        if self._window:
+            await self._delimit("session_end", forced=True)
+        await self._wait_extractions(budget)
+
+    # -- core loop --------------------------------------------------------- #
+
+    async def _on_node(self, node: SegmentChainNode) -> None:
+        self.stats.chain_nodes += 1
+        if not self._seen_node:
+            self._seen_node = True
+            if node.kind == "user":
+                # The opening user message is the global task itself, injected
+                # into both prompts as the query rather than judged.
+                self._set_query(node)
+                return
+
+        if node.kind == "hint":
+            # Guidance invalidates the draft it interrupts: the window is
+            # cleared without a segment, and the hint frames what follows.
+            if _covered_nodes(self._window):
+                self.stats.cleared_by_hint += 1
+            self._window = [node]
+            return
+
+        if node.kind == "user":
+            self._set_query(node)
+            await self._delimit("user_message", forced=True)
+            self._open_window(node)
+            return
+
+        if node.kind == "ask":
+            await self._delimit("ask_user_question", forced=True)
+            self._open_window(node)
+            return
+
+        if node.kind == "orchestration":
+            await self._on_plan_boundary(node)
+            return
+
+        summary_window = _summary_nodes(self._window)
+        if not summary_window:
+            # Nothing judgeable yet: empty, framing-only, or only TaskStateUpdate
+            # bookkeeping waiting to be absorbed into the next productive stretch.
+            self._open_window(node)
+            return
+
+        decision = await self.judge.judge(summary_window, node, scope=self._scope)
+        self.stats.judge_calls += 1
+        await self._log_continuity(node, decision)
+
+        if decision.continues:
+            self._window.append(node)
+            if len(self._window) >= self.max_span:
+                await self._delimit("max_span", forced=True)
+            return
+        await self._delimit("natural", forced=False)
+        self._open_window(node)
+
+    def _set_query(self, node: SegmentChainNode) -> None:
+        query = "\n".join(
+            str(block.get("text") or "")
+            for block in node.content
+            if block.get("type") == "text"
+        ).strip()
+        if query:
+            self.judge.query = query
+            self.extractor.query = query
+
+    def _open_window(self, node: SegmentChainNode) -> None:
+        # Context a non-productive delimit left behind leads the new window.
+        self._window = [*self._window, node]
+
+    async def _on_plan_boundary(self, node: SegmentChainNode) -> None:
+        """Plan events cut deterministically, without a continuity call.
+
+        ``TaskStateUpdate`` force-cuts and updates scope. The node is covered so
+        the frontend can fold it under a segment, but summary/judge prompts skip
+        it. ``PlanUpdate`` still opens the next stretch as its frame.
+        """
+        info = node.orchestration or {}
+        if info.get("category") == "PlanUpdate":
+            # The revision announces the next stretch of work, so it opens it.
+            await self._delimit("PlanUpdate", forced=True)
+            self._open_window(node)
+            return
+        if info.get("subtask_state") == "in_progress":
+            await self._delimit("TaskStateUpdate", forced=True)
+            self._scope = _build_scope(info)
+            # Lead the next stretch so its coverage absorbs this bookkeeping.
+            self._open_window(node)
+            return
+        self._window.append(node)
+        if not _productive_nodes(self._window):
+            # No productive work yet; keep the node so a later segment (or
+            # session_end with real work) can absorb it into coverage.
+            self._scope = None
+            return
+        await self._delimit("TaskStateUpdate", forced=True)
+        self._scope = None
+
+    async def _delimit(self, reason: BoundaryReason, *, forced: bool) -> None:
+        """Freeze the window, write the placeholder row, then extract metadata."""
+        snapshot = self._window
+        covered = _covered_nodes(snapshot)
+        productive = _productive_nodes(snapshot)
+        if not productive:
+            # Only framing / TaskStateUpdate bookkeeping: keep it in the window
+            # so a later productive segment can absorb those seqs for the FE.
+            return
+        self._window = []
+
+        self._segment_no += 1
+        now = _now()
+        # Coverage includes TaskStateUpdate so the frontend hides those cards;
+        # extraction below sees only the productive summary nodes.
+        event_ids = [eid for node in covered for eid in node.event_ids]
+        seqs = [seq for node in covered for seq in node.seqs]
+        summary = _summary_nodes(snapshot)
+        scope = self._scope
+        segment = Segment(
+            segment_id=f"seg_{self._segment_no:04d}",
+            session_id=self.session_id,
+            status="extracting",
+            coverage=Coverage(
+                start_seq=min(seqs), end_seq=max(seqs), event_ids=event_ids
+            ),
+            subtask=scope,
+            boundary_reason=reason,
+            forced_complete=forced,
+            started_at=covered[0].started_at,
+            ended_at=covered[-1].ended_at or covered[-1].started_at,
+            created_at=now,
+            updated_at=now,
+        )
+        self.stats.segments += 1
+        self.stats.boundaries[reason] = self.stats.boundaries.get(reason, 0) + 1
+        # The placeholder persists the boundary immediately but is not
+        # delivered: the host only publishes segments whose summary is ready.
+        await self._write(segment)
+
+        task = asyncio.create_task(
+            self._extract(segment, summary, covered, scope, reason)
+        )
+        self._extractions[task] = segment
+        task.add_done_callback(self._extractions.pop)
+
+    async def _extract(
+        self,
+        segment: Segment,
+        snapshot: list[SegmentChainNode],
+        covered: list[SegmentChainNode],
+        scope: SubtaskScope | None,
+        reason: BoundaryReason,
+    ) -> None:
+        async with self._slots:
+            result = await self.extractor.extract(
+                snapshot,
+                scope=scope,
+                boundary_reason=reason,
+                files=self._files_for(segment),
+            )
+        await self._log_extraction(segment.segment_id, covered, result)
+        if result.ok:
+            segment = segment.model_copy(
+                update={"status": "done", **result.fields, "updated_at": _now()}
+            )
+        else:
+            self.stats.failed += 1
+            segment = segment.model_copy(
+                update={"status": "failed", "updated_at": _now()}
+            )
+        await self._write(segment)
+        if segment.status == "done" and self.on_segment is not None:
+            await self.on_segment(segment)
+
+    def _files_for(self, segment: Segment) -> dict[str, str]:
+        """Return files produced inside this segment's coverage seq range.
+
+        A segment is worth summarizing even when the file feed is unavailable, so
+        a failure here costs the artifact list rather than the whole segment.
+        """
+
+        try:
+            files = self.artifact_files(
+                segment.coverage.start_seq, segment.coverage.end_seq
+            )
+        except Exception:
+            logger.exception(
+                "Artifact file lookup failed for %s", segment.segment_id
+            )
+            return {}
+        if not files:
+            logger.info(
+                "segment %s has no in-coverage artifact file", segment.segment_id
+            )
+        return files
+
+    async def _wait_extractions(self, budget: float) -> None:
+        """Wait out the in-flight extractions, failing whatever overruns."""
+        tasks = list(self._extractions)
+        if not tasks:
+            return
+        _finished, pending = await asyncio.wait(tasks, timeout=budget)
+        for task in pending:
+            segment = self._extractions.get(task)
+            task.cancel()
+            if segment is None:
+                continue
+            self.stats.failed += 1
+            logger.warning(
+                "segment %s extraction timed out at close", segment.segment_id
+            )
+            await self._write(
+                segment.model_copy(
+                    update={"status": "failed", "updated_at": _now()}
+                )
+            )
+
+    async def _write(self, segment: Segment) -> None:
+        self._seq += 1
+        self.stats.rows += 1
+        await self.on_row(segment)
+
+    # -- judge logs -------------------------------------------------------- #
+
+    async def _log_continuity(
+        self, peek: SegmentChainNode, decision: ContinuityDecision
+    ) -> None:
+        if self.on_judge_log is None:
+            return
+        await self.on_judge_log(
+            {
+                "type": "continuity",
+                "window_start_seq": self._window[0].seqs[0]
+                if self._window[0].seqs
+                else None,
+                "window_end_seq": self._window[-1].seqs[-1]
+                if self._window[-1].seqs
+                else None,
+                "peek_event_id": peek.event_ids[0] if peek.event_ids else None,
+                "continues": decision.continues,
+                "reason": decision.reason,
+            }
+        )
+
+    async def _log_extraction(
+        self,
+        segment_id: str,
+        covered: list[SegmentChainNode],
+        result: ExtractionOutcome,
+    ) -> None:
+        if self.on_judge_log is None:
+            return
+        await self.on_judge_log(
+            {
+                "type": "extraction",
+                "segment_id": segment_id,
+                "window_start_seq": covered[0].seqs[0] if covered[0].seqs else None,
+                "window_end_seq": covered[-1].seqs[-1] if covered[-1].seqs else None,
+                "ok": result.ok,
+                "fields": result.log_fields(),
+            }
+        )
+
+
+def _covered_nodes(window: list[SegmentChainNode]) -> list[SegmentChainNode]:
+    """Return the window nodes a segment claims, dropping pure context."""
+    return [node for node in window if node.covered and node.seqs]
+
+
+def _is_task_state_update(node: SegmentChainNode) -> bool:
+    info = node.orchestration or {}
+    return node.kind == "orchestration" and info.get("category") == "TaskStateUpdate"
+
+
+def _summary_nodes(window: list[SegmentChainNode]) -> list[SegmentChainNode]:
+    """Nodes the continuity judge and extractor may read.
+
+    ``TaskStateUpdate`` stays in the window for coverage (frontend fold) but is
+    omitted here so bookkeeping tools do not shape the segment summary.
+    """
+    return [node for node in window if not _is_task_state_update(node)]
+
+
+def _productive_nodes(window: list[SegmentChainNode]) -> list[SegmentChainNode]:
+    """Covered nodes that justify emitting a segment (excludes TaskStateUpdate)."""
+    return [node for node in _covered_nodes(window) if not _is_task_state_update(node)]
+
+
+def _build_scope(info: dict[str, Any]) -> SubtaskScope | None:
+    node_id = info.get("node_id")
+    if not node_id:
+        logger.warning("sub-task scope missing task_id/node_id: %r", info)
+        return None
+    graph_id = info.get("graph_id")
+    return SubtaskScope(
+        node_id=str(node_id),
+        node_name=str(info.get("node_name") or node_id),
+        graph_id=str(graph_id) if graph_id else None,
+    )
+
+
+def _scope_text(scope: SubtaskScope | None) -> str | None:
+    if scope is None:
+        return None
+    return f"{scope.node_name} (node_id={scope.node_id})"
+
+
+def _title_from(behavior: str) -> str:
+    """Derive a title from the first sentence of the behavior summary."""
+    for stop in ("。", ". ", "\n"):
+        head, sep, _ = behavior.partition(stop)
+        if sep:
+            return head[:TITLE_CHAR_CAP]
+    return behavior[:TITLE_CHAR_CAP]
+
+
+def _clean(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    return text or None
+
+
+def _text_field(value: Any) -> str | None:
+    """Normalize an extractor text field into a single markdown string.
+
+    A small model often ignores ``"type": "string"`` and emits a JSON array of
+    steps for input / behavior / conclusion. Folding those back into markdown
+    keeps a segment that is otherwise perfectly good.
+    """
+
+    if isinstance(value, str):
+        return value.strip() or None
+    if not isinstance(value, list):
+        return None
+    lines: list[str] = []
+    for index, item in enumerate(value, start=1):
+        if isinstance(item, str):
+            piece = item.strip()
+        elif isinstance(item, bool | int | float):
+            piece = str(item)
+        else:
+            continue
+        if not piece:
+            continue
+        lines.append(piece if _LIST_MARKER_RE.match(piece) else f"{index}. {piece}")
+    return "\n".join(lines).strip() or None
+
+
+def _mentions_filename(text: str, filename: str) -> bool:
+    """Whether ``filename`` appears as an exact path segment in ``text``."""
+    if not filename:
+        return False
+    pattern = re.compile(rf"(?<![\w.-]){re.escape(filename)}(?![\w.-])", re.IGNORECASE)
+    return pattern.search(text) is not None
+
+
+def _strip_artifact_names_from_input(
+    text: str | None, produced_names: set[str]
+) -> str | None:
+    """Drop input lines that name files produced in this window.
+
+    Input describes what the segment consumed, not what it wrote. ``produced_names``
+    is the in-window candidate set (plus any verified artifact names); lines that
+    mention those filenames are removed so outputs cannot pad input. An emptied
+    field becomes None.
+    """
+
+    names = {name for name in produced_names if name}
+    if text is None or not names:
+        return text
+    kept = [
+        line
+        for line in text.splitlines()
+        if line.strip() and not any(_mentions_filename(line, name) for name in names)
+    ]
+    return "\n".join(kept).strip() or None
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+__all__ = [
+    "ArtifactFiles",
+    "ChainBuilder",
+    "ContinuityDecision",
+    "ContinuityJudge",
+    "DEFAULT_MAX_SPAN",
+    "ExtractionOutcome",
+    "SegmentAssembler",
+    "SegmentChainNode",
+    "SegmentExtractor",
+    "SegmentStats",
+    "no_artifact_files",
+    "render_block",
+    "render_window",
+]

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/algo/biztrace/semantic_vocab.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/algo/biztrace/semantic_vocab.py
@@ -1,0 +1,250 @@
+# -*- coding: utf-8 -*-
+"""Semantic-config vocabulary used to link business entities in card bodies.
+
+Four Context Manager endpoints supply the terms: business domains, metrics,
+dimensions and datasets. They are pulled page by page into an in-memory index
+and refreshed in the background, so linking a card never touches the network.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from time import monotonic
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+BIZ_DOMAIN_PATH = "/api/semantic-config/biz-domain"
+DIMENSION_PATH = "/api/semantic-config/dimension"
+METRIC_PATH = "/api/semantic-config/metric-lib"
+DATASET_PATH = "/api/semantic-config/dataset-meta"
+
+DEFAULT_PAGE_SIZE = 200
+MAX_PAGES = 100
+DEFAULT_TIMEOUT_SECONDS = 10.0
+
+EntityType = str
+
+
+@dataclass(frozen=True)
+class VocabEntry:
+    """One linkable term and the record it points at."""
+
+    entity_type: EntityType
+    domain_id: str | None
+    entity_id: str | None
+
+
+@dataclass(frozen=True)
+class VocabSource:
+    """How one endpoint's records map onto vocabulary entries."""
+
+    entity_type: EntityType
+    path: str
+    name_field: str
+    id_field: str | None
+    synonym_field: str | None = None
+
+
+VOCAB_SOURCES: tuple[VocabSource, ...] = (
+    # Business domains match on their canonical name only: display_name and
+    # aliases are editorial labels and would over-link.
+    VocabSource(entity_type="biz_domain", path=BIZ_DOMAIN_PATH,
+                name_field="domain_name", id_field=None),
+    VocabSource(entity_type="metric", path=METRIC_PATH,
+                name_field="metric_name", id_field="metric_id",
+                synonym_field="synonyms"),
+    # /dimension rather than /dataset-dimension: only this one carries synonyms.
+    VocabSource(entity_type="dimension", path=DIMENSION_PATH,
+                name_field="dimension_name", id_field="dimension_id",
+                synonym_field="synonyms"),
+    VocabSource(entity_type="dataset", path=DATASET_PATH,
+                name_field="dataset_name", id_field="dataset_id"),
+)
+
+
+def split_terms(value: Any) -> list[str]:
+    """Split a comma- or pipe-separated synonym field, as the graph loader does."""
+    if not value:
+        return []
+    if isinstance(value, str):
+        if "," in value or "|" in value:
+            return [
+                part.strip()
+                for part in value.replace("|", ",").split(",")
+                if part.strip()
+            ]
+        return [value.strip()] if value.strip() else []
+    if isinstance(value, (list, tuple)):
+        return [str(item).strip() for item in value if str(item).strip()]
+    return [str(value).strip()]
+
+
+class SemanticVocabulary:
+    """In-memory term index with TTL refresh and silent degradation."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        datasource_id: str | None,
+        access_token: str | None = None,
+        ttl: float = 300.0,
+        page_size: int = DEFAULT_PAGE_SIZE,
+        timeout: float = DEFAULT_TIMEOUT_SECONDS,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.datasource_id = datasource_id
+        self.access_token = access_token
+        self.ttl = ttl
+        self.page_size = page_size
+        self.timeout = timeout
+        self._client = client
+        self._owns_client = client is None
+        self._terms: dict[str, VocabEntry] = {}
+        self._loaded_at = 0.0
+        self._lock = asyncio.Lock()
+
+    @property
+    def terms(self) -> dict[str, VocabEntry]:
+        return self._terms
+
+    async def aclose(self) -> None:
+        if self._owns_client and self._client is not None:
+            await self._client.aclose()
+            self._client = None
+
+    async def ensure_fresh(self) -> None:
+        """Reload the vocabulary when the TTL has elapsed; never raises."""
+        if self._terms and monotonic() - self._loaded_at < self.ttl:
+            return
+        async with self._lock:
+            if self._terms and monotonic() - self._loaded_at < self.ttl:
+                return
+            terms = await self._load()
+            if terms is None:
+                # Keep serving the previous snapshot rather than un-linking.
+                return
+            self._terms = terms
+            self._loaded_at = monotonic()
+
+    async def _load(self) -> dict[str, VocabEntry] | None:
+        collected: dict[str, list[VocabEntry]] = {}
+        loaded_any = False
+        for source in VOCAB_SOURCES:
+            records = await self._fetch(source)
+            if records is None:
+                continue
+            loaded_any = True
+            for record in records:
+                self._collect(collected, source, record)
+        if not loaded_any:
+            return None
+        # A term claimed by more than one record is ambiguous, within a type or
+        # across types, and is dropped rather than linked to an arbitrary one.
+        return {
+            term: entries[0]
+            for term, entries in collected.items()
+            if len(entries) == 1
+        }
+
+    def _collect(
+        self,
+        collected: dict[str, list[VocabEntry]],
+        source: VocabSource,
+        record: dict[str, Any],
+    ) -> None:
+        # v2.1: only datasets stay datasource-scoped. Domain / dimension /
+        # metric rows no longer carry datasource_id; filtering them would
+        # silently drop every term in a bound session.
+        if (
+            source.path == DATASET_PATH
+            and self.datasource_id
+            and record.get("datasource_id") != self.datasource_id
+        ):
+            return
+        name = record.get(source.name_field)
+        if not isinstance(name, str) or not name.strip():
+            return
+        entry = VocabEntry(
+            entity_type=source.entity_type,
+            domain_id=_as_id(record.get("domain_id")),
+            entity_id=(
+                _as_id(record.get(source.id_field)) if source.id_field else None
+            ),
+        )
+        terms = [name.strip()]
+        if source.synonym_field:
+            terms.extend(split_terms(record.get(source.synonym_field)))
+        for term in terms:
+            if term:
+                collected.setdefault(term, []).append(entry)
+
+    async def _fetch(self, source: VocabSource) -> list[dict[str, Any]] | None:
+        records: list[dict[str, Any]] = []
+        params: dict[str, Any] = {"size": self.page_size}
+        if source.path == DATASET_PATH and self.datasource_id:
+            params["datasource_id"] = self.datasource_id
+        try:
+            for page in range(1, MAX_PAGES + 1):
+                payload = await self._get(source.path, {**params, "page": page})
+                if isinstance(payload, list):
+                    return [item for item in payload if isinstance(item, dict)]
+                page_records = payload.get("records")
+                if not isinstance(page_records, list):
+                    return records
+                records.extend(
+                    item for item in page_records if isinstance(item, dict)
+                )
+                total = payload.get("total")
+                if not page_records or not isinstance(total, int):
+                    return records
+                if len(records) >= total:
+                    return records
+        except (httpx.HTTPError, ValueError) as exc:
+            logger.warning("semantic vocabulary %s unavailable: %s", source.path, exc)
+            return None
+        return records
+
+    async def _get(self, path: str, params: dict[str, Any]) -> Any:
+        if self._client is None:
+            self._client = httpx.AsyncClient(timeout=self.timeout)
+            self._owns_client = True
+        headers: dict[str, str] = {}
+        if self.access_token:
+            headers["Authorization"] = f"Bearer {self.access_token}"
+        response = await self._client.get(
+            f"{self.base_url}{path}", params=params, headers=headers
+        )
+        if response.status_code in (401, 403):
+            raise httpx.HTTPError(
+                f"HTTP {response.status_code} (auth rejected for {path})"
+            )
+        if not response.is_success:
+            raise httpx.HTTPError(f"HTTP {response.status_code}")
+        return response.json()
+
+
+def _as_id(value: Any) -> str | None:
+    if value is None or isinstance(value, bool):
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+__all__ = [
+    "BIZ_DOMAIN_PATH",
+    "DATASET_PATH",
+    "DIMENSION_PATH",
+    "METRIC_PATH",
+    "SemanticVocabulary",
+    "VOCAB_SOURCES",
+    "VocabEntry",
+    "VocabSource",
+    "split_terms",
+]

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/algo/biztrace/settings.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/algo/biztrace/settings.py
@@ -1,0 +1,127 @@
+# -*- coding: utf-8 -*-
+"""Feature switches, budgets and vocabulary config for BizTrace.
+
+The model is not configured here: the host builds it from the user's
+preferences and hands it to the Transformer.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+CONVERTER_QUEUE_SIZE = 2048
+SEGMENT_QUEUE_SIZE = 1024
+PRESENTATION_TIMEOUT_SECONDS = 5.0
+JUDGE_TIMEOUT_SECONDS = 30.0
+EXTRACT_TIMEOUT_SECONDS = 60.0
+FLUSH_BUDGET_SECONDS = 75.0
+
+_ENV_PREFIX = "QWENPAW_DATA_"
+CM_FRONTEND_URL_ENV = f"{_ENV_PREFIX}CM_FRONTEND_URL"
+DEFAULT_CM_FRONTEND_URL = "http://localhost:3000"
+
+
+def _env(name: str) -> str | None:
+    raw = os.environ.get(f"{_ENV_PREFIX}{name.upper()}")
+    if raw is None or not raw.strip():
+        return None
+    return raw.strip()
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = _env(name)
+    if raw is None:
+        return default
+    return raw.lower() not in {"0", "false", "no", "off"}
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = _env(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return default
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = _env(name)
+    if raw is None:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        return default
+
+
+def _env_lang(name: str, default: Literal["zh", "en"]) -> Literal["zh", "en"]:
+    raw = (_env(name) or "").lower()
+    return raw if raw in ("zh", "en") else default  # type: ignore[return-value]
+
+
+class BizTraceSettings(BaseModel):
+    """Runtime configuration; every knob degrades to a safe default.
+
+    Defaults come from ``QWENPAW_DATA_*`` env vars; constructor kwargs win.
+    """
+
+    biz_trace_enabled: bool = Field(
+        default_factory=lambda: _env_bool("biz_trace_enabled", True)
+    )
+    trace2segment_enabled: bool = Field(
+        default_factory=lambda: _env_bool("trace2segment_enabled", True)
+    )
+
+    biz_trace_log_dir: str | None = Field(
+        default_factory=lambda: _env("biz_trace_log_dir")
+    )
+
+    segment_max_span: int = Field(
+        default_factory=lambda: _env_int("segment_max_span", 100)
+    )
+    segment_extract_concurrency: int = Field(
+        default_factory=lambda: _env_int("segment_extract_concurrency", 2)
+    )
+    segment_prompt_lang: Literal["zh", "en"] = Field(
+        default_factory=lambda: _env_lang("segment_prompt_lang", "zh")
+    )
+
+    biz_link_enabled: bool = Field(
+        default_factory=lambda: _env_bool("biz_link_enabled", True)
+    )
+    biz_link_base_url: str | None = Field(
+        default_factory=lambda: _env("biz_link_base_url")
+    )
+    biz_link_datasource_id: str | None = Field(
+        default_factory=lambda: _env("biz_link_datasource_id")
+    )
+    biz_link_ttl: float = Field(
+        default_factory=lambda: _env_float("biz_link_ttl", 300.0)
+    )
+
+
+def resolve_link_base_url(settings: BizTraceSettings) -> str:
+    """Origin the entity links point at; defaults to the Context frontend."""
+    configured = (settings.biz_link_base_url or "").strip()
+    if configured:
+        return configured.rstrip("/")
+    frontend = (os.environ.get(CM_FRONTEND_URL_ENV) or "").strip()
+    return (frontend or DEFAULT_CM_FRONTEND_URL).rstrip("/")
+
+
+__all__ = [
+    "BizTraceSettings",
+    "CM_FRONTEND_URL_ENV",
+    "CONVERTER_QUEUE_SIZE",
+    "DEFAULT_CM_FRONTEND_URL",
+    "EXTRACT_TIMEOUT_SECONDS",
+    "FLUSH_BUDGET_SECONDS",
+    "JUDGE_TIMEOUT_SECONDS",
+    "PRESENTATION_TIMEOUT_SECONDS",
+    "SEGMENT_QUEUE_SIZE",
+    "resolve_link_base_url",
+]

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/algo/biztrace/store.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/algo/biztrace/store.py
@@ -1,0 +1,106 @@
+# -*- coding: utf-8 -*-
+"""Append-only JSONL storage for BizTrace rows, segments and judge logs."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class StorePaths:
+    """The three JSONL files a session writes."""
+
+    biz_trace: Path
+    segments: Path
+    judge: Path
+
+
+def build_store_paths(*, session_id: str, log_dir: str | None = None) -> StorePaths:
+    """Locate the JSONL files for one session.
+
+    They live outside every agent workspace on purpose: anything under one is
+    reported by ``list_session_files`` and would pollute artifact verification.
+    """
+
+    from qwenpaw_data.host.core.paths import resolve_qwenpaw_data_home
+
+    root = (
+        Path(log_dir)
+        if log_dir
+        else resolve_qwenpaw_data_home() / "host" / "biztrace"
+    )
+    return StorePaths(
+        biz_trace=root / "biz_trace" / f"{session_id}.jsonl",
+        segments=root / "segments" / f"{session_id}.jsonl",
+        judge=root / "segments" / f"{session_id}.judge.jsonl",
+    )
+
+
+def _append_lines(path: Path, lines: list[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        for line in lines:
+            handle.write(line)
+            handle.write("\n")
+
+
+def _read_rows(path: Path) -> list[dict[str, Any]]:
+    if not path.is_file():
+        return []
+    rows: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                payload = json.loads(line)
+            except ValueError:
+                # Partial line from an interrupted process; readers skip it.
+                continue
+            if isinstance(payload, dict):
+                rows.append(payload)
+    return rows
+
+
+class BizTraceStore:
+    """Write and read the derived JSONL streams off the event loop."""
+
+    def __init__(self, paths: StorePaths, *, enabled: bool = True) -> None:
+        self.paths = paths
+        self.enabled = enabled
+
+    async def append_event(self, *, seq: int, event: dict[str, Any]) -> None:
+        await self._append(self.paths.biz_trace, {"seq": seq, "event": event})
+
+    async def append_segment(self, *, seq: int, segment: dict[str, Any]) -> None:
+        await self._append(self.paths.segments, {"seq": seq, "segment": segment})
+
+    async def append_judge(self, entry: dict[str, Any]) -> None:
+        await self._append(self.paths.judge, entry)
+
+    async def _append(self, path: Path, payload: dict[str, Any]) -> None:
+        if not self.enabled:
+            return
+        line = json.dumps(payload, ensure_ascii=False)
+        try:
+            await asyncio.to_thread(_append_lines, path, [line])
+        except OSError:
+            logger.exception("Failed to append BizTrace row to %s", path)
+
+    async def read_events(self) -> list[dict[str, Any]]:
+        return await asyncio.to_thread(_read_rows, self.paths.biz_trace)
+
+    async def read_segments(self, *, after_seq: int = -1) -> list[dict[str, Any]]:
+        rows = await asyncio.to_thread(_read_rows, self.paths.segments)
+        return [row for row in rows if int(row.get("seq", -1)) > after_seq]
+
+
+__all__ = ["BizTraceStore", "StorePaths", "build_store_paths"]

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/algo/biztrace/tools.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/algo/biztrace/tools.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+"""Canonical tool names shared by presentation, segmentation and artifacts.
+
+The agent registers AgentScope's built-in tools (``Read`` / ``Write`` / ``Edit``
+/ ``Bash`` / ``Glob`` / ``Grep``) plus MCP tools, while both PRDs speak in terms
+of ``read_file`` / ``write_file`` / ``edit_file``. Plan tools keep the host's
+exact names (``PlanCreate`` / ``PlanUpdate`` / ``TaskStateUpdate``). Everything
+downstream keys off the canonical name so a rename on either side stays local
+to this module.
+"""
+
+from __future__ import annotations
+
+CANONICAL_TOOL_NAMES: dict[str, str] = {
+    "read": "read_file",
+    "write": "write_file",
+    "edit": "edit_file",
+    "multiedit": "edit_file",
+    "notebookedit": "edit_file",
+    "bash": "execute_shell_command",
+    # Host plan tools already use their public names; normalize case only.
+    "plancreate": "PlanCreate",
+    "planupdate": "PlanUpdate",
+    "taskstateupdate": "TaskStateUpdate",
+}
+
+ASK_USER_QUESTION = "ask_user_question"
+SPAWN_SUBAGENT = "spawn_subagent"
+# AgentScope's builtin skill viewer; reads a skill by name, not by path.
+SKILL_VIEWER = "Skill"
+
+ORCHESTRATION_TOOLS = frozenset({"PlanCreate", "PlanUpdate", "TaskStateUpdate"})
+PLAN_SUMMARY_TOOLS = frozenset({"PlanCreate", "PlanUpdate"})
+
+# Result cards for these say nothing new beyond "the call landed".
+NOTE_ONLY_RESULT_TOOLS = frozenset({"TaskStateUpdate"})
+
+
+def canonical_tool_name(tool_name: str | None) -> str:
+    """Normalize a registered tool name to the name the PRDs / host use."""
+    if not tool_name:
+        return ""
+    raw = tool_name.rsplit("__", 1)[-1].strip()
+    return CANONICAL_TOOL_NAMES.get(raw.lower(), raw)
+
+
+__all__ = [
+    "ASK_USER_QUESTION",
+    "CANONICAL_TOOL_NAMES",
+    "NOTE_ONLY_RESULT_TOOLS",
+    "ORCHESTRATION_TOOLS",
+    "PLAN_SUMMARY_TOOLS",
+    "SKILL_VIEWER",
+    "SPAWN_SUBAGENT",
+    "canonical_tool_name",
+]

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/algo/biztrace/transformer.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/algo/biztrace/transformer.py
@@ -1,0 +1,143 @@
+# -*- coding: utf-8 -*-
+"""The algorithm side of the Segment contract: one Transformer per Chat.
+
+Everything the host sees is here: the constructor the host middleware calls, the
+three lifecycle calls, and the two Envelope methods the algorithm is allowed to
+touch. The conversion and segmentation logic sits behind
+:class:`~qwenpaw_data.host.core.algo.biztrace.pipeline.BizTracePipeline`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from qwenpaw_data.host.core.algo.biztrace.llm import for_structured_calls
+from qwenpaw_data.host.core.algo.biztrace.pipeline import BizTracePipeline, build_pipeline
+from qwenpaw_data.host.core.model import build_model_from_env
+from qwenpaw_data.host.core.providers.factory import build_model
+from qwenpaw_data.host.core.utils.workspace import list_session_files
+
+if TYPE_CHECKING:
+    from agentscope.model import ChatModelBase
+
+    # Typing only: the host's runtime package imports this module through its
+    # middleware, so importing it back at import time would close a cycle.
+    from qwenpaw_data.host.core.runtime.context import RunContext
+    from qwenpaw_data.host.core.runtime.envelope import Envelope
+
+logger = logging.getLogger(__name__)
+
+
+class BizTraceTransformer:
+    """Turn one Chat's raw agent events into BizEvents and Segments.
+
+    The host drives ``start`` once, ``append`` per event, and ``join`` before
+    the terminal SSE event. None of the three may block the reply, so all the
+    work happens on the pipeline's own workers.
+    """
+
+    def __init__(self, *, run_context: RunContext, envelope: Envelope) -> None:
+        self.run_context = run_context
+        self.chat_id = run_context.chat_id
+        self.session_id = run_context.session_id
+        self.artifact_dir = Path(run_context.paths.artifact_dir)
+        self.datasource_id = run_context.request_context.get("datasource_id")
+        token = run_context.request_context.get("access_token")
+        self.access_token = token if isinstance(token, str) else None
+        self.envelope = envelope
+        self._pipeline: BizTracePipeline | None = None
+        self._flush: asyncio.Task[None] | None = None
+
+    async def start(self) -> None:
+        """Build the pipeline and spin up its workers; never raises."""
+        if self._pipeline is not None:
+            return
+        try:
+            self._pipeline = build_pipeline(
+                session_id=self.session_id,
+                datasource_id=self.datasource_id,
+                access_token=self.access_token,
+                biz_event_callback=self.envelope.send_biz_event,
+                segment_callback=self.envelope.send_segment,
+                lister=self._list_files,
+                chat_model=self._chat_model(),
+            )
+        except Exception:
+            logger.exception("BizTrace failed to start for chat %s", self.chat_id)
+
+    async def append(self, entry: dict[str, Any] | None, *, last: bool = False) -> None:
+        """Enqueue one raw entry; ``last`` is the EOF sentinel and carries none.
+
+        Non-blocking by contract: the queue is bounded and drops rather than
+        waits, so a slow model can never hold the reply up.
+        """
+
+        try:
+            pipeline = self._pipeline
+            if pipeline is not None and entry is not None:
+                pipeline.on_trace_event(dict(entry))
+            if last:
+                # Start flushing now rather than at join, so the last segment's
+                # summary runs while the host closes the turn down.
+                self._begin_flush()
+        except Exception:
+            logger.exception("BizTrace failed to accept an entry")
+
+    async def join(self) -> None:
+        """Wait until every BizEvent and Segment has been sent."""
+        self._begin_flush()
+        task = self._flush
+        if task is None:
+            return
+        # Shielded: the host caps this wait, and a cancelled wait must not take
+        # the flush down with it, or the events already in the worker would die
+        # with the Chat instead of reaching the host.
+        await asyncio.shield(task)
+
+    def _chat_model(self) -> ChatModelBase | None:
+        """The model every step runs on, or None to stay on the rule-based path.
+
+        ``light`` is the small model the user picked for background work; the
+        default model stands in when none is configured. Without either, a
+        fresh env-configured model is built — never the agent's own instance,
+        which retuning would corrupt.
+        """
+
+        config = self.run_context.user_runtime_config
+        active = None
+        if config is not None:
+            active = getattr(config, "light", None) or getattr(
+                config, "default", None
+            )
+        try:
+            if active is not None:
+                return for_structured_calls(build_model(active))
+            return for_structured_calls(build_model_from_env())
+        except Exception:
+            logger.exception(
+                "BizTrace has no usable model for chat %s; using rule-based cards",
+                self.chat_id,
+            )
+            return None
+
+    def _begin_flush(self) -> None:
+        if self._flush is None and self._pipeline is not None:
+            self._flush = asyncio.create_task(self._flush_pipeline())
+
+    async def _flush_pipeline(self) -> None:
+        pipeline = self._pipeline
+        if pipeline is None:
+            return
+        try:
+            await pipeline.aclose()
+        except Exception:
+            logger.exception("BizTrace failed to flush chat %s", self.chat_id)
+
+    def _list_files(self) -> list[dict[str, Any]]:
+        return list_session_files(self.artifact_dir)
+
+
+__all__ = ["BizTraceTransformer"]

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/algo/biztrace/workspace_index.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/algo/biztrace/workspace_index.py
@@ -1,0 +1,257 @@
+# -*- coding: utf-8 -*-
+"""Turn chat agent-view files into artifacts the frontend can open.
+
+The candidate set is the host ``artifact_delta`` files whose producing
+tool_result seq falls inside the segment coverage. Verification stays
+two-level: the candidate must be in that set, and ``list_session_files`` must
+still find it under the artifact root. The listing supplies the
+``relative_path`` handed to the frontend, so a name the model invented can
+never become a download link. What the model adds on top is labelling — a
+description, a kind and a role — over a candidate set it cannot extend.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import dataclass
+from posixpath import basename, splitext
+from typing import Any
+
+from qwenpaw_data.host.core.algo.biztrace.models import Artifact
+
+logger = logging.getLogger(__name__)
+
+_NAME_TRIM = " \t\n`\"'《》「」()（）"
+
+_QUERY_EXTS = frozenset({".sql"})
+_DATASET_EXTS = frozenset({".csv", ".tsv", ".parquet", ".xlsx"})
+_REPORT_EXTS = frozenset({".md", ".pdf", ".txt"})
+_DASHBOARD_EXTS = frozenset({".html", ".htm"})
+# Files a run writes about itself rather than for the user.
+_SUPPORTING_NAMES = frozenset(
+    {"problem.json", "schema.json", "metrics.json", "nl2sql_prompt.md"}
+)
+_INTERMEDIATE_MARKERS = ("/steps/", "/tmp/", "/raw/", "/intermediate/", "/data/raw/")
+_DISPLAYABLE_KINDS = frozenset({"dataset", "report", "dashboard"})
+_KIND_VALUES = frozenset({"query_script", "dataset", "report", "dashboard", "other"})
+_ROLE_VALUES = frozenset({"intermediate", "final", "supporting"})
+
+# Shaped like ``utils.workspace.list_session_files``: the host owns the listing,
+# and its ``rel_path`` is what a download URL is built from.
+WorkspaceLister = Callable[[], list[dict[str, Any]]]
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactProposal:
+    """One artifact entry as the extractor wrote it, before verification.
+
+    ``kind`` and ``role`` may be empty: a small model skips them, and the
+    workspace path is a better guess than a wrong label anyway.
+    """
+
+    name: str
+    description: str = ""
+    kind: str = ""
+    role: str = ""
+
+
+def resolve_artifact(name: str, files: Mapping[str, str]) -> str | None:
+    """Match a proposed artifact name against files that were actually saved.
+
+    A model names a file loosely — with its directory, in quotes, or wrapped in
+    prose. Only the filename is trusted, and only when exactly one candidate
+    fits, so a vague name never resolves to an arbitrary file.
+    """
+
+    candidate = basename(name.strip(_NAME_TRIM))
+    if candidate in files:
+        return candidate
+    matches = [filename for filename in files if filename in name]
+    if len(matches) == 1:
+        return matches[0]
+    return None
+
+
+def infer_artifact_meta(name: str, path: str) -> tuple[str, str, str]:
+    """Infer kind / role / a short description from a filename and its path.
+
+    This is what a candidate the model never labelled falls back to, so an
+    unmentioned final report still reaches the card.
+    """
+
+    lower = name.lower()
+    # Rooted so a marker matches a relative path too: tools write both
+    # "steps/x.csv" and "/session/steps/x.csv".
+    path_lower = "/" + path.lower().replace("\\", "/").lstrip("/")
+    ext = splitext(lower)[1]
+    intermediate = any(marker in path_lower for marker in _INTERMEDIATE_MARKERS)
+
+    if lower in _SUPPORTING_NAMES or ext == ".py":
+        return "other", "supporting", "探测或生成脚本"
+    if ext in _QUERY_EXTS:
+        return "query_script", "supporting", "查询脚本"
+    if ext in _DASHBOARD_EXTS:
+        if "dashboard" in lower or "dashboard" in path_lower:
+            return "dashboard", "final", "交互式看板"
+        return "report", "final", "HTML 报告"
+    if ext in _REPORT_EXTS:
+        if intermediate:
+            return "other", "supporting", "中间说明文件"
+        return "report", "final", "分析报告"
+    if ext in _DATASET_EXTS:
+        if intermediate:
+            return "dataset", "intermediate", "中间结果数据"
+        return "dataset", "final", "结果数据"
+    return "other", "supporting", "工作区文件"
+
+
+def is_displayable_artifact(*, kind: str, role: str, relative_path: str | None) -> bool:
+    """Whether an artifact passes the frontend keep filter.
+
+    Keep query scripts and final datasets / reports / dashboards. Everything
+    else — intermediate CSVs, probing files, generator scripts, pathless rows —
+    stays out of the segment card.
+    """
+
+    if not relative_path:
+        return False
+    if kind == "query_script":
+        return True
+    return role == "final" and kind in _DISPLAYABLE_KINDS
+
+
+def normalize_kind(raw: str | None, fallback: str) -> str:
+    """Return a known artifact kind, else ``fallback``."""
+    value = (raw or "").strip()
+    return value if value in _KIND_VALUES else fallback
+
+
+def normalize_role(raw: str | None, fallback: str) -> str:
+    """Return a known artifact role, else ``fallback``."""
+    value = (raw or "").strip()
+    return value if value in _ROLE_VALUES else fallback
+
+
+class ArtifactVerifier:
+    """Turn the files a segment produced into links the workspace can back.
+
+    Verification is deliberately two-level: the host must have registered the
+    file for this segment, and the file must still be listed under the artifact
+    root. The listing wins on the path, so ``relative_path`` is always something
+    the frontend can fetch.
+    """
+
+    def __init__(self, lister: WorkspaceLister | None = None) -> None:
+        self.lister = lister
+        self.unverified = 0
+
+    def verify(
+        self,
+        proposals: Iterable[ArtifactProposal],
+        *,
+        files: Mapping[str, str],
+    ) -> list[Artifact] | None:
+        """Return the displayable artifacts among the files the segment produced.
+
+        The candidate set is ``files`` and nothing else. A proposal that fits a
+        candidate improves its description, kind and role; a candidate nobody
+        named is inferred from its path, so a file the model forgot is not lost.
+
+        Args:
+            proposals: What the extractor named, in its own words.
+            files: Filename-to-path map of what this segment produced.
+        """
+
+        labels = self._resolve(proposals, files)
+        listed = self._listing()
+        artifacts: list[Artifact] = []
+        filtered: list[str] = []
+        for filename, path in sorted(files.items()):
+            label = labels.get(filename)
+            rel_path = _match_listing(filename, path, listed)
+            if rel_path is None:
+                if label is not None:
+                    self.unverified += 1
+                    logger.info(
+                        "artifact %s is not in the workspace listing", filename
+                    )
+                continue
+            kind_guess, role_guess, description_guess = infer_artifact_meta(
+                filename, path
+            )
+            kind = normalize_kind(label.kind if label else "", kind_guess)
+            role = normalize_role(label.role if label else "", role_guess)
+            if not is_displayable_artifact(
+                kind=kind, role=role, relative_path=rel_path
+            ):
+                filtered.append(f"{filename}({kind}/{role})")
+                continue
+            description = (label.description if label else "") or description_guess
+            artifacts.append(
+                Artifact(
+                    name=filename,
+                    description=description,
+                    relative_path=rel_path,
+                    kind=kind,  # type: ignore[arg-type]
+                    role=role,  # type: ignore[arg-type]
+                )
+            )
+        # Logged as a summary so a run that keeps nothing is distinguishable
+        # from one that had no candidate to begin with.
+        logger.info(
+            "artifact verification: %d candidates, %d kept, %d filtered%s",
+            len(files),
+            len(artifacts),
+            len(filtered),
+            f" ({', '.join(filtered)})" if filtered else "",
+        )
+        return artifacts or None
+
+    def _resolve(
+        self,
+        proposals: Iterable[ArtifactProposal],
+        files: Mapping[str, str],
+    ) -> dict[str, ArtifactProposal]:
+        """Key the proposals by the candidate they name, counting the misses."""
+        labels: dict[str, ArtifactProposal] = {}
+        for proposal in proposals:
+            filename = resolve_artifact(proposal.name, files)
+            if filename is None:
+                self.unverified += 1
+                continue
+            labels.setdefault(filename, proposal)
+        return labels
+
+    def _listing(self) -> list[str]:
+        if self.lister is None:
+            return []
+        try:
+            listed = self.lister()
+        except Exception:
+            logger.exception("Workspace listing failed; dropping all artifacts")
+            return []
+        return [str(item.get("rel_path") or "") for item in listed]
+
+
+def _match_listing(filename: str, recorded_path: str, listed: list[str]) -> str | None:
+    """Locate the listed file, preferring the exact path the tool wrote."""
+    tail = recorded_path.replace("\\", "/").lstrip("./")
+    if tail in listed:
+        return tail
+    matches = [rel_path for rel_path in listed if basename(rel_path) == filename]
+    if len(matches) == 1:
+        return matches[0]
+    return None
+
+
+__all__ = [
+    "ArtifactProposal",
+    "ArtifactVerifier",
+    "WorkspaceLister",
+    "infer_artifact_meta",
+    "is_displayable_artifact",
+    "normalize_kind",
+    "normalize_role",
+    "resolve_artifact",
+]

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/runtime/chat_runtime.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/runtime/chat_runtime.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Literal
 
 from agentscope.event import EventType
 from agentscope.message import UserMsg
 
+from qwenpaw_data.host.core.algo.biztrace.transformer import BizTraceTransformer
 from qwenpaw_data.host.core.algo.followup.recommend import FollowUpRecommend
 from qwenpaw_data.host.core.domain.chat import Chat
 from qwenpaw_data.host.core.domain.identity import Identity
@@ -22,16 +25,25 @@ from qwenpaw_data.host.core.runtime.turn import TurnInput
 from qwenpaw_data.host.core.store.protocols import ChatEventStore, ChatStore
 from qwenpaw_data.host.core.stream.hub import get_hub
 from qwenpaw_data.host.core.stream.output_stream import OutputStream
+from qwenpaw_data.host.core.utils.ids import create_id
+from qwenpaw_data.host.core.utils.workspace import list_session_files
 
 Outcome = Literal["completed", "canceled", "failed"]
 
 FOLLOWUP_ENABLED_ENV = "QWENPAW_DATA_FOLLOWUP_ENABLED"
+BIZTRACE_ENABLED_ENV = "QWENPAW_DATA_BIZ_TRACE_ENABLED"
+BIZTRACE_JOIN_TIMEOUT_SECONDS = 90.0
 
 logger = logging.getLogger(__name__)
 
 
 def _followup_enabled() -> bool:
     raw = (os.environ.get(FOLLOWUP_ENABLED_ENV) or "1").strip().lower()
+    return raw not in {"0", "false", "off"}
+
+
+def _biztrace_enabled() -> bool:
+    raw = (os.environ.get(BIZTRACE_ENABLED_ENV) or "1").strip().lower()
     return raw not in {"0", "false", "off"}
 
 
@@ -57,6 +69,9 @@ class ChatRuntime:
         self._run_context: RunContext | None = None
         self._stream: OutputStream | None = None
         self._followup: FollowUpRecommend | None = None
+        self._biztrace: BizTraceTransformer | None = None
+        self._envelope: Envelope | None = None
+        self._artifact_seen: dict[str, tuple[int, int]] = {}
 
     @property
     def agent(self) -> Any:
@@ -115,6 +130,7 @@ class ChatRuntime:
             )
             self._stream = stream
             envelope = Envelope(stream)
+            self._envelope = envelope
             await envelope.begin()
 
             request_context = {"datasource_id": chat.datasource_id}
@@ -131,8 +147,11 @@ class ChatRuntime:
                 identity=identity,
                 request_context=request_context,
             )
+            await self._load_runtime_config(identity)
             if _followup_enabled():
-                await self._start_followup(chat, identity, envelope)
+                await self._start_followup(chat, envelope)
+            if _biztrace_enabled():
+                await self._start_biztrace(chat, envelope)
             if self._cancel_requested:
                 outcome, error = "canceled", None
             else:
@@ -142,6 +161,7 @@ class ChatRuntime:
                     envelope,
                     after_event_callback=self._after_event_callback,
                 )
+                await self._deliver_biztrace()
                 await self._deliver_followup(envelope)
                 outcome, error = "completed", None
         except asyncio.CancelledError:
@@ -157,24 +177,30 @@ class ChatRuntime:
             )
 
         await self._executor.stop()
-        if self._followup is not None and outcome != "completed":
-            # Cancel/failure path: stop collecting without recommending.
-            await self._followup.append(None, last=True)
+        if outcome != "completed":
+            # Cancel/failure path: stop collecting without waiting on results.
+            if self._followup is not None:
+                await self._followup.append(None, last=True)
+            if self._biztrace is not None:
+                await self._biztrace.append(None, last=True)
         await self._finish(chat, envelope, outcome, error=error)
+
+    async def _load_runtime_config(self, identity: Identity) -> None:
+        """Attach the user's model preferences to the run context; never raises."""
+        if self.prefs is None or self._run_context is None:
+            return
+        try:
+            prefs = await self.prefs.load(identity.user_id)
+            self._run_context.user_runtime_config = prefs.runtime_config()
+        except Exception:
+            logger.exception("failed to load preferences for chat runtime")
 
     async def _start_followup(
         self,
         chat: Chat,
-        identity: Identity,
         envelope: Envelope,
     ) -> None:
         try:
-            if self.prefs is not None and self._run_context is not None:
-                try:
-                    prefs = await self.prefs.load(identity.user_id)
-                    self._run_context.user_runtime_config = prefs.runtime_config()
-                except Exception:
-                    logger.exception("followup: failed to load preferences")
             followup = FollowUpRecommend(
                 run_context=self._run_context,
                 previous_followups=await self._load_previous_followups(chat),
@@ -193,6 +219,51 @@ class ChatRuntime:
         except Exception:
             logger.exception("followup: failed to start for chat %s", chat.id)
             self._followup = None
+
+    async def _start_biztrace(
+        self,
+        chat: Chat,
+        envelope: Envelope,
+    ) -> None:
+        try:
+            transformer = BizTraceTransformer(
+                run_context=self._run_context,
+                envelope=envelope,
+            )
+            await transformer.start()
+            await transformer.append(
+                {
+                    "kind": "user_input",
+                    "payload": UserMsg(
+                        name="user", content=chat.user_input
+                    ).model_dump(),
+                }
+            )
+            self._artifact_seen = self._artifact_snapshot()
+            self._biztrace = transformer
+        except Exception:
+            logger.exception("biztrace: failed to start for chat %s", chat.id)
+            self._biztrace = None
+
+    async def _deliver_biztrace(self) -> None:
+        """Cap the wait here: the algorithm's join is shielded and has no limit."""
+        biztrace = self._biztrace
+        if biztrace is None:
+            return
+        try:
+            await biztrace.append(None, last=True)
+            await asyncio.wait_for(
+                biztrace.join(), timeout=BIZTRACE_JOIN_TIMEOUT_SECONDS
+            )
+        except TimeoutError:
+            logger.warning(
+                "biztrace: join timed out after %ss for chat %s; "
+                "completing with raw trace only",
+                BIZTRACE_JOIN_TIMEOUT_SECONDS,
+                biztrace.chat_id,
+            )
+        except Exception:
+            logger.exception("biztrace: delivery failed")
 
     async def _deliver_followup(self, envelope: Envelope) -> None:
         followup = self._followup
@@ -226,15 +297,85 @@ class ChatRuntime:
             return ()
 
     async def _after_event_callback(self, event: Any) -> None:
-        if self._followup is not None and hasattr(event, "model_dump"):
-            await self._followup.append(
-                {"kind": "agent_event", "payload": event.model_dump()}
-            )
+        if self._biztrace is not None and self._is_tool_success(event):
+            # Delta first: the pipeline binds pending files to the coming
+            # TOOL_RESULT_END, so order matters.
+            await self._register_new_files()
+        if hasattr(event, "model_dump"):
+            entry = {"kind": "agent_event", "payload": event.model_dump()}
+            if self._followup is not None:
+                await self._followup.append(dict(entry))
+            if self._biztrace is not None:
+                await self._biztrace.append(dict(entry))
         if event.type != EventType.TOOL_RESULT_START:
             return
         if event.tool_call_name not in PLAN_TOOL_NAMES:
             return
         await self._save_plan()
+
+    @staticmethod
+    def _is_tool_success(event: Any) -> bool:
+        evt_type = getattr(event, "type", None)
+        if hasattr(evt_type, "value"):
+            evt_type = evt_type.value
+        if evt_type != EventType.TOOL_RESULT_END.value:
+            return False
+        tool_state = getattr(event, "state", None)
+        if hasattr(tool_state, "value"):
+            tool_state = tool_state.value
+        return tool_state == "success"
+
+    async def _register_new_files(self) -> None:
+        """Diff the artifact directory; notify the stream and the algorithm."""
+        biztrace = self._biztrace
+        envelope = self._envelope
+        if biztrace is None or envelope is None:
+            return
+        try:
+            current = self._artifact_snapshot()
+            changed = [
+                path
+                for path, stamp in current.items()
+                if self._artifact_seen.get(path) != stamp
+            ]
+            self._artifact_seen = current
+            if not changed:
+                return
+            now = datetime.now(timezone.utc)
+            files: dict[str, str] = {}
+            for path in changed:
+                name = Path(path).name
+                await envelope.stream.artifact_registered(
+                    id=create_id("artifact"),
+                    name=name,
+                    path=path,
+                    created_at=now,
+                    updated_at=now,
+                )
+                files[name] = path
+            await biztrace.append(
+                {"kind": "artifact_delta", "payload": {"files": files}}
+            )
+        except Exception:
+            logger.exception(
+                "biztrace: failed to register artifact files for chat %s",
+                biztrace.chat_id,
+            )
+
+    def _artifact_snapshot(self) -> dict[str, tuple[int, int]]:
+        ctx = self._run_context
+        if ctx is None:
+            return {}
+        artifact_dir = Path(ctx.paths.artifact_dir)
+        stamps: dict[str, tuple[int, int]] = {}
+        for item in list_session_files(artifact_dir):
+            path = item["rel_path"]
+            try:
+                stat = (artifact_dir / path).stat()
+            except OSError:
+                continue
+            stamps[path] = (stat.st_size, stat.st_mtime_ns)
+        return stamps
 
     async def _save_plan(self) -> None:
         ctx = self._run_context

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/runtime/envelope.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/runtime/envelope.py
@@ -48,6 +48,7 @@ class Envelope:
         self.stream = stream
         self._msg_seq = 0
         self._usage: dict[str, Any] | None = None
+        self._terminal = False
 
         # Open text blocks: block_id -> {msg_id, seq, text}
         self._text_blocks: dict[str, dict[str, Any]] = {}
@@ -71,6 +72,7 @@ class Envelope:
 
     async def complete(self) -> None:
         await self._finalize_open_messages()
+        self._terminal = True
         if self._usage is not None:
             await self.stream.response("completed", usage=self._usage)
         else:
@@ -78,10 +80,12 @@ class Envelope:
 
     async def fail(self, *, error: dict[str, Any]) -> None:
         await self._finalize_open_messages()
+        self._terminal = True
         await self.stream.response_failed(error=error)
 
     async def cancel(self) -> None:
         await self._finalize_open_messages()
+        self._terminal = True
         await self.stream.response_cancelled()
 
     # ---- algorithm-side send surface ----
@@ -89,7 +93,10 @@ class Envelope:
     async def send_biz_event(self, biz_event: dict[str, Any]) -> None:
         """Persist and broadcast one biz_event; re-sends overwrite by event_id."""
         # Algorithm workers run concurrently with the chat main flow:
-        # failures are logged, never raised back into the worker.
+        # failures are logged, never raised back into the worker. A flush
+        # that outlives the turn must not land behind the terminal frame.
+        if self._terminal:
+            return
         try:
             await self.stream.biz_event(**biz_event)
         except Exception:
@@ -100,6 +107,8 @@ class Envelope:
 
     async def send_segment(self, segment: dict[str, Any]) -> None:
         """Persist and broadcast one segment; each segment is sent once."""
+        if self._terminal:
+            return
         try:
             await self.stream.segment(**segment)
         except Exception:

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/utils/workspace.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/utils/workspace.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import mimetypes
 import os
 import shlex
 import tempfile
 import uuid
 from collections.abc import AsyncGenerator, Awaitable, Callable
+from datetime import datetime, timezone
 from importlib.metadata import PackageNotFoundError, distribution
 from pathlib import Path
 from typing import Any
@@ -534,3 +536,36 @@ def QwenPawDataDockerWorkspace(**kwargs: Any) -> Any:  # noqa: N802
     """工厂函数形态的入口，保持调用侧类似构造器的用法。"""
     cls = _make_qwenpaw_data_docker_workspace_cls()
     return cls(**kwargs)
+
+
+_SKIPPED_DIRS = {"skills", "__pycache__"}
+
+
+def list_session_files(workspace_dir: str | Path) -> list[dict[str, Any]]:
+    """List workspace files for segment artifacts (rel_path relative to root)."""
+    root = Path(workspace_dir)
+    if not root.is_dir():
+        return []
+    items: list[dict[str, Any]] = []
+    for path in sorted(root.rglob("*")):
+        if not path.is_file():
+            continue
+        rel = path.relative_to(root)
+        parts = rel.parts
+        if any(p.startswith(".") for p in parts):
+            continue
+        if parts[0] in _SKIPPED_DIRS:
+            continue
+        stat = path.stat()
+        items.append(
+            {
+                "rel_path": rel.as_posix(),
+                "size_bytes": stat.st_size,
+                "mime_type": mimetypes.guess_type(path.name)[0]
+                or "application/octet-stream",
+                "modified_at": datetime.fromtimestamp(
+                    stat.st_mtime, tz=timezone.utc
+                ).isoformat(),
+            }
+        )
+    return items

--- a/packages/qwenpaw-data-host-core/tests/conftest.py
+++ b/packages/qwenpaw-data-host-core/tests/conftest.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import pytest
+
+_MODEL_ENV_VARS = (
+    "QWENPAW_DATA_MODEL_PROVIDER",
+    "QWENPAW_DATA_MODEL_NAME",
+    "QWENPAW_DATA_MODEL_API_KEY",
+    "QWENPAW_DATA_MODEL_BASE_URL",
+    "LLM_MODEL",
+    "OPENAI_API_KEY",
+    "OPENAI_BASE_URL",
+)
+
+
+@pytest.fixture(autouse=True)
+def _hermetic_model_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Strip ambient model credentials so no test talks to a real LLM.
+
+    Background algorithms (follow-up, BizTrace) fall back to
+    ``build_model_from_env`` when the user configured no model. Importing the
+    context package loads a ``.env`` into ``os.environ`` (and developers may
+    export credentials in their shell), which would silently turn rule-based
+    test turns into real, slow model calls.
+    """
+    for name in _MODEL_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+
+
+@pytest.fixture(autouse=True)
+def _no_biztrace_linking(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep entity linking off by default in tests.
+
+    Its vocabulary fetches add real network waits to every chat turn and made
+    terminal-status polls flaky under full-suite load. Linking tests opt back
+    in explicitly via BizTraceSettings(biz_link_enabled=True) or monkeypatch.
+    """
+    monkeypatch.setenv("QWENPAW_DATA_BIZ_LINK_ENABLED", "0")

--- a/packages/qwenpaw-data-host-core/tests/test_biztrace_artifact_index.py
+++ b/packages/qwenpaw-data-host-core/tests/test_biztrace_artifact_index.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from qwenpaw_data.host.core.algo.biztrace.pipeline import ArtifactFileIndex
+
+
+def test_artifact_index_scopes_files_by_tool_result_seq() -> None:
+    index = ArtifactFileIndex()
+
+    index.note_delta({"a.csv": "out/a.csv"})
+    index.bind_pending("c1")
+    index.note_delta({"b.csv": "out/b.csv", "a.csv": "out/a2.csv"})
+    index.bind_pending("c2")
+    index.assign_seq("c1", 10)
+    index.assign_seq("c2", 20)
+
+    # Earlier production survives a later rewrite when filtering by seq.
+    assert index.files_in(10, 10) == {"a.csv": "out/a.csv"}
+    assert index.files_in(20, 20) == {"a.csv": "out/a2.csv", "b.csv": "out/b.csv"}
+    # Same name in range: last in-range writer wins.
+    assert index.files_in(10, 20) == {"a.csv": "out/a2.csv", "b.csv": "out/b.csv"}
+    assert index.files_in(11, 19) == {}
+
+
+def test_artifact_index_ignores_empty_delta_and_unknown_call() -> None:
+    index = ArtifactFileIndex()
+
+    index.bind_pending("c1")
+    index.assign_seq("c1", 1)
+    index.assign_seq(None, 2)
+    index.assign_seq("missing", 3)
+
+    assert index.files_in(1, 3) == {}

--- a/packages/qwenpaw-data-host-core/tests/test_biztrace_artifacts.py
+++ b/packages/qwenpaw-data-host-core/tests/test_biztrace_artifacts.py
@@ -1,0 +1,203 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from qwenpaw_data.host.core.utils.workspace import list_session_files
+from qwenpaw_data.host.core.algo.biztrace.workspace_index import (
+    ArtifactProposal,
+    ArtifactVerifier,
+    infer_artifact_meta,
+    is_displayable_artifact,
+    resolve_artifact,
+)
+
+
+def _listing(*rel_paths: str) -> list[dict[str, Any]]:
+    return [
+        {
+            "rel_path": rel_path,
+            "size_bytes": 1,
+            "mime_type": "text/plain",
+            "modified_at": "2026-08-02T00:00:00+00:00",
+        }
+        for rel_path in rel_paths
+    ]
+
+
+def test_workspace_listing_skips_hidden_directories(tmp_path: Path) -> None:
+    (tmp_path / "analysis").mkdir()
+    (tmp_path / "analysis" / "report.md").write_text("# 报告", encoding="utf-8")
+    (tmp_path / ".cache").mkdir()
+    (tmp_path / ".cache" / "state.json").write_text("{}", encoding="utf-8")
+
+    listed = list_session_files(tmp_path)
+
+    assert [info["rel_path"] for info in listed] == ["analysis/report.md"]
+    assert listed[0]["mime_type"] == "text/markdown"
+    assert listed[0]["size_bytes"] > 0
+
+
+def test_listing_a_missing_directory_is_empty(tmp_path: Path) -> None:
+    assert list_session_files(tmp_path / "nope") == []
+
+
+def test_artifact_metadata_is_inferred_from_the_path() -> None:
+    assert infer_artifact_meta("query.sql", "sql/query.sql")[:2] == (
+        "query_script",
+        "supporting",
+    )
+    assert infer_artifact_meta("result.csv", "out/result.csv")[:2] == (
+        "dataset",
+        "final",
+    )
+    assert infer_artifact_meta("step1.csv", "steps/step1.csv")[:2] == (
+        "dataset",
+        "intermediate",
+    )
+    assert infer_artifact_meta("report.md", "out/report.md")[:2] == ("report", "final")
+    assert infer_artifact_meta("kpi_dashboard.html", "out/kpi_dashboard.html")[:2] == (
+        "dashboard",
+        "final",
+    )
+    assert infer_artifact_meta("export.py", "scripts/export.py")[:2] == (
+        "other",
+        "supporting",
+    )
+    assert infer_artifact_meta("problem.json", "problem.json")[:2] == (
+        "other",
+        "supporting",
+    )
+
+
+def test_only_query_scripts_and_final_products_reach_a_card() -> None:
+    assert is_displayable_artifact(
+        kind="query_script", role="supporting", relative_path="sql/q.sql"
+    )
+    assert is_displayable_artifact(
+        kind="dataset", role="final", relative_path="out/r.csv"
+    )
+    assert not is_displayable_artifact(
+        kind="dataset", role="intermediate", relative_path="steps/s.csv"
+    )
+    assert not is_displayable_artifact(
+        kind="other", role="supporting", relative_path="scripts/x.py"
+    )
+    assert not is_displayable_artifact(
+        kind="report", role="final", relative_path=None
+    )
+
+
+def test_a_proposal_resolves_only_when_one_file_fits() -> None:
+    files = {"report.md": "analysis/report.md", "data.csv": "analysis/data.csv"}
+
+    assert resolve_artifact("report.md", files) == "report.md"
+    assert resolve_artifact("`analysis/report.md`", files) == "report.md"
+    assert resolve_artifact("「report.md」", files) == "report.md"
+    assert resolve_artifact("summary.md", files) is None
+
+
+def _label(name: str, description: str, kind: str = "", role: str = "") -> (
+    ArtifactProposal
+):
+    return ArtifactProposal(
+        name=name, description=description, kind=kind, role=role
+    )
+
+
+def test_verification_needs_both_the_write_and_the_listing() -> None:
+    verifier = ArtifactVerifier(lambda: _listing("analysis/report.md"))
+
+    artifacts = verifier.verify(
+        [
+            _label("report.md", "分析报告", "report", "final"),
+            _label("data.csv", "结果数据", "dataset", "final"),
+            _label("ghost.md", "并不存在", "report", "final"),
+        ],
+        files={"report.md": "analysis/report.md", "data.csv": "analysis/data.csv"},
+    )
+
+    assert artifacts is not None
+    # data.csv was written but is gone from the workspace; ghost.md never was.
+    assert [item.name for item in artifacts] == ["report.md"]
+    assert artifacts[0].relative_path == "analysis/report.md"
+    assert verifier.unverified == 2
+
+
+def test_the_listing_supplies_the_path_even_when_the_tool_used_an_absolute_one() -> (
+    None
+):
+    verifier = ArtifactVerifier(lambda: _listing("analysis/report.md"))
+
+    artifacts = verifier.verify(
+        [_label("report.md", "分析报告", "report", "final")],
+        files={"report.md": "/tmp/run/report.md"},
+    )
+
+    assert artifacts is not None
+    assert artifacts[0].relative_path == "analysis/report.md"
+
+
+def test_a_broken_lister_drops_every_artifact() -> None:
+    def lister() -> list[dict[str, Any]]:
+        raise OSError("workspace is gone")
+
+    verifier = ArtifactVerifier(lister)
+
+    assert (
+        verifier.verify(
+            [_label("report.md", "分析报告", "report", "final")],
+            files={"report.md": "analysis/report.md"},
+        )
+        is None
+    )
+
+
+def test_a_candidate_nobody_labelled_is_still_backfilled() -> None:
+    verifier = ArtifactVerifier(lambda: _listing("out/report.md", "sql/query.sql"))
+
+    artifacts = verifier.verify(
+        [_label("report.md", "分析报告", "report", "final")],
+        files={"report.md": "out/report.md", "query.sql": "sql/query.sql"},
+    )
+
+    assert artifacts is not None
+    inferred, labelled = artifacts
+    assert (labelled.name, labelled.description) == ("report.md", "分析报告")
+    assert (inferred.name, inferred.kind, inferred.role) == (
+        "query.sql",
+        "query_script",
+        "supporting",
+    )
+    assert inferred.description == "查询脚本"
+    assert verifier.unverified == 0
+
+
+def test_an_intermediate_dataset_is_kept_out_of_the_card() -> None:
+    verifier = ArtifactVerifier(lambda: _listing("steps/step1.csv", "out/final.csv"))
+
+    artifacts = verifier.verify(
+        [
+            _label("step1.csv", "中间结果", "dataset", "intermediate"),
+            _label("final.csv", "结果数据", "dataset", "final"),
+        ],
+        files={"step1.csv": "steps/step1.csv", "final.csv": "out/final.csv"},
+    )
+
+    assert artifacts is not None
+    assert [item.name for item in artifacts] == ["final.csv"]
+    # Filtered for display, not unverified: the file is really there.
+    assert verifier.unverified == 0
+
+
+def test_a_nonsense_label_falls_back_to_what_the_path_says() -> None:
+    verifier = ArtifactVerifier(lambda: _listing("out/result.csv"))
+
+    artifacts = verifier.verify(
+        [_label("result.csv", "结果数据", "spreadsheet", "definitive")],
+        files={"result.csv": "out/result.csv"},
+    )
+
+    assert artifacts is not None
+    assert (artifacts[0].kind, artifacts[0].role) == ("dataset", "final")

--- a/packages/qwenpaw-data-host-core/tests/test_biztrace_converter.py
+++ b/packages/qwenpaw-data-host-core/tests/test_biztrace_converter.py
@@ -1,0 +1,333 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from qwenpaw_data.host.core.algo.biztrace.converter import BizTraceConverter
+from qwenpaw_data.host.core.algo.biztrace.models import BizEvent
+from qwenpaw_data.host.core.algo.biztrace.presentation import PresentationBuilder
+
+REPLY_ID = "reply-1"
+
+
+class Collector:
+    """Records every row and every post-emit event, in arrival order."""
+
+    def __init__(self) -> None:
+        self.rows: list[BizEvent] = []
+        self.events: list[BizEvent] = []
+
+    async def on_row(self, event: BizEvent) -> None:
+        self.rows.append(event)
+
+    async def on_event(self, event: BizEvent) -> None:
+        self.events.append(event)
+
+
+def _agent_event(**payload: Any) -> dict[str, Any]:
+    payload.setdefault("reply_id", REPLY_ID)
+    return {"kind": "agent_event", "payload": payload}
+
+
+def _text_block(block_id: str, text: str) -> list[dict[str, Any]]:
+    return [
+        _agent_event(type="TEXT_BLOCK_START", block_id=block_id),
+        _agent_event(type="TEXT_BLOCK_DELTA", block_id=block_id, delta=text),
+        _agent_event(type="TEXT_BLOCK_END", block_id=block_id),
+    ]
+
+
+def _tool_pair(
+    call_id: str,
+    name: str,
+    arguments: str,
+    *,
+    output: str = "ok",
+    state: str = "success",
+    close: bool = True,
+) -> list[dict[str, Any]]:
+    entries = [
+        _agent_event(
+            type="TOOL_CALL_START", tool_call_id=call_id, tool_call_name=name
+        ),
+        _agent_event(type="TOOL_CALL_DELTA", tool_call_id=call_id, delta=arguments),
+        # TOOL_CALL_END carries no tool name; it must come from the start event.
+        _agent_event(type="TOOL_CALL_END", tool_call_id=call_id),
+    ]
+    if not close:
+        return entries
+    return entries + [
+        _agent_event(type="TOOL_RESULT_START", tool_call_id=call_id),
+        _agent_event(
+            type="TOOL_RESULT_TEXT_DELTA", tool_call_id=call_id, delta=output
+        ),
+        # TOOL_RESULT_END carries no output; only the deltas do.
+        _agent_event(type="TOOL_RESULT_END", tool_call_id=call_id, state=state),
+    ]
+
+
+async def _run(entries: list[dict[str, Any]]) -> tuple[Collector, BizTraceConverter]:
+    collector = Collector()
+    converter = BizTraceConverter(
+        presenter=PresentationBuilder(),
+        on_row=collector.on_row,
+        on_event=collector.on_event,
+    )
+    converter.start()
+    for entry in entries:
+        converter.enqueue(entry)
+    await converter.aclose()
+    return collector, converter
+
+
+async def test_events_map_one_to_one_with_stable_ids() -> None:
+    entries = [
+        {
+            "kind": "user_input",
+            "payload": {
+                "id": "msg-1",
+                "content": [{"type": "text", "id": "blk-u", "text": "分析日活"}],
+            },
+        },
+        _agent_event(type="THINKING_BLOCK_START", block_id="blk-t"),
+        _agent_event(type="THINKING_BLOCK_DELTA", block_id="blk-t", delta="先取数"),
+        _agent_event(type="THINKING_BLOCK_END", block_id="blk-t"),
+        *_tool_pair("call-1", "Bash", '{"command": "ls"}'),
+        *_text_block("blk-a", "结论如下"),
+        # Neither of these produces a card.
+        _agent_event(type="MODEL_CALL_START"),
+        _agent_event(type="REPLY_END"),
+    ]
+
+    collector, converter = await _run(entries)
+
+    assert [(event.kind, event.event_id) for event in collector.rows] == [
+        ("user", "blk-u"),
+        ("assistant_thinking", "blk-t"),
+        ("tool_use", "call-1"),
+        ("tool_result", "call-1:result"),
+        ("assistant_text", "blk-a"),
+    ]
+    assert [event.seq for event in collector.rows] == [1, 2, 3, 4, 5]
+    assert converter.stats.events == 5
+    assert converter.stats.tool_calls == 1
+
+
+async def test_user_event_id_falls_back_to_the_message() -> None:
+    collector, _ = await _run(
+        [
+            {
+                "kind": "user_input",
+                "payload": {"id": "msg-9", "content": [{"type": "text", "text": "hi"}]},
+            }
+        ]
+    )
+
+    row = collector.rows[0]
+    assert row.event_id == "msg-9:0"
+    assert row.parent_msg_id == "msg-9"
+    assert row.block_id == "msg-9:0"
+
+
+async def test_tool_pair_shares_a_block_id_and_keeps_its_arguments() -> None:
+    collector, _ = await _run(
+        _tool_pair("call-1", "Write", '{"file_path": "a.md", "content": "x"}')
+    )
+
+    call, result = collector.rows
+    assert call.block_id == result.block_id == "call-1"
+    assert call.parent_msg_id == REPLY_ID
+    assert call.tool_name == "Write"
+    assert call.input == {"file_path": "a.md", "content": "x"}
+    assert result.tool_name == "Write"
+    assert result.output == "ok"
+    assert call.status == result.status == "done"
+
+
+async def test_failed_states_map_to_error_and_explain_themselves() -> None:
+    collector, converter = await _run(
+        [
+            *_tool_pair("call-1", "Bash", "{}", state="error"),
+            *_tool_pair("call-2", "Bash", "{}", state="interrupted"),
+        ]
+    )
+
+    error_result = collector.rows[1]
+    interrupted_result = collector.rows[3]
+    assert error_result.status == "error"
+    assert interrupted_result.status == "error"
+    assert interrupted_result.presentation is not None
+    assert "打断" in interrupted_result.presentation.body
+    assert converter.stats.error_tools == 2
+
+
+async def test_unclosed_call_is_rewritten_once_and_not_forwarded_again() -> None:
+    collector, converter = await _run(
+        _tool_pair("call-1", "Bash", '{"command": "sleep"}', close=False)
+    )
+
+    first, rewrite = collector.rows
+    assert first.status == "done"
+    assert rewrite.status == "error"
+    assert rewrite.event_id == first.event_id
+    # The rewrite lands in the slot the first row took, and segmentation has
+    # already consumed that event.
+    assert rewrite.seq == first.seq == 1
+    assert [event.event_id for event in collector.events] == ["call-1"]
+    assert converter.stats.unclosed_tools == 1
+    assert converter.stats.events == 1
+
+
+async def test_hint_becomes_a_rule_based_card() -> None:
+    collector, _ = await _run(
+        [
+            _agent_event(
+                type="HINT_BLOCK",
+                block_id="blk-h",
+                source="interaction-strategy",
+                hint=[{"type": "text", "text": "先确认口径"}],
+            )
+        ]
+    )
+
+    row = collector.rows[0]
+    assert row.kind == "assistant_text"
+    assert row.event_id == "blk-h"
+    assert row.content == "先确认口径"
+    assert row.presentation is not None
+    assert row.presentation.card_type == "text"
+    assert row.presentation.caption == "模型回复"
+    assert "先确认口径" in row.presentation.body
+    assert "interaction-strategy" not in row.presentation.body
+
+
+async def test_steer_hint_stays_user_guidance() -> None:
+    collector, _ = await _run(
+        [
+            _agent_event(
+                type="HINT_BLOCK",
+                block_id="blk-s",
+                source="steer",
+                hint=[{"type": "text", "text": "请改用周口径"}],
+            )
+        ]
+    )
+
+    row = collector.rows[0]
+    assert row.kind == "hint"
+    assert row.source == "steer"
+    assert row.content == "请改用周口径"
+    assert row.presentation is not None
+    assert row.presentation.card_type == "hint"
+    assert row.presentation.caption == "用户引导"
+    assert "请改用周口径" in row.presentation.body
+
+
+async def test_non_steer_system_reminder_becomes_assistant_text() -> None:
+    collector, _ = await _run(
+        [
+            _agent_event(
+                type="HINT_BLOCK",
+                block_id="blk-r",
+                hint=[
+                    {
+                        "type": "text",
+                        "text": (
+                            "<system-reminder>\n"
+                            "Remember to cite sources.\n"
+                            "</system-reminder>"
+                        ),
+                    }
+                ],
+            )
+        ]
+    )
+
+    row = collector.rows[0]
+    assert row.kind == "assistant_text"
+    assert row.content == "Remember to cite sources."
+    assert "<system-reminder>" not in (row.content or "")
+    assert row.presentation is not None
+    assert row.presentation.card_type == "text"
+    assert row.presentation.caption == "模型回复"
+    assert "Remember to cite sources." in row.presentation.body
+    assert "<system-reminder>" not in row.presentation.body
+
+
+async def test_rows_keep_arrival_order_when_cards_finish_out_of_order() -> None:
+    class SlowFirstPresenter(PresentationBuilder):
+        """Delays the first card so a later one would win a race."""
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.calls = 0
+
+        async def build(self, event: BizEvent, **kwargs: Any) -> Any:
+            self.calls += 1
+            if self.calls == 1:
+                await asyncio.sleep(0.05)
+            return await super().build(event, **kwargs)
+
+    collector = Collector()
+    converter = BizTraceConverter(
+        presenter=SlowFirstPresenter(), on_row=collector.on_row
+    )
+    converter.start()
+    for entry in [*_text_block("blk-a", "one"), *_text_block("blk-b", "two")]:
+        converter.enqueue(entry)
+    await converter.aclose()
+
+    assert [event.event_id for event in collector.rows] == ["blk-a", "blk-b"]
+    assert [event.seq for event in collector.rows] == [1, 2]
+
+
+async def test_enqueue_after_close_is_ignored() -> None:
+    collector, converter = await _run(_text_block("blk-a", "done"))
+
+    converter.enqueue(_agent_event(type="TEXT_BLOCK_START", block_id="blk-b"))
+
+    assert [event.event_id for event in collector.rows] == ["blk-a"]
+
+
+async def test_host_plan_tools_become_orchestration_events() -> None:
+    """Force-segment tools must match PlanCreate / PlanUpdate / TaskStateUpdate."""
+    collector, converter = await _run(
+        [
+            *_tool_pair(
+                "c1",
+                "PlanCreate",
+                '{"tasks":[{"id":"n1","subject":"取数","description":"拉明细",'
+                '"blocked_by":[]}]}',
+            ),
+            *_tool_pair(
+                "c2",
+                "TaskStateUpdate",
+                '{"task_id":"n1","state":"in_progress"}',
+            ),
+            *_tool_pair(
+                "c3",
+                "PlanUpdate",
+                '{"changes":[{"task_id":"n2","action":"add","task":'
+                '{"subject":"出图","description":"画趋势","blocked_by":["n1"]}}]}',
+            ),
+        ]
+    )
+
+    create, update_state, revise = [
+        row for row in collector.rows if row.kind == "tool_use"
+    ]
+    assert create.orchestration is not None
+    assert create.orchestration.category == "PlanCreate"
+    assert converter._plan_nodes["n1"] == "取数"
+
+    assert update_state.orchestration is not None
+    assert update_state.orchestration.category == "TaskStateUpdate"
+    assert update_state.orchestration.subtask_state == "in_progress"
+    assert update_state.orchestration.node_id == "n1"
+    assert update_state.orchestration.node_name == "取数"
+
+    assert revise.orchestration is not None
+    assert revise.orchestration.category == "PlanUpdate"
+    assert converter._plan_nodes["n2"] == "出图"
+    assert converter.stats.orchestration_events == 3

--- a/packages/qwenpaw-data-host-core/tests/test_biztrace_linking.py
+++ b/packages/qwenpaw-data-host-core/tests/test_biztrace_linking.py
@@ -1,0 +1,386 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from qwenpaw_data.host.core.algo.biztrace.linking import EntityLinker, build_entity_url
+from qwenpaw_data.host.core.algo.biztrace.semantic_vocab import (
+    BIZ_DOMAIN_PATH,
+    DATASET_PATH,
+    DIMENSION_PATH,
+    METRIC_PATH,
+    SemanticVocabulary,
+    VocabEntry,
+    split_terms,
+)
+
+BASE_URL = "http://cm.test"
+
+
+def _linker(terms: dict[str, VocabEntry]) -> EntityLinker:
+    return EntityLinker(terms=terms, base_url=BASE_URL, datasource_id="ds-1")
+
+
+def _vocabulary(
+    records: dict[str, list[dict[str, Any]]],
+    *,
+    seen: list[httpx.Request] | None = None,
+) -> SemanticVocabulary:
+    """Serve the four endpoints from a canned mapping of path to records."""
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if seen is not None:
+            seen.append(request)
+        page = int(request.url.params.get("page", 1))
+        rows = records.get(request.url.path, [])
+        return httpx.Response(
+            200,
+            json={
+                "records": rows if page == 1 else [],
+                "total": len(rows),
+                "page": page,
+                "size": 200,
+            },
+        )
+
+    return SemanticVocabulary(
+        base_url=BASE_URL,
+        datasource_id="ds-1",
+        client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+
+
+def test_each_entity_type_has_its_own_url() -> None:
+    urls = {
+        entry.entity_type: build_entity_url(
+            entry, base_url=BASE_URL, datasource_id="ds-1"
+        )
+        for entry in (
+            VocabEntry(entity_type="biz_domain", domain_id="d1", entity_id=None),
+            VocabEntry(entity_type="dimension", domain_id="d1", entity_id="dim1"),
+            VocabEntry(entity_type="metric", domain_id="d1", entity_id="m1"),
+            VocabEntry(entity_type="dataset", domain_id="d1", entity_id="ds9"),
+        )
+    }
+
+    assert urls["biz_domain"] == (
+        f"{BASE_URL}/business-domain?datasource_id=ds-1&domain_id=d1"
+    )
+    assert urls["dimension"] == (
+        f"{BASE_URL}/dimension?datasource_id=ds-1&domain_id=d1&dimension_id=dim1"
+    )
+    assert urls["metric"] == (
+        f"{BASE_URL}/metric-lib?datasource_id=ds-1&domain_id=d1&metric_id=m1"
+    )
+    assert urls["dataset"] == (
+        f"{BASE_URL}/data-set?datasource_id=ds-1&domain_id=d1&dataset_id=ds9"
+    )
+
+
+def test_every_occurrence_of_a_term_is_linked() -> None:
+    linker = _linker(
+        {"日活": VocabEntry(entity_type="metric", domain_id=None, entity_id="m1")}
+    )
+
+    body = linker.link("日活下降，日活需要复核")
+
+    assert body.count("](") == 2
+    assert body.startswith("[日活](http://cm.test/metric-lib?")
+    assert "，[日活](http://cm.test/metric-lib?" in body
+
+
+def test_the_longest_matching_term_wins() -> None:
+    metric = VocabEntry(entity_type="metric", domain_id=None, entity_id="m1")
+    dimension = VocabEntry(entity_type="dimension", domain_id=None, entity_id="d1")
+    linker = _linker({"日活": metric, "日活用户数": dimension})
+
+    body = linker.link("日活用户数偏低")
+
+    assert body.startswith("[日活用户数](http://cm.test/dimension?")
+
+
+def test_protected_regions_are_left_alone() -> None:
+    linker = _linker(
+        {"日活": VocabEntry(entity_type="metric", domain_id=None, entity_id="m1")}
+    )
+
+    assert linker.link("[日活](http://old)") == "[日活](http://old)"
+    assert linker.link("```\n日活\n```") == "```\n日活\n```"
+    assert linker.link("http://x/日活") == "http://x/日活"
+    # Inline code that is not an exact vocab term stays untouched.
+    assert linker.link("`日活下降`") == "`日活下降`"
+
+
+def test_terms_in_inline_code_or_bold_are_linked() -> None:
+    linker = _linker(
+        {
+            "日活": VocabEntry(entity_type="metric", domain_id=None, entity_id="m1"),
+            "成交额": VocabEntry(entity_type="metric", domain_id=None, entity_id="m2"),
+            "订单表": VocabEntry(entity_type="dataset", domain_id=None, entity_id="ds9"),
+        }
+    )
+
+    assert linker.link("`日活` 下降").startswith("[日活](http://cm.test/metric-lib?")
+    assert "`" not in linker.link("`日活`")
+    assert linker.link("关注 **成交额**").startswith("关注 [成交额](http://cm.test/metric-lib?")
+    assert "**" not in linker.link("**成交额**")
+    assert linker.link("写入 __订单表__").startswith("写入 [订单表](http://cm.test/data-set?")
+    # Marked and plain mentions are both linked.
+    assert linker.link("`日活` 与 日活").count("](") == 2
+
+
+def test_a_term_inside_an_html_tag_is_not_linked() -> None:
+    linker = _linker(
+        {
+            "日活": VocabEntry(entity_type="metric", domain_id=None, entity_id="m1"),
+            "text-red-500": VocabEntry(
+                entity_type="metric", domain_id=None, entity_id="m2"
+            ),
+        }
+    )
+
+    body = linker.link('日活 <span class="text-red-500 font-bold">-3.2%</span>')
+
+    # The colour span survives verbatim; only the prose around it is linked.
+    assert '<span class="text-red-500 font-bold">-3.2%</span>' in body
+    assert body.startswith("[日活](http://cm.test/metric-lib?")
+
+
+def test_an_ascii_term_inside_a_longer_identifier_is_not_linked() -> None:
+    linker = _linker(
+        {"dau": VocabEntry(entity_type="metric", domain_id=None, entity_id="m1")}
+    )
+
+    assert linker.link("dau_7d 指标") == "dau_7d 指标"
+    assert linker.link("dau 指标").startswith("[dau](")
+
+
+def test_an_empty_vocabulary_leaves_the_body_untouched() -> None:
+    linker = _linker({})
+
+    assert not linker
+    assert linker.link("日活下降") == "日活下降"
+
+
+def test_synonyms_are_split_the_way_the_graph_loader_splits_them() -> None:
+    assert split_terms("日活, DAU|活跃用户") == ["日活", "DAU", "活跃用户"]
+    assert split_terms("日活") == ["日活"]
+    assert split_terms(None) == []
+
+
+async def test_the_vocabulary_indexes_domain_layer_without_datasource() -> None:
+    """v2.1: domain / metric / dimension have no datasource_id; only datasets do."""
+    seen: list[httpx.Request] = []
+    vocabulary = _vocabulary(
+        {
+            BIZ_DOMAIN_PATH: [{"domain_name": "电商", "domain_id": "d1"}],
+            METRIC_PATH: [
+                {
+                    "metric_name": "日活",
+                    "synonyms": "DAU,活跃用户",
+                    "metric_id": "m1",
+                    "domain_id": "d1",
+                },
+                {"metric_name": "越界指标", "metric_id": "m2", "domain_id": "d2"},
+            ],
+            DIMENSION_PATH: [
+                {
+                    "dimension_name": "城市",
+                    "dimension_id": "dim1",
+                    "domain_id": "d1",
+                }
+            ],
+            DATASET_PATH: [
+                {"dataset_name": "订单表", "dataset_id": "t1", "datasource_id": "ds-1"},
+                {
+                    "dataset_name": "他源表",
+                    "dataset_id": "t2",
+                    "datasource_id": "ds-other",
+                },
+            ],
+        },
+        seen=seen,
+    )
+
+    await vocabulary.ensure_fresh()
+
+    assert set(vocabulary.terms) == {
+        "电商",
+        "日活",
+        "DAU",
+        "活跃用户",
+        "越界指标",
+        "城市",
+        "订单表",
+    }
+    assert "他源表" not in vocabulary.terms
+    assert vocabulary.terms["DAU"].entity_type == "metric"
+    assert vocabulary.terms["DAU"].entity_id == "m1"
+    assert vocabulary.terms["城市"].entity_id == "dim1"
+
+    by_path = {request.url.path: request.url.params for request in seen}
+    assert "datasource_id" not in by_path[BIZ_DOMAIN_PATH]
+    assert "datasource_id" not in by_path[METRIC_PATH]
+    assert "datasource_id" not in by_path[DIMENSION_PATH]
+    assert by_path[DATASET_PATH].get("datasource_id") == "ds-1"
+    await vocabulary.aclose()
+
+
+async def test_a_term_claimed_by_two_types_is_dropped() -> None:
+    vocabulary = _vocabulary(
+        {
+            METRIC_PATH: [
+                {"metric_name": "城市", "metric_id": "m1", "domain_id": "d1"}
+            ],
+            DIMENSION_PATH: [
+                {
+                    "dimension_name": "城市",
+                    "dimension_id": "dim1",
+                    "domain_id": "d1",
+                }
+            ],
+        }
+    )
+
+    await vocabulary.ensure_fresh()
+
+    assert "城市" not in vocabulary.terms
+    await vocabulary.aclose()
+
+
+async def test_an_unreachable_endpoint_degrades_to_no_links() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        _ = request
+        return httpx.Response(503)
+
+    vocabulary = SemanticVocabulary(
+        base_url=BASE_URL,
+        datasource_id="ds-1",
+        client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+
+    await vocabulary.ensure_fresh()
+
+    assert vocabulary.terms == {}
+    await vocabulary.aclose()
+
+
+async def test_vocabulary_sends_bearer_token_when_configured() -> None:
+    seen: list[str | None] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request.headers.get("Authorization"))
+        return httpx.Response(
+            200,
+            json={"records": [], "total": 0, "page": 1, "size": 200},
+        )
+
+    vocabulary = SemanticVocabulary(
+        base_url=BASE_URL,
+        datasource_id="ds-1",
+        access_token="tok-user-1",
+        client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+
+    await vocabulary.ensure_fresh()
+
+    assert seen
+    assert all(header == "Bearer tok-user-1" for header in seen)
+    await vocabulary.aclose()
+
+
+async def test_vocabulary_omits_authorization_without_a_token() -> None:
+    seen: list[bool] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        seen.append("Authorization" in request.headers)
+        return httpx.Response(
+            200,
+            json={"records": [], "total": 0, "page": 1, "size": 200},
+        )
+
+    vocabulary = SemanticVocabulary(
+        base_url=BASE_URL,
+        datasource_id="ds-1",
+        client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+
+    await vocabulary.ensure_fresh()
+
+    assert seen
+    assert all(not has_auth for has_auth in seen)
+    await vocabulary.aclose()
+
+
+def test_same_origin_base_url_builds_relative_href() -> None:
+    entry = VocabEntry(entity_type="metric", domain_id="d1", entity_id="m1")
+    assert build_entity_url(entry, base_url="", datasource_id="ds-1") == (
+        "/metric-lib?datasource_id=ds-1&domain_id=d1&metric_id=m1"
+    )
+
+
+def test_resolve_link_base_url_prefers_context_frontend(monkeypatch) -> None:
+    from qwenpaw_data.host.core.algo.biztrace.settings import (
+        DEFAULT_CM_FRONTEND_URL,
+        BizTraceSettings,
+        resolve_link_base_url,
+    )
+
+    settings = BizTraceSettings(biz_link_base_url=None)
+    monkeypatch.setenv("QWENPAW_DATA_CM_FRONTEND_URL", "https://context.example/")
+    assert resolve_link_base_url(settings) == "https://context.example"
+
+    monkeypatch.setenv("QWENPAW_DATA_CM_FRONTEND_URL", "/")
+    assert resolve_link_base_url(settings) == ""
+
+    monkeypatch.delenv("QWENPAW_DATA_CM_FRONTEND_URL", raising=False)
+    assert resolve_link_base_url(settings) == DEFAULT_CM_FRONTEND_URL
+    assert resolve_link_base_url(settings) == "http://localhost:3000"
+
+    override = BizTraceSettings(biz_link_base_url="https://override.example/")
+    assert resolve_link_base_url(override) == "https://override.example"
+
+
+async def test_build_linker_scopes_cache_by_datasource_and_refreshes_token(
+    monkeypatch,
+) -> None:
+    from qwenpaw_data.host.core.algo.biztrace import linking as linking_module
+    from qwenpaw_data.host.core.algo.biztrace.settings import BizTraceSettings
+
+    await linking_module.shutdown_vocabularies()
+    monkeypatch.setattr(
+        linking_module, "resolve_link_base_url", lambda _settings: "http://frontend.test"
+    )
+    monkeypatch.setattr(
+        linking_module, "resolve_cm_base_url", lambda: BASE_URL
+    )
+    settings = BizTraceSettings(biz_link_enabled=True, biz_link_ttl=300.0)
+
+    first = linking_module.build_linker(
+        settings,
+        datasource_id="ds-1",
+        access_token="tok-a",
+    )
+    second = linking_module.build_linker(
+        settings,
+        datasource_id="ds-1",
+        access_token="tok-b",
+    )
+    other = linking_module.build_linker(
+        settings,
+        datasource_id="ds-2",
+        access_token="tok-c",
+    )
+
+    assert first is not None and second is not None and other is not None
+    assert first.base_url == "http://frontend.test"
+    assert second.base_url == "http://frontend.test"
+    shared = linking_module._VOCABULARIES[(BASE_URL, "ds-1")]
+    isolated = linking_module._VOCABULARIES[(BASE_URL, "ds-2")]
+    assert shared is not isolated
+    assert shared.base_url == BASE_URL
+    assert shared.access_token == "tok-b"
+    assert isolated.access_token == "tok-c"
+    await linking_module.shutdown_vocabularies()

--- a/packages/qwenpaw-data-host-core/tests/test_biztrace_llm.py
+++ b/packages/qwenpaw-data-host-core/tests/test_biztrace_llm.py
@@ -1,0 +1,311 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+import pytest
+
+from qwenpaw_data.host.core.algo.biztrace import pipeline
+from qwenpaw_data.host.core.algo.biztrace.llm import (
+    StructuredLLM,
+    StructuredLLMError,
+    _tolerant_schema,
+    for_structured_calls,
+)
+from qwenpaw_data.host.core.algo.biztrace.segmentation import _EXTRACTION_SCHEMA
+from qwenpaw_data.host.core.domain.preference import ActiveModel
+from qwenpaw_data.host.core.providers.factory import build_model
+
+SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "additionalProperties": False,
+    "properties": {"body": {"type": "string"}},
+    "required": ["body"],
+}
+
+
+@dataclass
+class _Answer:
+    """The one field StructuredLLM reads off a StructuredResponse."""
+
+    content: Any
+
+
+@dataclass
+class _FakeModel:
+    """Stands in for a host-built chat model, recording what it was asked."""
+
+    answers: list[Any]
+    delay: float = 0.0
+    calls: list[dict[str, Any]] = field(default_factory=list)
+
+    async def generate_structured_output(
+        self, *, messages: list[Any], structured_model: Any
+    ) -> _Answer:
+        self.calls.append({"messages": messages, "schema": structured_model})
+        if self.delay:
+            await asyncio.sleep(self.delay)
+        answer = self.answers[min(len(self.calls) - 1, len(self.answers) - 1)]
+        if isinstance(answer, Exception):
+            raise answer
+        return _Answer(answer)
+
+
+def _llm(model: _FakeModel, *, timeout: float = 1.0) -> StructuredLLM:
+    return StructuredLLM(model, timeout=timeout)  # type: ignore[arg-type]
+
+
+def _active(**overrides: object) -> ActiveModel:
+    values: dict[str, object] = {
+        "provider_id": "dashscope",
+        "model_id": "qwen3.7-flash",
+        "api_key": "secret",
+        "base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+        "chat_model": "DashScopeChatModel",
+        "name": "Qwen3.7 Flash",
+    }
+    values.update(overrides)
+    return ActiveModel(**values)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("provider", ["dashscope", "openai"])
+def test_a_host_built_model_is_retuned_for_extraction(provider: str) -> None:
+    model = for_structured_calls(build_model(_active(provider_id=provider)))
+
+    assert model.stream is False
+    assert model.parameters.thinking_enable is False
+    assert model.parameters.temperature == 0.0
+    # The host's own choice is left alone: one forced tool call at a time.
+    assert model.parameters.parallel_tool_calls is False
+
+
+async def test_a_call_carries_the_prompt_and_the_schema() -> None:
+    model = _FakeModel([{"body": "取数完成"}])
+    llm = _llm(model)
+
+    data = await llm.complete(
+        system="s", user="u", schema=SCHEMA, schema_name="presentation_body"
+    )
+
+    assert data == {"body": "取数完成"}
+    assert model.calls[0]["schema"] is SCHEMA
+    roles = [(msg.role, msg.get_text_content()) for msg in model.calls[0]["messages"]]
+    assert roles == [("system", "s"), ("user", "u")]
+
+
+async def test_a_first_bad_answer_is_retried(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("qwenpaw_data.host.core.algo.biztrace.llm._BACKOFF_BASE_SECONDS", 0)
+    model = _FakeModel([RuntimeError("no tool call"), {"body": "ok"}])
+    llm = _llm(model)
+
+    data = await llm.complete(system="s", user="u", schema=SCHEMA, schema_name="body")
+
+    assert data == {"body": "ok"}
+    assert len(model.calls) == 2
+    assert llm.failures == 0
+
+
+async def test_a_retry_tells_the_model_what_was_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """温度为 0，重问同一句只会得到同一个坏答案，必须把错误告诉模型。"""
+
+    monkeypatch.setattr("qwenpaw_data.host.core.algo.biztrace.llm._BACKOFF_BASE_SECONDS", 0)
+    model = _FakeModel([RuntimeError("'x' is not of type 'array'"), {"body": "ok"}])
+    llm = _llm(model)
+
+    await llm.complete(system="s", user="u", schema=SCHEMA, schema_name="body")
+
+    retry = [msg.get_text_content() for msg in model.calls[1]["messages"]]
+    assert len(retry) == 3
+    assert "'x' is not of type 'array'" in retry[2]
+
+
+async def test_a_nested_container_sent_as_text_is_decoded() -> None:
+    """小模型常把嵌套数组塞成字符串；这与它写成数组是同一个值。"""
+
+    schema: dict[str, Any] = {
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {
+            "title": {"type": "string"},
+            "artifact": {"type": ["array", "null"], "items": {"type": "object"}},
+        },
+        "required": ["title"],
+    }
+    model = _FakeModel(
+        [{"title": "产出报告", "artifact": '[{"name": "a.md"}]'}]
+    )
+
+    data = await _llm(model).complete(
+        system="s", user="u", schema=schema, schema_name="segment_metadata"
+    )
+
+    assert data == {"title": "产出报告", "artifact": [{"name": "a.md"}]}
+    # The model is asked for an array and only *accepts* the string form, so
+    # the transport never rejects the payload before it can be repaired.
+    accepted = model.calls[0]["schema"]["properties"]
+    assert accepted["artifact"]["type"] == ["array", "null", "string"]
+    assert accepted["title"]["type"] == "string"
+
+
+async def test_the_reported_extraction_failure_now_survives_the_round_trip() -> None:
+    """线上真实样本：模型把 artifact 整个数组塞成一串 JSON 文本。
+
+    真正兜住这个失败的是传输层，不是提示词：出事时提示词已经两处写明
+    ``artifact (array | null)``，模型照样交了字符串。这里按真实 schema 钉住
+    「provider 端能过、交回流水线时又是数组」这条不变量。
+    """
+
+    artifacts = [
+        {
+            "name": "user_behavior_analysis.py",
+            "description": "用户行为数据分析脚本",
+            "kind": "query_script",
+            "role": "supporting",
+        },
+        {
+            "name": "visualize_analysis.py",
+            "description": "生成可视化图表的脚本",
+            "kind": "query_script",
+            "role": "supporting",
+        },
+    ]
+    payload = {
+        "title": "分析用户行为并出图",
+        "input": None,
+        "behavior": "1. 读取行为明细\n2. 汇总后出图",
+        "conclusion": "活跃用户集中在晚间。",
+        "artifact": json.dumps(artifacts, ensure_ascii=False),
+    }
+
+    # This is the exact rejection that was reported.
+    with pytest.raises(jsonschema.ValidationError, match="is not of type"):
+        jsonschema.validate(payload, _EXTRACTION_SCHEMA)
+
+    # The schema the provider validates against accepts the stringified form,
+    # so the payload reaches us instead of failing inside the transport.
+    jsonschema.validate(payload, _tolerant_schema(_EXTRACTION_SCHEMA))
+
+    data = await _llm(_FakeModel([payload])).complete(
+        system="s",
+        user="u",
+        schema=_EXTRACTION_SCHEMA,
+        schema_name="segment_metadata",
+    )
+
+    # And what the pipeline gets back conforms to the strict schema again.
+    jsonschema.validate(data, _EXTRACTION_SCHEMA)
+    assert data["artifact"] == artifacts
+
+
+async def test_text_that_only_looks_like_a_container_is_left_alone() -> None:
+    schema: dict[str, Any] = {
+        "type": "object",
+        "properties": {"artifact": {"type": ["array", "null"]}},
+    }
+    model = _FakeModel([{"artifact": "没有产出文件"}])
+
+    data = await _llm(model).complete(
+        system="s", user="u", schema=schema, schema_name="segment_metadata"
+    )
+
+    assert data == {"artifact": "没有产出文件"}
+
+
+async def test_an_answer_that_is_not_an_object_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("qwenpaw_data.host.core.algo.biztrace.llm._BACKOFF_BASE_SECONDS", 0)
+    llm = _llm(_FakeModel(["not an object"]))
+
+    with pytest.raises(StructuredLLMError):
+        await llm.complete(system="s", user="u", schema=SCHEMA, schema_name="body")
+
+    assert llm.failures == 1
+
+
+async def test_a_broken_model_raises_after_its_attempts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("qwenpaw_data.host.core.algo.biztrace.llm._BACKOFF_BASE_SECONDS", 0)
+    model = _FakeModel([RuntimeError("gateway is down")])
+    llm = _llm(model)
+
+    with pytest.raises(StructuredLLMError, match="gateway is down"):
+        await llm.complete(system="s", user="u", schema=SCHEMA, schema_name="body")
+
+    assert len(model.calls) == llm.attempts
+    assert llm.failures == 1
+
+
+async def test_a_stalled_call_gives_up_at_this_step_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """算法侧的超时是这一步自己的预算，慢模型不能拖住整轮回复。"""
+
+    monkeypatch.setattr("qwenpaw_data.host.core.algo.biztrace.llm._BACKOFF_BASE_SECONDS", 0)
+    llm = _llm(_FakeModel([{"body": "ok"}], delay=1.0), timeout=0.02)
+
+    with pytest.raises(StructuredLLMError):
+        await llm.complete(system="s", user="u", schema=SCHEMA, schema_name="body")
+
+    assert llm.failures == 1
+
+
+@dataclass
+class _RecordedClient:
+    """Stands in for StructuredLLM to record what each step was given."""
+
+    model: Any
+    timeout: float
+
+
+def _record_clients(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> list[_RecordedClient]:
+    monkeypatch.setenv("QWENPAW_DATA_BIZ_LINK_ENABLED", "false")
+    monkeypatch.setenv("QWENPAW_DATA_BIZ_TRACE_LOG_DIR", str(tmp_path))
+    built: list[_RecordedClient] = []
+
+    def _client(model: Any, *, timeout: float) -> _RecordedClient:
+        client = _RecordedClient(model, timeout)
+        built.append(client)
+        return client
+
+    monkeypatch.setattr(pipeline, "StructuredLLM", _client)
+    return built
+
+
+async def test_every_step_shares_one_model_and_differs_only_in_budget(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    built = _record_clients(monkeypatch, tmp_path)
+    model = _FakeModel([{"body": "ok"}])
+
+    made = pipeline.build_pipeline(
+        session_id="ses_1",
+        chat_model=model,  # type: ignore[arg-type]
+    )
+
+    assert made is not None
+    assert {id(client.model) for client in built} == {id(model)}
+    assert sorted(client.timeout for client in built) == [5.0, 30.0, 60.0]
+    await made.aclose()
+
+
+async def test_a_run_without_a_model_stays_rule_based(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    built = _record_clients(monkeypatch, tmp_path)
+
+    made = pipeline.build_pipeline(session_id="ses_1")
+
+    assert made is not None
+    assert built == []
+    await made.aclose()

--- a/packages/qwenpaw-data-host-core/tests/test_biztrace_presentation.py
+++ b/packages/qwenpaw-data-host-core/tests/test_biztrace_presentation.py
@@ -1,0 +1,311 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from typing import Any
+
+from qwenpaw_data.host.core.algo.biztrace.llm import StructuredLLMError
+from qwenpaw_data.host.core.algo.biztrace.models import BizEvent, OrchestrationInfo, Presentation
+from qwenpaw_data.host.core.algo.biztrace.presentation import (
+    DESCRIPTION_CHAR_CAP,
+    THINKING_CHAR_CAP,
+    PresentationBuilder,
+)
+
+
+class FakeLLM:
+    """Returns canned payloads by schema name, or raises to force a fallback."""
+
+    def __init__(
+        self, payloads: dict[str, dict[str, Any]] | None = None, *, fail: bool = False
+    ) -> None:
+        self.payloads = payloads or {}
+        self.fail = fail
+        self.calls: list[tuple[str, str, str]] = []
+
+    async def complete(
+        self, *, system: str, user: str, schema_name: str, schema: dict[str, Any]
+    ) -> dict[str, Any]:
+        _ = schema
+        self.calls.append((schema_name, user, system))
+        if self.fail:
+            raise StructuredLLMError("model unavailable")
+        return self.payloads.get(schema_name, {})
+
+
+def _tool_use(name: str, payload: Any, **fields: Any) -> BizEvent:
+    return BizEvent(
+        event_id="call-1",
+        kind="tool_use",
+        block_id="call-1",
+        tool_name=name,
+        input=payload,
+        **fields,
+    )
+
+
+def _tool_result(name: str, output: Any, **fields: Any) -> BizEvent:
+    return BizEvent(
+        event_id="call-1:result",
+        kind="tool_result",
+        block_id="call-1",
+        tool_name=name,
+        output=output,
+        **fields,
+    )
+
+
+async def test_reply_cards_keep_raw_text_and_skip_the_model() -> None:
+    llm = FakeLLM({"presentation_body": {"body": "这是摘要"}})
+    builder = PresentationBuilder(llm=llm)
+    source = "结论是周末效应。\n建议按周复盘。"
+
+    card = await builder.build(
+        BizEvent(event_id="t", kind="assistant_text", content=source)
+    )
+
+    assert card.card_type == "text"
+    assert card.caption == "模型回复"
+    assert card.body == source
+    assert builder.llm_calls == 0
+    assert llm.calls == []
+
+
+async def test_thinking_cards_keep_key_decisions_in_the_prompt() -> None:
+    llm = FakeLLM({"presentation_body": {"body": "取数失败后改查周表"}})
+    builder = PresentationBuilder(llm=llm)
+
+    card = await builder.build(
+        BizEvent(
+            event_id="t",
+            kind="assistant_thinking",
+            content="SQL 报错缺分区，先改查周表再出结论。",
+        )
+    )
+
+    assert card.body == "取数失败后改查周表"
+    assert builder.llm_calls == 1
+    _schema, user, system = llm.calls[0]
+    assert "错误分析" in user
+    assert "关键决策" in system
+    assert "2 句" not in system
+
+
+async def test_thinking_fallback_keeps_more_than_the_short_card_cap() -> None:
+    builder = PresentationBuilder()
+    source = "决策" * 300
+
+    card = await builder.build(
+        BizEvent(event_id="t", kind="assistant_thinking", content=source)
+    )
+
+    assert card.card_type == "thinking"
+    assert len(card.body) > DESCRIPTION_CHAR_CAP
+    assert len(card.body) <= THINKING_CHAR_CAP
+
+
+async def test_user_and_text_cards_come_from_rules_without_a_model() -> None:
+    builder = PresentationBuilder()
+
+    user = await builder.build(
+        BizEvent(event_id="u", kind="user", content="分析日活下降")
+    )
+    text = await builder.build(
+        BizEvent(event_id="t", kind="assistant_text", content="结论是周末效应")
+    )
+
+    assert user.card_type == "user"
+    assert user.caption == "用户输入"
+    assert user.body == "分析日活下降"
+    assert text.card_type == "text"
+    assert text.body == "结论是周末效应"
+    assert builder.llm_calls == 0
+
+
+async def test_read_of_a_skill_names_it_and_the_result_carries_the_description() -> (
+    None
+):
+    builder = PresentationBuilder()
+    call = await builder.build(
+        _tool_use("Read", {"file_path": "skills/query-odps/SKILL.md"})
+    )
+    result = await builder.build(
+        _tool_result(
+            "Read",
+            "---\nname: query-odps\ndescription: 查询 ODPS 表\n---\n\n正文",
+        ),
+        call_card=call,
+    )
+
+    assert call.caption == "读取「query-odps」技能"
+    assert result.caption == call.caption
+    assert "查询 ODPS 表" in result.body
+
+
+async def test_skill_viewer_matches_the_read_file_skill_card(
+    monkeypatch,
+) -> None:
+    """AgentScope's Skill tool returns body-only markdown; look up description."""
+    import qwenpaw_data.host.core.algo.biztrace.presentation as presentation_module
+
+    monkeypatch.setattr(
+        presentation_module,
+        "_lookup_skill_description",
+        lambda name: "查询 ODPS 表" if name == "query-odps" else None,
+    )
+    builder = PresentationBuilder()
+    call = await builder.build(_tool_use("Skill", {"skill": "query-odps"}))
+    result = await builder.build(
+        _tool_result(
+            "Skill",
+            "# query-odps\n\n正文",
+            input={"skill": "query-odps"},
+        ),
+        call_card=call,
+    )
+
+    assert call.caption == "读取「query-odps」技能"
+    assert call.body == ""
+    assert result.caption == call.caption
+    assert result.body == "## 技能描述\n\n查询 ODPS 表"
+    assert builder.llm_calls == 0
+
+
+async def test_orchestration_cards_are_templates() -> None:
+    builder = PresentationBuilder()
+
+    subtask = await builder.build(
+        _tool_use(
+            "TaskStateUpdate",
+            {"task_id": "n1", "state": "completed"},
+            orchestration=OrchestrationInfo(
+                category="TaskStateUpdate",
+                subtask_state="completed",
+                node_name="取数",
+            ),
+        )
+    )
+
+    assert subtask.caption == "更新子任务状态"
+    assert subtask.body == "将子任务「取数」的状态更新为 completed。"
+    assert builder.llm_calls == 0
+
+
+async def test_bodies_are_capped_at_the_description_limit() -> None:
+    builder = PresentationBuilder(
+        llm=FakeLLM({"tool_output_presentation": {"output_summary": "长" * 500}})
+    )
+
+    card = await builder.build(_tool_result("Bash", "x" * 5000))
+
+    assert len(card.body) <= DESCRIPTION_CHAR_CAP + len("## Output\n\n")
+    assert card.body.endswith("...")
+
+
+async def test_a_failing_model_falls_back_to_the_template() -> None:
+    llm = FakeLLM(fail=True)
+    builder = PresentationBuilder(llm=llm)
+
+    card = await builder.build(_tool_use("Bash", {"command": "echo hi"}))
+
+    # Cards name the canonical tool, as they already do for Write / Edit.
+    assert card.caption == "调用 execute_shell_command"
+    assert "echo hi" in card.body
+    assert builder.llm_failures == 1
+
+
+async def test_the_result_card_reuses_the_call_caption_and_context() -> None:
+    llm = FakeLLM({"tool_output_presentation": {"output_summary": "共 12 行"}})
+    builder = PresentationBuilder(llm=llm)
+    call = Presentation(card_type="tool", caption="查询日活", body="## Input\n\nSQL")
+
+    card = await builder.build(_tool_result("Bash", "12 rows"), call_card=call)
+
+    assert card.caption == "查询日活"
+    assert "共 12 行" in card.body
+    assert "## Input\n\nSQL" in llm.calls[0][1]
+    assert "只填写 output_summary" in llm.calls[0][1]
+
+
+async def test_output_summary_strips_echoed_call_card_fields() -> None:
+    llm = FakeLLM(
+        {
+            "tool_output_presentation": {
+                "output_summary": (
+                    "卡片小标题：执行Python脚本分析DAU趋势失败。\n"
+                    "目的：在指定工作目录下运行analyze_trend.py。\n"
+                    "输入摘要：包含一个shell命令。\n"
+                    "输出摘要：调用失败，KeyError: trend_o。"
+                )
+            }
+        }
+    )
+    builder = PresentationBuilder(llm=llm)
+
+    card = await builder.build(
+        _tool_result("Bash", "Traceback...", status="error"),
+        call_card=Presentation(
+            card_type="tool",
+            caption="执行Python脚本分析DAU趋势",
+            body="在指定工作目录下运行analyze_trend.py。\n\n## Input\n\nshell命令",
+        ),
+    )
+
+    assert card.body == "## Output\n\n调用失败，KeyError: trend_o。"
+    assert "卡片小标题" not in card.body
+    assert "输入摘要" not in card.body
+
+
+async def test_a_failed_result_says_so() -> None:
+    builder = PresentationBuilder()
+
+    card = await builder.build(
+        _tool_result("PlanCreate", "", status="error"), note="调用被拒绝执行。"
+    )
+
+    assert card.body.startswith("调用失败。")
+    assert card.body.endswith("调用被拒绝执行。")
+
+
+async def test_hint_cards_never_reach_the_model() -> None:
+    llm = FakeLLM()
+    builder = PresentationBuilder(llm=llm)
+
+    card = await builder.build(
+        BizEvent(event_id="h", kind="hint", source="interaction-strategy"),
+        hint=[
+            {"type": "text", "text": "先确认口径"},
+            {"type": "image", "source": {"media_type": "image/png", "url": "u"}},
+        ],
+    )
+
+    assert card.card_type == "hint"
+    assert card.body.startswith("先确认口径")
+    assert "[image/png](u)" in card.body
+    assert "interaction-strategy" in card.body
+    assert llm.calls == []
+
+
+async def test_identical_requests_hit_the_cache() -> None:
+    llm = FakeLLM({"presentation_body": {"body": "取数"}})
+    builder = PresentationBuilder(llm=llm)
+    event = BizEvent(event_id="t", kind="assistant_thinking", content="我要先取数")
+
+    first = await builder.build(event)
+    second = await builder.build(event)
+
+    assert first.body == second.body == "取数"
+    assert builder.llm_calls == 1
+    assert builder.cache_hits == 1
+
+
+async def test_entity_links_are_injected_into_the_body_only() -> None:
+    builder = PresentationBuilder(
+        linker=lambda body: body.replace("日活", "[日活](http://cm/metric)")
+    )
+
+    card = await builder.build(
+        BizEvent(event_id="t", kind="assistant_text", content="日活下降")
+    )
+
+    assert card.body == "[日活](http://cm/metric)下降"
+    assert card.caption == "模型回复"

--- a/packages/qwenpaw-data-host-core/tests/test_biztrace_replay.py
+++ b/packages/qwenpaw-data-host-core/tests/test_biztrace_replay.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+"""End-to-end replay of a recorded AgentScope run through the pipeline."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from qwenpaw_data.host.core.algo.biztrace.models import BizTrace
+from qwenpaw_data.host.core.algo.biztrace.pipeline import BizTracePipeline
+from qwenpaw_data.host.core.algo.biztrace.presentation import PresentationBuilder
+from qwenpaw_data.host.core.algo.biztrace.settings import BizTraceSettings
+from qwenpaw_data.host.core.algo.biztrace.store import BizTraceStore, build_store_paths
+
+TRACE_EVENTS = (
+    Path(__file__).resolve().parents[3] / "assets" / "trace_events.jsonl"
+)
+
+
+def _entries() -> list[dict[str, Any]]:
+    if not TRACE_EVENTS.is_file():
+        pytest.skip(f"recorded trace not available at {TRACE_EVENTS}")
+    return [
+        {"kind": "agent_event", "payload": json.loads(line)}
+        for line in TRACE_EVENTS.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def _pipeline(tmp_path: Path, *, published: list[dict[str, Any]]) -> BizTracePipeline:
+    async def biz_event_callback(event: dict[str, Any]) -> None:
+        published.append(event)
+
+    settings = BizTraceSettings(trace2segment_enabled=False, biz_link_enabled=False)
+    return BizTracePipeline(
+        session_id="ses-1",
+        store=BizTraceStore(
+            build_store_paths(session_id="ses-1", log_dir=str(tmp_path))
+        ),
+        presenter=PresentationBuilder(),
+        settings=settings,
+        biz_event_callback=biz_event_callback,
+    )
+
+
+async def test_recorded_run_converts_and_persists(tmp_path: Path) -> None:
+    published: list[dict[str, Any]] = []
+    pipeline = _pipeline(tmp_path, published=published)
+    pipeline.start()
+
+    for entry in _entries():
+        pipeline.on_trace_event(entry)
+    await pipeline.aclose()
+
+    assert [event["presentation"]["card_type"] for event in published] == [
+        "tool",
+        "tool",
+        "tool",
+        "tool",
+        "text",
+    ]
+    assert [event["seq"] for event in published] == [1, 2, 3, 4, 5]
+    assert all(event["status"] == "done" for event in published)
+    # The Write call and its result share the block the frontend replaces.
+    assert published[0]["block_id"] == published[1]["block_id"]
+    assert published[0]["block_id"] != published[2]["block_id"]
+    assert published[0]["presentation"]["caption"] != ""
+
+
+async def test_the_persisted_rows_rebuild_the_same_trace(tmp_path: Path) -> None:
+    published: list[dict[str, Any]] = []
+    pipeline = _pipeline(tmp_path, published=published)
+    pipeline.start()
+
+    for entry in _entries():
+        pipeline.on_trace_event(entry)
+    await pipeline.aclose()
+
+    rows = await pipeline.store.read_events()
+    trace = BizTrace.from_rows(rows, session_id="ses-1")
+
+    assert [event.event_id for event in trace.events] == [
+        event["event_id"] for event in published
+    ]
+    assert [event.kind for event in trace.events] == [
+        "tool_use",
+        "tool_result",
+        "tool_use",
+        "tool_result",
+        "assistant_text",
+    ]
+    write_call = trace.events[0]
+    assert write_call.tool_name == "Write"
+    assert write_call.input["file_path"].endswith("hello.txt")
+    assert "written successfully" in trace.events[1].output

--- a/packages/qwenpaw-data-host-core/tests/test_biztrace_segmentation.py
+++ b/packages/qwenpaw-data-host-core/tests/test_biztrace_segmentation.py
@@ -1,0 +1,716 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from qwenpaw_data.host.core.algo.biztrace.models import BizEvent, OrchestrationInfo, Segment
+from qwenpaw_data.host.core.algo.biztrace.segmentation import (
+    ChainBuilder,
+    ContinuityJudge,
+    SegmentAssembler,
+    SegmentExtractor,
+)
+from qwenpaw_data.host.core.algo.biztrace.workspace_index import ArtifactVerifier
+
+class FakeJudgeLLM:
+    """Answers continuity questions from a queue of scripted decisions."""
+
+    def __init__(self, decisions: list[bool]) -> None:
+        self.decisions = list(decisions)
+        self.calls = 0
+
+    async def complete(self, **kwargs: Any) -> dict[str, Any]:
+        _ = kwargs
+        self.calls += 1
+        continues = self.decisions.pop(0) if self.decisions else True
+        return {"continues": continues, "reason": "scripted"}
+
+
+class FakeExtractLLM:
+    """Returns one canned summary for every window."""
+
+    def __init__(self, payload: dict[str, Any] | None = None) -> None:
+        self.payload = payload or {
+            "title": "取数并核对",
+            "input": "分析日活",
+            "behavior": "读取明细并比较两周数据。",
+            "conclusion": "周末效应导致下降。",
+            "artifact": None,
+        }
+        self.calls = 0
+        self.prompts: list[str] = []
+
+    async def complete(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls += 1
+        self.prompts.append(str(kwargs.get("user") or ""))
+        return self.payload
+
+
+class FakeRegistry:
+    """Stands in for coverage-scoped agent-view files from artifact_delta."""
+
+    def __init__(self, files: dict[str, str] | None = None) -> None:
+        self.files = files or {}
+        self.calls = 0
+        self.ranges: list[tuple[int, int]] = []
+
+    def __call__(self, start_seq: int, end_seq: int) -> dict[str, str]:
+        self.calls += 1
+        self.ranges.append((start_seq, end_seq))
+        return dict(self.files)
+
+
+class Collector:
+    def __init__(self) -> None:
+        self.rows: list[Segment] = []
+        self.done: list[Segment] = []
+        self.logs: list[dict[str, Any]] = []
+
+    async def on_row(self, segment: Segment) -> None:
+        self.rows.append(segment)
+
+    async def on_segment(self, segment: Segment) -> None:
+        self.done.append(segment)
+
+    async def on_judge_log(self, entry: dict[str, Any]) -> None:
+        self.logs.append(entry)
+
+
+_SEQ = iter(range(1, 10_000))
+
+
+def _event(kind: str, **fields: Any) -> BizEvent:
+    fields.setdefault("event_id", f"e{next(_SEQ)}")
+    fields.setdefault("seq", next(_SEQ))
+    fields.setdefault("parent_msg_id", "reply-1")
+    fields.setdefault("started_at", 1.0)
+    fields.setdefault("ended_at", 2.0)
+    return BizEvent(kind=kind, **fields)  # type: ignore[arg-type]
+
+
+def _text(content: str, msg_id: str) -> BizEvent:
+    return _event("assistant_text", content=content, parent_msg_id=msg_id)
+
+
+def _tool_use(name: str, payload: Any, *, call_id: str, **fields: Any) -> BizEvent:
+    return _event(
+        "tool_use",
+        event_id=call_id,
+        block_id=call_id,
+        tool_name=name,
+        input=payload,
+        **fields,
+    )
+
+
+def _tool_result(name: str, output: Any, *, call_id: str, **fields: Any) -> BizEvent:
+    return _event(
+        "tool_result",
+        event_id=f"{call_id}:result",
+        block_id=call_id,
+        tool_name=name,
+        output=output,
+        **fields,
+    )
+
+
+def _assembler(
+    *,
+    judge: FakeJudgeLLM | None = None,
+    extract: FakeExtractLLM | None = None,
+    max_span: int = 100,
+    artifact_files: FakeRegistry | None = None,
+    verifier: ArtifactVerifier | None = None,
+    linker: Callable[[str], str] | None = None,
+) -> tuple[SegmentAssembler, Collector]:
+    collector = Collector()
+    assembler = SegmentAssembler(
+        session_id="ses-1",
+        judge=ContinuityJudge(llm=judge),  # type: ignore[arg-type]
+        extractor=SegmentExtractor(
+            llm=extract if extract is not None else FakeExtractLLM(),  # type: ignore[arg-type]
+            verifier=verifier,
+            linker=linker,
+        ),
+        on_row=collector.on_row,
+        on_segment=collector.on_segment,
+        on_judge_log=collector.on_judge_log,
+        max_span=max_span,
+        artifact_files=artifact_files,
+    )
+    return assembler, collector
+
+
+# -- chain building --------------------------------------------------------- #
+
+
+def test_one_message_folds_into_one_node() -> None:
+    builder = ChainBuilder()
+    events = [
+        _event("assistant_thinking", content="先取数"),
+        _tool_use("Bash", {"command": "ls"}, call_id="c1"),
+        _tool_result("Bash", "ok", call_id="c1"),
+        _event("assistant_text", content="完成"),
+    ]
+
+    closed = [node for event in events for node in builder.push(event)]
+    closed.extend(builder.flush())
+
+    assert len(closed) == 1
+    node = closed[0]
+    assert node.kind == "normal"
+    assert [block["type"] for block in node.content] == [
+        "thinking",
+        "tool_use",
+        "tool_result",
+        "text",
+    ]
+    # The two halves of the tool pair are joined by the same call key.
+    assert node.content[1]["call"] == node.content[2]["call"]
+
+
+def test_a_new_message_starts_a_new_node() -> None:
+    builder = ChainBuilder()
+    builder.push(_text("第一轮", "r1"))
+    closed = builder.push(_text("第二轮", "r2"))
+
+    assert [node.parent_msg_id for node in closed] == ["r1"]
+    assert [node.parent_msg_id for node in builder.flush()] == ["r2"]
+
+
+def test_hint_and_orchestration_split_a_message_open() -> None:
+    builder = ChainBuilder()
+    builder.push(_event("assistant_text", content="前半"))
+    hint_nodes = builder.push(_event("hint", content="换个口径"))
+    held = builder.push(
+        _tool_use(
+            "TaskStateUpdate",
+            {"task_id": "n1", "state": "in_progress"},
+            call_id="c9",
+            orchestration=OrchestrationInfo(
+                category="TaskStateUpdate",
+                subtask_state="in_progress",
+                node_id="n1",
+                node_name="取数",
+            ),
+        )
+    )
+    subtask_nodes = builder.push(
+        _tool_result("TaskStateUpdate", "ok", call_id="c9")
+    )
+
+    assert [node.kind for node in hint_nodes] == ["normal", "hint"]
+    assert hint_nodes[1].covered is False
+    assert held == []
+    assert [node.kind for node in subtask_nodes] == ["orchestration"]
+    assert subtask_nodes[0].orchestration is not None
+    # Covered for FE fold under a segment; excluded from summary separately.
+    assert subtask_nodes[0].covered is True
+    assert subtask_nodes[0].event_ids == ["c9", "c9:result"]
+
+
+def test_a_question_is_uncovered_until_its_answer_arrives() -> None:
+    builder = ChainBuilder()
+    builder.push(_event("assistant_text", content="需要确认"))
+    nodes = builder.push(
+        _tool_use("ask_user_question", {"question": "看哪个口径?"}, call_id="q1")
+    )
+    ask = nodes[1]
+    assert [node.kind for node in nodes] == ["normal", "ask"]
+    assert ask.covered is False
+
+    trailing = builder.push(
+        _tool_result("ask_user_question", "看自然日", call_id="q1")
+    )
+
+    assert trailing == []
+    assert ask.covered is True
+    assert len(ask.content) == 2
+
+
+def test_pending_task_state_does_not_force_an_orchestration_node() -> None:
+    """Host TaskStateUpdate(pending) is bookkeeping; it stays in the open bubble."""
+    builder = ChainBuilder()
+    builder.push(_event("assistant_text", content="准备开干"))
+    closed = builder.push(
+        _tool_use(
+            "TaskStateUpdate",
+            {"task_id": "n1", "state": "pending"},
+            call_id="c1",
+            orchestration=OrchestrationInfo(
+                category="TaskStateUpdate",
+                subtask_state="pending",
+                node_id="n1",
+            ),
+        )
+    )
+
+    assert closed == []
+    flushed = builder.flush()
+    assert [node.kind for node in flushed] == ["normal"]
+
+
+# -- windowing -------------------------------------------------------------- #
+
+
+async def test_the_opening_user_message_becomes_the_query_not_a_segment() -> None:
+    assembler, collector = _assembler(judge=FakeJudgeLLM([]))
+
+    await assembler.feed(_event("user", content="分析日活下降"))
+    await assembler.aclose()
+
+    assert collector.rows == []
+    assert assembler.extractor.query == "分析日活下降"
+
+
+async def test_a_natural_boundary_closes_one_segment_and_opens_the_next() -> None:
+    judge = FakeJudgeLLM([False])
+    assembler, collector = _assembler(judge=judge)
+
+    await assembler.feed(_event("user", content="分析日活"))
+    await assembler.feed(_text("第一步", "r1"))
+    await assembler.feed(_text("第二步", "r2"))
+    await assembler.aclose()
+
+    assert judge.calls == 1
+    assert [segment.boundary_reason for segment in collector.done] == [
+        "natural",
+        "session_end",
+    ]
+    assert [segment.status for segment in collector.done] == ["done", "done"]
+    assert collector.done[0].title == "取数并核对"
+    assert any(entry["type"] == "continuity" for entry in collector.logs)
+
+
+async def test_a_hint_clears_the_draft_without_emitting_a_segment() -> None:
+    assembler, collector = _assembler(judge=FakeJudgeLLM([]))
+
+    await assembler.feed(_event("user", content="分析日活"))
+    await assembler.feed(_text("半成品", "r1"))
+    await assembler.feed(_event("hint", content="口径换成自然日"))
+    await assembler.feed(_text("重来", "r2"))
+    await assembler.aclose()
+
+    assert assembler.stats.cleared_by_hint == 1
+    assert [segment.boundary_reason for segment in collector.done] == ["session_end"]
+    # The discarded draft is not part of what the surviving segment covers.
+    assert len(collector.done[0].coverage.event_ids) == 1
+
+
+async def test_a_question_delimits_and_its_answer_joins_the_next_segment() -> None:
+    assembler, collector = _assembler(judge=FakeJudgeLLM([]))
+
+    await assembler.feed(_event("user", content="分析日活"))
+    await assembler.feed(_text("先跑一版", "r1"))
+    await assembler.feed(
+        _tool_use("ask_user_question", {"question": "口径?"}, call_id="q1")
+    )
+    await assembler.feed(_tool_result("ask_user_question", "自然日", call_id="q1"))
+    await assembler.feed(_text("按自然日重跑", "r2"))
+    await assembler.aclose()
+
+    reasons = [segment.boundary_reason for segment in collector.done]
+    assert reasons == ["ask_user_question", "session_end"]
+    assert "q1" not in collector.done[0].coverage.event_ids
+    covered_ids = collector.done[1].coverage.event_ids
+    assert "q1" in covered_ids and "q1:result" in covered_ids
+
+
+async def test_an_unanswered_question_does_not_enter_coverage() -> None:
+    assembler, collector = _assembler(judge=FakeJudgeLLM([]))
+
+    await assembler.feed(_event("user", content="分析日活"))
+    await assembler.feed(_text("先跑一版", "r1"))
+    await assembler.feed(
+        _tool_use("ask_user_question", {"question": "口径?"}, call_id="q1")
+    )
+    await assembler.aclose()
+
+    assert [segment.boundary_reason for segment in collector.done] == [
+        "ask_user_question"
+    ]
+    assert "q1" not in collector.done[0].coverage.event_ids
+
+
+async def test_a_user_message_forces_a_boundary_and_replaces_the_query() -> None:
+    assembler, collector = _assembler(judge=FakeJudgeLLM([]))
+
+    await assembler.feed(_event("user", content="分析日活"))
+    await assembler.feed(_text("做完了", "r1"))
+    await assembler.feed(_event("user", content="再看月活"))
+    await assembler.feed(_text("再做一遍", "r2"))
+    await assembler.aclose()
+
+    assert [segment.boundary_reason for segment in collector.done] == [
+        "user_message",
+        "session_end",
+    ]
+    assert assembler.extractor.query == "再看月活"
+
+
+async def test_a_sub_task_scopes_the_segments_it_opens() -> None:
+    assembler, collector = _assembler(judge=FakeJudgeLLM([]))
+    scope = OrchestrationInfo(
+        category="TaskStateUpdate",
+        subtask_state="in_progress",
+        node_id="n1",
+        node_name="取数",
+    )
+
+    await assembler.feed(_event("user", content="分析日活"))
+    await assembler.feed(
+        _tool_use("TaskStateUpdate", {}, call_id="c1", orchestration=scope)
+    )
+    await assembler.feed(
+        _tool_result("TaskStateUpdate", "ok", call_id="c1")
+    )
+    await assembler.feed(_text("取数完成", "r1"))
+    await assembler.feed(
+        _tool_use(
+            "TaskStateUpdate",
+            {},
+            call_id="c2",
+            orchestration=scope.model_copy(update={"subtask_state": "completed"}),
+        )
+    )
+    await assembler.feed(
+        _tool_result("TaskStateUpdate", "ok", call_id="c2")
+    )
+    await assembler.aclose()
+
+    # The closing TaskStateUpdate ends the scope, so it produces the only
+    # segment and nothing is left to delimit at session end. Bookkeeping calls
+    # and results are covered for FE fold, but are not the only content.
+    assert len(collector.done) == 1
+    assert collector.done[0].boundary_reason == "TaskStateUpdate"
+    assert collector.done[0].subtask is not None
+    assert collector.done[0].subtask.node_name == "取数"
+    covered = set(collector.done[0].coverage.event_ids)
+    assert {"c1", "c1:result", "c2", "c2:result"} <= covered
+    assert len(covered) == 5  # in_progress(+result) + text + completed(+result)
+
+
+async def test_plan_update_forces_a_boundary() -> None:
+    assembler, collector = _assembler(judge=FakeJudgeLLM([]))
+    revision = OrchestrationInfo(category="PlanUpdate")
+
+    await assembler.feed(_event("user", content="分析日活"))
+    await assembler.feed(_text("先按旧计划做", "r1"))
+    await assembler.feed(
+        _tool_use("PlanUpdate", {"changes": []}, call_id="p1", orchestration=revision)
+    )
+    await assembler.feed(_text("按新计划重来", "r2"))
+    await assembler.aclose()
+
+    assert [segment.boundary_reason for segment in collector.done] == [
+        "PlanUpdate",
+        "session_end",
+    ]
+
+
+async def test_max_span_cuts_a_window_that_never_ends() -> None:
+    assembler, collector = _assembler(judge=FakeJudgeLLM([True] * 10), max_span=3)
+
+    await assembler.feed(_event("user", content="分析日活"))
+    for index in range(4):
+        await assembler.feed(
+            _text(f"第{index}步", f"r{index}")
+        )
+    await assembler.aclose()
+
+    assert collector.done[0].boundary_reason == "max_span"
+    assert collector.done[0].forced_complete is True
+
+
+async def test_each_segment_is_written_twice_and_published_once() -> None:
+    assembler, collector = _assembler(judge=FakeJudgeLLM([]))
+
+    await assembler.feed(_event("user", content="分析日活"))
+    await assembler.feed(_text("做完了", "r1"))
+    await assembler.aclose()
+
+    assert [segment.status for segment in collector.rows] == ["extracting", "done"]
+    assert len(collector.done) == 1
+    assert collector.done[0].segment_id == collector.rows[0].segment_id
+
+
+async def test_a_failed_extraction_is_recorded_but_not_published() -> None:
+    class FailingLLM:
+        async def complete(self, **kwargs: Any) -> dict[str, Any]:
+            _ = kwargs
+            return {"title": "", "input": None, "behavior": "", "conclusion": ""}
+
+    assembler, collector = _assembler(
+        judge=FakeJudgeLLM([]),
+        extract=FailingLLM(),  # type: ignore[arg-type]
+    )
+
+    await assembler.feed(_event("user", content="分析日活"))
+    await assembler.feed(_text("做完了", "r1"))
+    await assembler.aclose()
+
+    assert [segment.status for segment in collector.rows] == ["extracting", "failed"]
+    assert collector.done == []
+    assert assembler.stats.failed == 1
+
+
+async def test_artifacts_survive_only_when_the_workspace_lists_them() -> None:
+    registry = FakeRegistry({"report.md": "analysis/report.md"})
+    verifier = ArtifactVerifier(
+        lambda: [
+            {
+                "rel_path": "analysis/report.md",
+                "size_bytes": 10,
+                "mime_type": "text/markdown",
+                "modified_at": "2026-08-02T00:00:00+00:00",
+            }
+        ]
+    )
+    extract = FakeExtractLLM(
+        {
+            "title": "产出报告",
+            "input": None,
+            "behavior": "写出分析报告。",
+            "conclusion": "报告已保存。",
+            "artifact": [
+                {"name": "report.md", "description": "分析报告"},
+                {"name": "ghost.csv", "description": "模型臆想的文件"},
+            ],
+        }
+    )
+    assembler, collector = _assembler(
+        judge=FakeJudgeLLM([]),
+        extract=extract,
+        artifact_files=registry,
+        verifier=verifier,
+    )
+
+    await assembler.feed(_event("user", content="出个报告"))
+    # The script writes the file, so no tool argument ever names it.
+    await assembler.feed(
+        _tool_use("Bash", {"command": "python build_report.py"}, call_id="c1")
+    )
+    await assembler.feed(_tool_result("Bash", "done", call_id="c1"))
+    await assembler.aclose()
+
+    artifacts = collector.done[0].artifact
+    assert artifacts is not None
+    assert [item.name for item in artifacts] == ["report.md"]
+    assert artifacts[0].relative_path == "analysis/report.md"
+    assert verifier.unverified == 1
+
+
+async def test_a_segment_that_registered_no_file_has_no_artifact() -> None:
+    verifier = ArtifactVerifier(lambda: [])
+    extract = FakeExtractLLM(
+        {
+            "title": "产出报告",
+            "input": None,
+            "behavior": "尝试写报告。",
+            "conclusion": "写入失败。",
+            "artifact": [{"name": "report.md", "description": "分析报告"}],
+        }
+    )
+    assembler, collector = _assembler(
+        judge=FakeJudgeLLM([]),
+        extract=extract,
+        artifact_files=FakeRegistry(),
+        verifier=verifier,
+    )
+
+    await assembler.feed(_event("user", content="出个报告"))
+    await assembler.feed(
+        _tool_use("Bash", {"command": "python build_report.py"}, call_id="c1")
+    )
+    await assembler.feed(
+        _tool_result("Bash", "denied", call_id="c1", status="error")
+    )
+    await assembler.aclose()
+
+    assert collector.done[0].artifact is None
+
+
+async def test_the_prompt_offers_the_files_the_segment_produced() -> None:
+    extract = FakeExtractLLM()
+    assembler, _ = _assembler(
+        judge=FakeJudgeLLM([]),
+        extract=extract,
+        artifact_files=FakeRegistry({"report.md": "analysis/report.md"}),
+        verifier=ArtifactVerifier(lambda: []),
+    )
+
+    await assembler.feed(_event("user", content="出个报告"))
+    await assembler.feed(
+        _tool_use("Bash", {"command": "python build_report.py"}, call_id="c1")
+    )
+    await assembler.feed(_tool_result("Bash", "done", call_id="c1"))
+    await assembler.aclose()
+
+    assert "候选工作区文件" in extract.prompts[0]
+    assert "`report.md`" in extract.prompts[0]
+
+
+async def test_extract_asks_for_coverage_scoped_agent_files() -> None:
+    registry = FakeRegistry({"report.md": "analysis/report.md"})
+    assembler, _ = _assembler(
+        judge=FakeJudgeLLM([]),
+        extract=FakeExtractLLM(),
+        artifact_files=registry,
+        verifier=ArtifactVerifier(lambda: [{"rel_path": "analysis/report.md"}]),
+    )
+
+    await assembler.feed(_event("user", content="出个报告"))
+    await assembler.feed(
+        _tool_use("Bash", {"command": "python build_report.py"}, call_id="c1")
+    )
+    await assembler.feed(_tool_result("Bash", "done", call_id="c1"))
+    await assembler.aclose()
+
+    assert registry.calls >= 1
+    assert registry.ranges
+    start, end = registry.ranges[0]
+    assert start <= end
+
+
+async def test_a_behavior_returned_as_steps_becomes_markdown() -> None:
+    extract = FakeExtractLLM(
+        {
+            "title": "取数并核对",
+            "input": None,
+            "behavior": ["拉取明细", "- 对比两周", "核对口径"],
+            "conclusion": "口径一致。",
+            "artifact": None,
+        }
+    )
+    assembler, collector = _assembler(judge=FakeJudgeLLM([]), extract=extract)
+
+    await assembler.feed(_event("user", content="分析日活"))
+    await assembler.feed(_text("做完了", "r1"))
+    await assembler.aclose()
+
+    assert collector.done[0].behavior == "1. 拉取明细\n- 对比两周\n3. 核对口径"
+
+
+async def test_the_segments_own_artifact_is_kept_out_of_its_input() -> None:
+    registry = FakeRegistry({"report.md": "analysis/report.md"})
+    verifier = ArtifactVerifier(lambda: [{"rel_path": "analysis/report.md"}])
+    extract = FakeExtractLLM(
+        {
+            "title": "产出报告",
+            "input": "- 六月明细 `june.csv`\n- 分析报告 `report.md`",
+            "behavior": "汇总明细并写出报告。",
+            "conclusion": "报告已保存。",
+            "artifact": [
+                {
+                    "name": "report.md",
+                    "description": "分析报告",
+                    "kind": "report",
+                    "role": "final",
+                }
+            ],
+        }
+    )
+    assembler, collector = _assembler(
+        judge=FakeJudgeLLM([]),
+        extract=extract,
+        artifact_files=registry,
+        verifier=verifier,
+    )
+
+    await assembler.feed(_event("user", content="出个报告"))
+    await assembler.feed(
+        _tool_use("Bash", {"command": "python build_report.py"}, call_id="c1")
+    )
+    await assembler.feed(_tool_result("Bash", "done", call_id="c1"))
+    await assembler.aclose()
+
+    segment = collector.done[0]
+    assert segment.input == "- 六月明细 `june.csv`"
+    assert segment.artifact is not None
+    assert (segment.artifact[0].kind, segment.artifact[0].role) == ("report", "final")
+
+
+async def test_window_candidates_are_stripped_from_input_even_without_artifact() -> (
+    None
+):
+    """In-window produced files are never inputs, even if omitted from artifact."""
+    registry = FakeRegistry(
+        {"report.md": "analysis/report.md", "scratch.csv": "analysis/scratch.csv"}
+    )
+    extract = FakeExtractLLM(
+        {
+            "title": "产出报告",
+            "input": "- 六月明细 `june.csv`\n- 中间表 `scratch.csv`\n- 报告 `report.md`",
+            "behavior": "汇总明细并写出报告。",
+            "conclusion": "报告已保存。",
+            "artifact": None,
+        }
+    )
+    assembler, collector = _assembler(
+        judge=FakeJudgeLLM([]),
+        extract=extract,
+        artifact_files=registry,
+    )
+
+    await assembler.feed(_event("user", content="出个报告"))
+    await assembler.feed(_text("做完了", "r1"))
+    await assembler.aclose()
+
+    assert collector.done[0].input == "- 六月明细 `june.csv`"
+    assert collector.done[0].artifact is None
+
+
+async def test_entity_links_reach_the_prose_fields_only() -> None:
+    def linker(text: str) -> str:
+        return text.replace("日活", "[日活](http://cm/metric?metric_id=m1)")
+
+    extract = FakeExtractLLM(
+        {
+            "title": "核对日活",
+            "input": "日活明细",
+            "behavior": "比较两周日活。",
+            "conclusion": "日活下降。",
+            "artifact": None,
+        }
+    )
+    assembler, collector = _assembler(
+        judge=FakeJudgeLLM([]), extract=extract, linker=linker
+    )
+
+    await assembler.feed(_event("user", content="分析日活"))
+    await assembler.feed(_text("做完了", "r1"))
+    await assembler.aclose()
+
+    segment = collector.done[0]
+    link = "[日活](http://cm/metric?metric_id=m1)"
+    assert segment.input == f"{link}明细"
+    assert segment.behavior == f"比较两周{link}。"
+    assert segment.conclusion == f"{link}下降。"
+    assert segment.title == "核对日活"
+
+
+async def test_a_broken_linker_leaves_the_fields_alone() -> None:
+    def linker(text: str) -> str:
+        raise RuntimeError("vocabulary exploded")
+
+    assembler, collector = _assembler(judge=FakeJudgeLLM([]), linker=linker)
+
+    await assembler.feed(_event("user", content="分析日活"))
+    await assembler.feed(_text("做完了", "r1"))
+    await assembler.aclose()
+
+    assert collector.done[0].behavior == "读取明细并比较两周数据。"
+
+
+async def test_a_judge_without_a_model_keeps_accumulating() -> None:
+    assembler, collector = _assembler(judge=None)
+
+    await assembler.feed(_event("user", content="分析日活"))
+    await assembler.feed(_text("一", "r1"))
+    await assembler.feed(_text("二", "r2"))
+    await assembler.aclose()
+
+    assert assembler.judge.degraded == 1
+    assert [segment.boundary_reason for segment in collector.done] == ["session_end"]
+    assert len(collector.done[0].coverage.event_ids) == 2

--- a/packages/qwenpaw-data-host-core/tests/test_biztrace_transformer.py
+++ b/packages/qwenpaw-data-host-core/tests/test_biztrace_transformer.py
@@ -1,0 +1,282 @@
+# -*- coding: utf-8 -*-
+"""The Transformer contract: start / append / join, and what reaches the host."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from qwenpaw_data.host.core.algo.biztrace import transformer as transformer_module
+from qwenpaw_data.host.core.algo.biztrace.transformer import BizTraceTransformer
+from qwenpaw_data.host.core.api.models.trace import (
+    BizEventSchema,
+    SegmentArtifactSchema,
+    SegmentSchema,
+)
+from qwenpaw_data.host.core.domain.identity import Identity
+from qwenpaw_data.host.core.domain.preference import ActiveModel, UserRuntimeConfig
+from qwenpaw_data.host.core.runtime.context import RunContext
+
+# Captured before the fixture below stubs the method out, so the model tests can
+# still drive the real resolution.
+_resolve_chat_model = BizTraceTransformer._chat_model
+
+
+class FakeEnvelope:
+    """Records what the algorithm sends, with the Envelope's exact signatures."""
+
+    def __init__(self) -> None:
+        self.biz_events: list[dict[str, Any]] = []
+        self.segments: list[dict[str, Any]] = []
+
+    async def send_biz_event(self, biz_event: dict[str, Any]) -> None:
+        self.biz_events.append(biz_event)
+
+    async def send_segment(self, segment: dict[str, Any]) -> None:
+        self.segments.append(segment)
+
+
+@pytest.fixture(autouse=True)
+def offline(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep the pipeline rule-based: no model calls, no vocabulary fetch."""
+    monkeypatch.setenv("QWENPAW_DATA_BIZ_LINK_ENABLED", "false")
+    monkeypatch.setenv("QWENPAW_DATA_TRACE2SEGMENT_ENABLED", "false")
+    monkeypatch.setattr(BizTraceTransformer, "_chat_model", lambda self: None)
+
+
+def _active(**overrides: object) -> ActiveModel:
+    values: dict[str, object] = {
+        "provider_id": "dashscope",
+        "model_id": "qwen3.7-flash",
+        "api_key": "secret",
+        "base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+        "chat_model": "DashScopeChatModel",
+        "name": "Qwen3.7 Flash",
+    }
+    values.update(overrides)
+    return ActiveModel(**values)  # type: ignore[arg-type]
+
+
+def _run_context(
+    tmp_path: Path,
+    *,
+    light: ActiveModel | None = None,
+    default: ActiveModel | None = None,
+) -> RunContext:
+    from qwenpaw_data.host.core.paths import Paths
+
+    return RunContext(
+        session_id="ses-1",
+        chat_id="chat-1",
+        workspace=object(),
+        paths=Paths(home=tmp_path, session_id="ses-1"),
+        user_runtime_config=UserRuntimeConfig(
+            default=default or _active(model_id="qwen-plus", name="Qwen Plus"),
+            light=light,
+        ),
+        request_context={"datasource_id": "ds-1"},
+        identity=Identity(user_id="u1"),
+    )
+
+
+def _transformer(
+    tmp_path: Path, envelope: FakeEnvelope, *, light: ActiveModel | None = None
+) -> BizTraceTransformer:
+    return BizTraceTransformer(
+        run_context=_run_context(tmp_path, light=light),
+        envelope=envelope,  # type: ignore[arg-type]
+    )
+
+
+def _agent_event(**payload: Any) -> dict[str, Any]:
+    payload.setdefault("reply_id", "reply-1")
+    return {"kind": "agent_event", "payload": payload}
+
+
+def _text_block(block_id: str, text: str) -> list[dict[str, Any]]:
+    return [
+        _agent_event(type="TEXT_BLOCK_START", block_id=block_id),
+        _agent_event(type="TEXT_BLOCK_DELTA", block_id=block_id, delta=text),
+        _agent_event(type="TEXT_BLOCK_END", block_id=block_id),
+    ]
+
+
+async def _drive(
+    transformer: BizTraceTransformer, entries: list[dict[str, Any]]
+) -> None:
+    await transformer.start()
+    for entry in entries:
+        await transformer.append(entry)  # type: ignore[arg-type]
+    await transformer.append(None, last=True)
+    await transformer.join()
+
+
+def _recording_build_model(
+    monkeypatch: pytest.MonkeyPatch, seen: list[ActiveModel]
+) -> None:
+    real = transformer_module.build_model
+
+    def record(model: ActiveModel) -> Any:
+        seen.append(model)
+        return real(model)
+
+    monkeypatch.setattr(transformer_module, "build_model", record)
+
+
+def test_the_light_model_is_what_conversion_runs_on(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    seen: list[ActiveModel] = []
+    _recording_build_model(monkeypatch, seen)
+    transformer = _transformer(tmp_path, FakeEnvelope(), light=_active())
+
+    model = _resolve_chat_model(transformer)
+
+    assert [active.model_id for active in seen] == ["qwen3.7-flash"]
+    assert model is not None
+    assert model.stream is False
+    assert model.parameters.thinking_enable is False
+
+
+def test_the_agents_own_model_stands_in_without_a_light_one(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    seen: list[ActiveModel] = []
+    _recording_build_model(monkeypatch, seen)
+    transformer = _transformer(tmp_path, FakeEnvelope(), light=None)
+
+    assert _resolve_chat_model(transformer) is not None
+    assert [active.model_id for active in seen] == ["qwen-plus"]
+
+
+def test_an_unusable_model_leaves_the_turn_rule_based(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def explode(_model: ActiveModel) -> Any:
+        raise ValueError("api_key is required")
+
+    monkeypatch.setattr(transformer_module, "build_model", explode)
+    transformer = _transformer(tmp_path, FakeEnvelope(), light=_active(api_key=""))
+
+    assert _resolve_chat_model(transformer) is None
+
+
+async def test_a_driven_turn_sends_its_cards(tmp_path: Path) -> None:
+    envelope = FakeEnvelope()
+    transformer = _transformer(tmp_path, envelope)
+
+    await _drive(transformer, _text_block("blk-1", "日活在月中下降。"))
+
+    assert [event["block_id"] for event in envelope.biz_events] == ["blk-1"]
+    assert envelope.biz_events[0]["status"] == "done"
+    assert envelope.biz_events[0]["presentation"]["card_type"] == "text"
+
+
+async def test_the_payload_matches_what_the_stream_accepts(
+    tmp_path: Path,
+) -> None:
+    """A stray key would only fail at ``stream.biz_event(**payload)``."""
+    envelope = FakeEnvelope()
+    transformer = _transformer(tmp_path, envelope)
+
+    await _drive(transformer, _text_block("blk-1", "结论"))
+
+    accepted = set(BizEventSchema.model_fields)
+    assert set(envelope.biz_events[0]) <= accepted - {"chat_id"}
+
+
+def test_the_segment_projection_matches_the_stream_schema() -> None:
+    from qwenpaw_data.host.core.algo.biztrace.models import (
+        FrontendArtifact,
+        FrontendSegment,
+    )
+
+    accepted = set(SegmentSchema.model_fields)
+    assert set(FrontendSegment.model_fields) <= accepted - {"chat_id"}
+    # The host's segment schema forbids unknown keys, so an artifact crosses
+    # over as name / description / relative_path and nothing else.
+    assert set(FrontendArtifact.model_fields) <= set(
+        SegmentArtifactSchema.model_fields
+    )
+
+
+async def test_the_eof_sentinel_starts_the_flush_before_join(
+    tmp_path: Path,
+) -> None:
+    envelope = FakeEnvelope()
+    transformer = _transformer(tmp_path, envelope)
+
+    await transformer.start()
+    for entry in _text_block("blk-1", "结论"):
+        await transformer.append(entry)  # type: ignore[arg-type]
+    await transformer.append(None, last=True)
+    flush = transformer._flush
+    await transformer.join()
+
+    assert flush is not None
+    assert transformer._flush is flush
+
+
+async def test_a_host_timeout_does_not_cancel_the_flush(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``join`` is shielded, so the worker still drains after the host stops
+    waiting; otherwise the events it holds would die with the Chat."""
+
+    envelope = FakeEnvelope()
+    transformer = _transformer(tmp_path, envelope)
+    await transformer.start()
+    pipeline = transformer._pipeline
+    assert pipeline is not None
+    drain = pipeline.aclose
+
+    async def slow_drain() -> None:
+        await asyncio.sleep(0.05)
+        await drain()
+
+    monkeypatch.setattr(pipeline, "aclose", slow_drain)
+    for entry in _text_block("blk-1", "结论"):
+        await transformer.append(entry)  # type: ignore[arg-type]
+
+    with pytest.raises(TimeoutError):
+        await asyncio.wait_for(transformer.join(), timeout=0.01)
+    flush = transformer._flush
+    assert flush is not None
+    await flush
+
+    assert not flush.cancelled()
+    assert len(envelope.biz_events) == 1
+
+
+async def test_append_and_join_are_no_ops_when_start_failed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def explode(**_kwargs: Any) -> None:
+        raise RuntimeError("no pipeline for you")
+
+    monkeypatch.setattr(
+        "qwenpaw_data.host.core.algo.biztrace.transformer.build_pipeline", explode
+    )
+    envelope = FakeEnvelope()
+    transformer = _transformer(tmp_path, envelope)
+
+    await _drive(transformer, _text_block("blk-1", "结论"))
+
+    assert envelope.biz_events == []
+
+
+async def test_the_feature_switch_leaves_nothing_running(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("QWENPAW_DATA_BIZ_TRACE_ENABLED", "false")
+    envelope = FakeEnvelope()
+    transformer = _transformer(tmp_path, envelope)
+
+    await _drive(transformer, _text_block("blk-1", "结论"))
+
+    assert transformer._pipeline is None
+    assert envelope.biz_events == []


### PR DESCRIPTION
## Summary
- transform raw agent events into structured business events and presentation cards
- segment complete sessions into business-semantic phases with continuity judging and optional model-assisted extraction
- link events to semantic vocabulary entities and verify newly produced workspace artifacts
- persist replayable JSONL traces and publish `biz_event` and `segment` objects over SSE
- keep processing bounded and resilient with rule-based fallbacks, isolated failures, and capped shutdown waits

## Stack
- stacked on #45
- retarget this PR to `main` after the preceding PRs merge

## Test plan
- [x] Run BizTrace conversion, presentation, linking, segmentation, replay, and transformer tests
- [x] Run artifact indexing and runtime integration tests
- [x] Run the full repository test suite (`762 passed, 8 skipped`)