### PR TITLE
feat(context): harden explorer subgraph search and cache global snapshots

### DIFF
--- a/packages/qwenpaw-data-context/src/context_manager/api/cypher_api.py
+++ b/packages/qwenpaw-data-context/src/context_manager/api/cypher_api.py
@@ -228,6 +228,11 @@ def _extract_write_targets(
     return targeted, unresolved
 
 
+def _is_write_statement(cypher: str) -> bool:
+    lowered = _strip_string_literals(cypher).lower()
+    return _has_keyword(lowered, _DML_KEYWORDS)
+
+
 def _check_write_acl(cypher: str) -> None:
     """Validate Cypher write ACL.  Raises via ``fail()`` on violation."""
     cleaned = _strip_string_literals(cypher)
@@ -418,6 +423,10 @@ def execute_cypher(body: CypherRequest, request: Request):
         raw_rows_serial = [dict(zip(keys, (r.data()[k] for k in keys))) for r in records]
 
     elapsed_ms = int((time.monotonic() - t0) * 1000)
+    if _is_write_statement(body.cypher):
+        from .retrieval import invalidate_global_graph_snapshot_cache
+
+        invalidate_global_graph_snapshot_cache()
     rows_native = raw_rows_native
     columns = keys if keys else (list(rows_native[0].keys()) if rows_native else [])
 

--- a/packages/qwenpaw-data-context/src/context_manager/api/doc_api.py
+++ b/packages/qwenpaw-data-context/src/context_manager/api/doc_api.py
@@ -159,6 +159,9 @@ def _run_kg_ingest_sync(
                 )
         log.exception("KG ingest failed for %r", filename)
     else:
+        from .retrieval import invalidate_global_graph_snapshot_cache
+
+        invalidate_global_graph_snapshot_cache()
         if not client.file_exists(doc_id):
             log.info("Skipped KG ingest success status for %r (document removed)", doc_id)
             return
@@ -177,6 +180,9 @@ def _run_kg_delete_sync(driver: Any, filename: str) -> None:
     try:
         result = delete_kg_nodes_by_source(driver, filename)
         log.info("KG delete completed for %r: %s", filename, result)
+        from .retrieval import invalidate_global_graph_snapshot_cache
+
+        invalidate_global_graph_snapshot_cache()
     except Exception:
         log.exception("KG delete failed for %r", filename)
 

--- a/packages/qwenpaw-data-context/src/context_manager/api/explorer_api.py
+++ b/packages/qwenpaw-data-context/src/context_manager/api/explorer_api.py
@@ -1,4 +1,5 @@
 """Unified graph explorer API used by the CM Graph frontend."""
+
 from __future__ import annotations
 
 from typing import Literal
@@ -16,6 +17,7 @@ from .retrieval import (
     _KNOWLEDGE_LAYER_LABELS,
     _METADATA_LAYER_LABELS,
     _TRACE_LAYER_LABELS,
+    search_explorer_subgraph,
 )
 
 log = get_logger("api.explorer")
@@ -24,10 +26,32 @@ router = APIRouter(prefix="/api/v1/admin/explorer", tags=["explorer"])
 
 _NODE_EDITABLE_FIELDS: dict[str, list[str]] = {
     "Claim": ["text", "confidence", "subject_type", "predicate", "object"],
-    "Strategy": ["strategy_semantics", "memory_tier", "source_trust", "polarity", "example_query"],
-    "StrategyCard": ["strategy_semantics", "memory_tier", "source_trust", "polarity", "example_query"],
+    "Strategy": [
+        "strategy_semantics",
+        "memory_tier",
+        "source_trust",
+        "polarity",
+        "example_query",
+    ],
+    "StrategyCard": [
+        "strategy_semantics",
+        "memory_tier",
+        "source_trust",
+        "polarity",
+        "example_query",
+    ],
     "Entity": ["canonical_name", "type", "aliases", "description", "lifecycle_state"],
-    "Event": ["name", "type", "description", "date_from", "date_to", "scope", "source_id", "source_trust", "extractor"],
+    "Event": [
+        "name",
+        "type",
+        "description",
+        "date_from",
+        "date_to",
+        "scope",
+        "source_id",
+        "source_trust",
+        "extractor",
+    ],
 }
 
 _EDGE_EDITABLE_FIELDS: dict[str, list[str]] = {
@@ -141,6 +165,7 @@ def global_graph(body: GlobalGraphRequest, request: Request):
         ds_id = body.resolved_datasource_id
         if ds_id:
             from .datasource_filter import filter_graph_by_datasource
+
             filtered = filter_graph_by_datasource(data, ds_id)
             if filtered is not None:
                 data = filtered
@@ -197,9 +222,7 @@ def expand_node(body: ExpandNodeRequest, request: Request):
         fail("INTERNAL_ERROR", str(exc), status_code=500)
 
 
-def _filter_expand_result(
-    data: dict, *, zone: str | None, label: str | None
-) -> dict:
+def _filter_expand_result(data: dict, *, zone: str | None, label: str | None) -> dict:
     nodes = data.get("nodes", [])
     center_id = data.get("center")
     filtered_ids: set[str] = set()
@@ -359,11 +382,15 @@ def cross_graph_neighbors(key: str, request: Request, limit: int = 50):
     node_zone = ""
     if zone_record:
         raw_zone = str(zone_record["zone"] or "")
-        node_zone = _LABEL_ZONE.get(raw_zone, raw_zone if raw_zone in _LABEL_ZONE.values() else "")
+        node_zone = _LABEL_ZONE.get(
+            raw_zone, raw_zone if raw_zone in _LABEL_ZONE.values() else ""
+        )
 
     neighbors = []
     for row in rows:
-        other_zone = row.get("other_zone") or _LABEL_ZONE.get(row.get("other_label", ""), "")
+        other_zone = row.get("other_zone") or _LABEL_ZONE.get(
+            row.get("other_label", ""), ""
+        )
         if other_zone and other_zone != node_zone:
             neighbors.append(
                 {
@@ -457,7 +484,9 @@ def edge_detail(body: EdgeDetailRequest, request: Request):
             "target_zone": target_zone,
             "properties": properties,
             "editable_fields": _EDGE_EDITABLE_FIELDS.get(body.rel_type, []),
-            "is_cross_graph": bool(source_zone and target_zone and source_zone != target_zone),
+            "is_cross_graph": bool(
+                source_zone and target_zone and source_zone != target_zone
+            ),
         }
     )
 
@@ -467,107 +496,27 @@ def search_subgraph(body: SearchSubgraphRequest, request: Request):
     """Search nodes and expand each hit by up to three hops."""
     query = body.query.strip()
     if not query:
-        return success({"hit_nodes": [], "nodes": [], "edges": []})
+        return _budgeted_success({"hit_nodes": [], "nodes": [], "edges": []})
 
-    zone_labels = {
-        label
-        for label, zone in _LABEL_ZONE.items()
-        if zone in (body.scope or ["metadata", "trace", "knowledge"])
-    }
-    label_filter = ""
-    if zone_labels:
-        label_filter = " AND (" + " OR ".join(
-            f"node:`{label}`" for label in sorted(zone_labels)
-        ) + ")"
-
-    if body.match_mode == "exact":
-        match_filter = "(node.key = $search_query OR node.name = $search_query)"
-    else:
-        match_filter = """(
-            toLower(coalesce(node.key, '')) CONTAINS $search_query_lower
-            OR toLower(coalesce(node.name, '')) CONTAINS $search_query_lower
-            OR toLower(coalesce(node.canonical_name, '')) CONTAINS $search_query_lower
-            OR toLower(coalesce(node.description, '')) CONTAINS $search_query_lower
-            OR any(alias IN coalesce(node.aliases, [])
-                   WHERE toLower(toString(alias)) CONTAINS $search_query_lower)
-        )"""
-
-    hit_query = f"""
-    MATCH (node)
-    WHERE {match_filter}{label_filter}
-    RETURN node.key AS key, head(labels(node)) AS label,
-           coalesce(node.zone, '') AS zone,
-           coalesce(node.name, node.canonical_name, node.goal, node.key) AS display_name
-    LIMIT $limit
-    """
-    driver = _driver(request)
-    with graph_session(driver) as session:
-        hit_rows = session.run(
-            hit_query,
-            search_query=query,
-            search_query_lower=query.lower(),
-            limit=body.limit,
-        ).data()
-
-    hit_nodes = []
-    for row in hit_rows:
-        hit_nodes.append(
-            {
-                "key": row["key"],
-                "label": row.get("label", ""),
-                "zone": row.get("zone") or _LABEL_ZONE.get(row.get("label", ""), ""),
-                "display_name": row.get("display_name", ""),
-            }
-        )
-    if not hit_nodes:
-        return success({"hit_nodes": [], "nodes": [], "edges": []})
-
-    nodes_by_key = {node["key"]: node for node in hit_nodes if node.get("key")}
-    edges: list[dict] = []
-    seen_edges: set[tuple[str, str, str]] = set()
-    expand_query = f"""
-    MATCH (hit {{key: $hit_key}})
-    OPTIONAL MATCH path = (hit)-[*1..{body.hops}]-(neighbor)
-    WITH hit, neighbor, relationships(path) AS relationships
-    WHERE neighbor IS NOT NULL AND neighbor <> hit
-    RETURN neighbor.key AS key, head(labels(neighbor)) AS label,
-           coalesce(neighbor.zone, '') AS zone,
-           coalesce(neighbor.name, neighbor.canonical_name, neighbor.goal, neighbor.key) AS display_name,
-           [rel IN relationships | {{
-             source_key: coalesce(startNode(rel).key, ''),
-             target_key: coalesce(endNode(rel).key, ''),
-             rel_type: type(rel)
-           }}] AS edge_info
-    LIMIT 200
-    """
-    with graph_session(driver) as session:
-        for hit_key in list(nodes_by_key):
-            for row in session.run(expand_query, hit_key=hit_key).data():
-                node_key = row.get("key")
-                if node_key and node_key not in nodes_by_key:
-                    nodes_by_key[node_key] = {
-                        "key": node_key,
-                        "label": row.get("label", ""),
-                        "zone": row.get("zone") or _LABEL_ZONE.get(row.get("label", ""), ""),
-                        "display_name": row.get("display_name", ""),
-                    }
-                for edge in row.get("edge_info") or []:
-                    edge_id = (
-                        edge.get("source_key", ""),
-                        edge.get("target_key", ""),
-                        edge.get("rel_type", ""),
-                    )
-                    if all(edge_id) and edge_id not in seen_edges:
-                        seen_edges.add(edge_id)
-                        edges.append(
-                            {
-                                "source_key": edge_id[0],
-                                "target_key": edge_id[1],
-                                "rel_type": edge_id[2],
-                                "properties": {},
-                            }
-                        )
-
-    return success(
-        {"hit_nodes": hit_nodes, "nodes": list(nodes_by_key.values()), "edges": edges}
+    scope = body.scope or ["metadata", "trace", "knowledge"]
+    allowed_labels = sorted(
+        label for label, zone in _LABEL_ZONE.items() if zone in scope
     )
+    requested_nodes = body.limit * (body.hops * 4 + 1)
+    requested_edges = body.limit * body.hops * 4
+    max_nodes, max_edges = current_request_budget().cap_graph(
+        nodes=requested_nodes,
+        edges=requested_edges,
+    )
+    data = search_explorer_subgraph(
+        _driver(request),
+        query,
+        allowed_labels=allowed_labels,
+        label_zones=_LABEL_ZONE,
+        match_mode=body.match_mode,
+        hops=body.hops,
+        limit=body.limit,
+        max_nodes=max_nodes,
+        max_edges=max_edges,
+    )
+    return _budgeted_success(data)

--- a/packages/qwenpaw-data-context/src/context_manager/api/import_api.py
+++ b/packages/qwenpaw-data-context/src/context_manager/api/import_api.py
@@ -182,6 +182,10 @@ async def import_data(request: ImportRequest, req: Request) -> ImportResult:
             result.task_id,
             result,
         )
+        if result.status in {ImportStatus.success, ImportStatus.degraded}:
+            from .retrieval import invalidate_global_graph_snapshot_cache
+
+            invalidate_global_graph_snapshot_cache()
         if callback_url:
             asyncio.create_task(_fire_callback(callback_url, result))
         return result

--- a/packages/qwenpaw-data-context/src/context_manager/api/kg_admin_api.py
+++ b/packages/qwenpaw-data-context/src/context_manager/api/kg_admin_api.py
@@ -31,6 +31,14 @@ def _driver(request: Request):
     return request.app.state.driver
 
 
+def _success_after_write(result):
+    """Wrap a successful graph mutation, dropping stale global snapshots."""
+    from .retrieval import invalidate_global_graph_snapshot_cache
+
+    invalidate_global_graph_snapshot_cache()
+    return success(result)
+
+
 # ═══════════════════════════════════════════════════════════════════════ #
 #  Entity
 # ═══════════════════════════════════════════════════════════════════════ #
@@ -63,7 +71,7 @@ def batch_delete_entities(body: BatchDeleteRequest, request: Request):
     driver = _driver(request)
     try:
         result = kg_admin.delete_knowledge_nodes_batch(driver, body.keys)
-        return success(result)
+        return _success_after_write(result)
     except ValueError as exc:
         fail("VALIDATION_ERROR", str(exc))
 
@@ -102,7 +110,7 @@ def upsert_entity(key: str, body: EntityUpsertRequest, request: Request):
             description=body.description,
             lifecycle_state=body.lifecycle_state,
         )
-        return success(result)
+        return _success_after_write(result)
     except ValueError as exc:
         fail("VALIDATION_ERROR", str(exc))
 
@@ -113,7 +121,7 @@ def delete_entity(key: str, request: Request):
     driver = _driver(request)
     try:
         result = kg_admin.delete_knowledge_node(driver, key)
-        return success(result)
+        return _success_after_write(result)
     except ValueError as exc:
         fail("VALIDATION_ERROR", str(exc))
 
@@ -180,7 +188,7 @@ def upsert_event(key: str, body: EventUpsertRequest, request: Request):
             source_trust=body.source_trust,
             extractor=body.extractor,
         )
-        return success(result)
+        return _success_after_write(result)
     except ValueError as exc:
         fail("VALIDATION_ERROR", str(exc))
 
@@ -191,7 +199,7 @@ def delete_event(key: str, request: Request):
     driver = _driver(request)
     try:
         result = kg_admin.delete_knowledge_node(driver, key)
-        return success(result)
+        return _success_after_write(result)
     except ValueError as exc:
         fail("VALIDATION_ERROR", str(exc))
 
@@ -212,7 +220,7 @@ def create_related_to(body: RelatedToRequest, request: Request):
             relation_subtype=body.relation_subtype,
             description=body.description,
         )
-        return success(result)
+        return _success_after_write(result)
     except ValueError as exc:
         fail("VALIDATION_ERROR", str(exc))
 
@@ -223,7 +231,7 @@ def delete_related_to(body: RelatedToDeleteRequest, request: Request):
     driver = _driver(request)
     try:
         result = kg_admin.delete_related_to(driver, from_key=body.from_key, to_key=body.to_key)
-        return success(result)
+        return _success_after_write(result)
     except ValueError as exc:
         fail("VALIDATION_ERROR", str(exc))
 
@@ -239,7 +247,7 @@ def toggle_about(body: AboutRequest, request: Request):
             entity_key=body.entity_key,
             connect=body.connect,
         )
-        return success(result)
+        return _success_after_write(result)
     except ValueError as exc:
         fail("VALIDATION_ERROR", str(exc))
 
@@ -256,7 +264,7 @@ def create_cross_graph_edge(body: CrossGraphEdgeRequest, request: Request):
             rel_type=body.rel_type,
             properties=body.properties,
         )
-        return success(result)
+        return _success_after_write(result)
     except ValueError as exc:
         fail("VALIDATION_ERROR", str(exc))
 
@@ -272,7 +280,7 @@ def delete_cross_graph_edge(body: CrossGraphEdgeDeleteRequest, request: Request)
             to_key=body.to_key,
             rel_type=body.rel_type,
         )
-        return success(result)
+        return _success_after_write(result)
     except ValueError as exc:
         fail("VALIDATION_ERROR", str(exc))
 
@@ -289,7 +297,7 @@ def update_edge_properties(body: EdgePropertiesUpdateRequest, request: Request):
             rel_type=body.rel_type,
             properties=body.properties,
         )
-        return success(result)
+        return _success_after_write(result)
     except ValueError as exc:
         fail("VALIDATION_ERROR", str(exc))
 
@@ -306,7 +314,7 @@ def delete_adjacent_edge(body: AdjacentEdgeDeleteRequest, request: Request):
             rel_type=body.rel_type,
             direction=body.direction,
         )
-        return success(result)
+        return _success_after_write(result)
     except ValueError as exc:
         fail("VALIDATION_ERROR", str(exc))
 
@@ -322,7 +330,7 @@ def delete_edges_by_type(body: EdgeDeleteByTypeRequest, request: Request):
             rel_type=body.rel_type,
             direction_scope=body.direction_scope,
         )
-        return success(result)
+        return _success_after_write(result)
     except ValueError as exc:
         fail("VALIDATION_ERROR", str(exc))
 
@@ -343,6 +351,6 @@ def purge_edges_by_type_global(body: GlobalEdgePurgeRequest, request: Request):
         result = kg_admin.delete_all_edges_touching_knowledge_nodes_by_type(
             driver, rel_type=body.rel_type,
         )
-        return success(result)
+        return _success_after_write(result)
     except ValueError as exc:
         fail("VALIDATION_ERROR", str(exc))

--- a/packages/qwenpaw-data-context/src/context_manager/api/retrieval.py
+++ b/packages/qwenpaw-data-context/src/context_manager/api/retrieval.py
@@ -8,10 +8,16 @@
 
 返回结构都是 plain ``dict``，前端 vis-network 直接消费。
 """
+
 from __future__ import annotations
 
+import copy
 import json
 import re
+import threading
+import time
+from collections import OrderedDict
+from collections.abc import Mapping
 from typing import Any, Optional
 
 from neo4j import Driver
@@ -19,7 +25,7 @@ from neo4j import Driver
 from ..embedder import embed_one
 from ..config import CFG
 from ..rrf import rrf_merge as _rrf_merge
-from ..utils import get_logger, neo4j_session
+from ..utils import get_logger, neo4j_database_ctx, neo4j_session
 
 log = get_logger("api.retrieval")
 
@@ -61,7 +67,11 @@ def relevance_gate(
     )
     from ..config import CFG
 
-    eff_threshold = threshold if (threshold is not None and threshold > 0) else CFG.relevance_threshold
+    eff_threshold = (
+        threshold
+        if (threshold is not None and threshold > 0)
+        else CFG.relevance_threshold
+    )
     eff_floor = floor if floor is not None else CFG.relevance_floor
 
     if not rows:
@@ -95,7 +105,11 @@ def relevance_gate(
         return [], {"status": status, "score": round(best_score, 3), "matched_name": ""}
 
     filtered = [row for score, row in scored_rows if score >= eff_threshold]
-    return filtered, {"status": status, "score": round(best_score, 3), "matched_name": best_name}
+    return filtered, {
+        "status": status,
+        "score": round(best_score, 3),
+        "matched_name": best_name,
+    }
 
 
 # ---------------------------------------------------------------------- #
@@ -147,8 +161,9 @@ def _vector_search(
 # ---------------------------------------------------------------------- #
 
 
-def detect_dimensions(driver: Driver, domain: Optional[str], query: str,
-                      datasource_id: str = "") -> list[dict[str, Any]]:
+def detect_dimensions(
+    driver: Driver, domain: Optional[str], query: str, datasource_id: str = ""
+) -> list[dict[str, Any]]:
     """在 ``Dimension.name + aliases`` 里做子串匹配；可选限定 domain 与 datasource_id。"""
     if not query:
         return []
@@ -189,8 +204,9 @@ def detect_domain(driver: Driver, query: str) -> Optional[str]:
 # ---------------------------------------------------------------------- #
 # Q-1: 自然语言 → metric (Hybrid: fulltext + vector via RRF)
 # ---------------------------------------------------------------------- #
-def _fulltext_search_metrics(driver: Driver, query: str, k: int,
-                             domain: Optional[str] = None) -> list[dict[str, Any]]:
+def _fulltext_search_metrics(
+    driver: Driver, query: str, k: int, domain: Optional[str] = None
+) -> list[dict[str, Any]]:
     domain_clause = "AND node.domain = $domain" if domain else ""
     cypher = f"""
     CALL db.index.fulltext.queryNodes('metric_text', $q) YIELD node, score
@@ -268,9 +284,9 @@ def resolve_metric(
             log.warning("embed_one failed (%s); skipping vector path", exc)
             qvec = None
         if qvec:
-            vec_rows = _vector_search(driver, index_name="met_vec",
-                                       query_vec=qvec, k=pool_k,
-                                       domain=domain)
+            vec_rows = _vector_search(
+                driver, index_name="met_vec", query_vec=qvec, k=pool_k, domain=domain
+            )
             if vec_rows:
                 rankings.append(vec_rows)
                 for r in vec_rows:
@@ -441,8 +457,9 @@ def resolve_column(
         log.warning("embed_one failed for column: %s", exc)
         qvec = None
     if qvec:
-        rankings.append(_vector_search(driver, index_name="col_vec",
-                                        query_vec=qvec, k=pool_k))
+        rankings.append(
+            _vector_search(driver, index_name="col_vec", query_vec=qvec, k=pool_k)
+        )
 
     # fulltext
     cypher_ft = """
@@ -463,8 +480,11 @@ def resolve_column(
     if domain_table_keys:
         # column.key = col:db.schema.table.col → 用前缀匹配
         prefixes = [tk.replace("tbl:", "col:") + "." for tk in domain_table_keys]
-        rows = [r for r in rows
-                if any(str(r.get("key", "")).startswith(p) for p in prefixes)]
+        rows = [
+            r
+            for r in rows
+            if any(str(r.get("key", "")).startswith(p) for p in prefixes)
+        ]
     return rows[:k]
 
 
@@ -547,7 +567,9 @@ def expand_subgraph(
             }
         return key
 
-    def add_edge(src: Optional[str], dst: Optional[str], rel: str, props: Optional[dict] = None) -> None:
+    def add_edge(
+        src: Optional[str], dst: Optional[str], rel: str, props: Optional[dict] = None
+    ) -> None:
         if not (src and dst):
             return
         edges.append({"from": src, "to": dst, "type": rel, "props": props or {}})
@@ -581,7 +603,11 @@ def expand_subgraph(
             add_edge(f_key, t_key, "OF_VIEW")
         if r.get("col"):
             _col_props = dict(r["col"])
-            _col_group = "DatasetColumn" if str(_col_props.get("key", "")).startswith("dscol:") else "Column"
+            _col_group = (
+                "DatasetColumn"
+                if str(_col_props.get("key", "")).startswith("dscol:")
+                else "Column"
+            )
             c_key = add_node(r["col"], _col_group)
             add_edge(f_key, c_key, "USES_COLUMN", {"role": r.get("role") or ""})
         # 整理 raw.formulas
@@ -613,12 +639,27 @@ def expand_subgraph(
             add_edge(metric_key_actual, dim_key, "ANALYZED_BY")
             if r.get("col"):
                 _dc_props = dict(r["col"])
-                _dc_group = "DatasetColumn" if str(_dc_props.get("key", "")).startswith("dscol:") else "Column"
+                _dc_group = (
+                    "DatasetColumn"
+                    if str(_dc_props.get("key", "")).startswith("dscol:")
+                    else "Column"
+                )
                 col_key = add_node(r["col"], _dc_group)
-                _dc_rel = "MAPS_TO_DATASET_COLUMN" if _dc_group == "DatasetColumn" else "MAPS_TO_COLUMN"
-                add_edge(dim_key, col_key, _dc_rel,
-                         {"expr": r.get("expr") or "", "filter": r.get("filter") or "",
-                          "binding_type": r.get("binding_type") or ""})
+                _dc_rel = (
+                    "MAPS_TO_DATASET_COLUMN"
+                    if _dc_group == "DatasetColumn"
+                    else "MAPS_TO_COLUMN"
+                )
+                add_edge(
+                    dim_key,
+                    col_key,
+                    _dc_rel,
+                    {
+                        "expr": r.get("expr") or "",
+                        "filter": r.get("filter") or "",
+                        "binding_type": r.get("binding_type") or "",
+                    },
+                )
             if dim_props.get("key") not in seen_dim:
                 seen_dim.add(dim_props.get("key"))
                 raw["drill_dims"].append(
@@ -636,8 +677,12 @@ def expand_subgraph(
             if not r or not r.get("parent"):
                 continue
             pk = add_node(r["parent"], "Metric")
-            add_edge(metric_key_actual, pk, "DERIVED_FROM",
-                     {"role": r.get("role"), "relation_type": r.get("relation_type")})
+            add_edge(
+                metric_key_actual,
+                pk,
+                "DERIVED_FROM",
+                {"role": r.get("role"), "relation_type": r.get("relation_type")},
+            )
             raw["derived"].append(
                 {
                     "key": dict(r["parent"]).get("key"),
@@ -709,7 +754,8 @@ def expand_subgraph(
 
     # DatasetColumn composite: 把 COMPOSED_OF 边和目标 Column 带入子图
     composite_dc_keys = [
-        k for k, n in nodes.items()
+        k
+        for k, n in nodes.items()
         if n["group"] == "DatasetColumn" and n["props"].get("composite")
     ]
     if composite_dc_keys:
@@ -732,8 +778,6 @@ def expand_subgraph(
         "edges": edges,
         "raw": raw,
     }
-
-
 
 
 # ---------------------------------------------------------------------- #
@@ -851,7 +895,13 @@ def _collect_keys_from_trigger_conditions(raw: Any) -> list[str]:
         if g:
             keys.append(f"db:{g}")
 
-    for ak in ("anchor_keys", "entry_anchor_keys", "metric_keys", "seed_keys", "dimension_keys"):
+    for ak in (
+        "anchor_keys",
+        "entry_anchor_keys",
+        "metric_keys",
+        "seed_keys",
+        "dimension_keys",
+    ):
         v = tc.get(ak)
         if isinstance(v, list):
             for x in v:
@@ -897,7 +947,9 @@ def _strategy_card_extra_fetch_keys(
             pks = str(pk).strip()
             if pks and pks not in nodes:
                 want.append(pks)
-        want.extend(_collect_keys_from_trigger_conditions(props.get("trigger_conditions")))
+        want.extend(
+            _collect_keys_from_trigger_conditions(props.get("trigger_conditions"))
+        )
 
     budget = max(0, max_total_nodes - len(nodes))
     out: list[str] = []
@@ -976,9 +1028,14 @@ def _append_strategy_card_synthetic_edges(
         if not ck:
             continue
         props = nv.get("props") or {}
-        path_keys = [_trim_key_token(x) for x in _parse_path_subgraph_keys(props.get("path_subgraph_keys"))]
+        path_keys = [
+            _trim_key_token(x)
+            for x in _parse_path_subgraph_keys(props.get("path_subgraph_keys"))
+        ]
         path_keys = [x for x in path_keys if x]
-        meta_keys = _collect_keys_from_trigger_conditions(props.get("trigger_conditions"))
+        meta_keys = _collect_keys_from_trigger_conditions(
+            props.get("trigger_conditions")
+        )
 
         first_path_idx: Optional[int] = None
         for i, pk in enumerate(path_keys):
@@ -1007,7 +1064,12 @@ def _append_strategy_card_synthetic_edges(
             add_edge(sa, sb, "PATH_ORDER", leg="chain", step=i)
 
         if path_keys and first_path_idx is not None:
-            add_edge(ck, f"syn:path_step:{ck}:{first_path_idx}", "CARD_ENTRY", role="path_head")
+            add_edge(
+                ck,
+                f"syn:path_step:{ck}:{first_path_idx}",
+                "CARD_ENTRY",
+                role="path_head",
+            )
         elif path_keys:
             p0 = path_keys[0]
             if p0 in nodes:
@@ -1105,7 +1167,12 @@ def subgraph_snapshot_from_keys(
                 continue
             seen_edge.add(sig)
             edges_out.append(
-                {"from": ka, "to": kb, "type": rt, "props": _trim_props(dict(row.get("rp") or {}))}
+                {
+                    "from": ka,
+                    "to": kb,
+                    "type": rt,
+                    "props": _trim_props(dict(row.get("rp") or {})),
+                }
             )
 
     _append_strategy_card_synthetic_edges(nodes, edges_out)
@@ -1318,9 +1385,7 @@ def _add_node_unchecked(add_node, node, group: str):
 def _all_layer_labels_union() -> tuple[str, ...]:
     """``zone_mode=all`` 时合并三类图层的结点标签（去重保序）。"""
     merged: dict[str, None] = {}
-    for lab in (
-        _METADATA_LAYER_LABELS + _KNOWLEDGE_LAYER_LABELS + _TRACE_LAYER_LABELS
-    ):
+    for lab in _METADATA_LAYER_LABELS + _KNOWLEDGE_LAYER_LABELS + _TRACE_LAYER_LABELS:
         merged.setdefault(lab, None)
     return tuple(merged.keys())
 
@@ -1337,8 +1402,7 @@ def _zone_mode_allowed(zone_mode: str) -> Optional[tuple[str, ...]]:
     if zm == "knowledge":
         return ("knowledge", "_shared")
     raise ValueError(
-        "zone_mode must be one of: all, metadata, trace, knowledge "
-        f"(got {zone_mode!r})"
+        f"zone_mode must be one of: all, metadata, trace, knowledge (got {zone_mode!r})"
     )
 
 
@@ -1521,7 +1585,259 @@ def search_explorer_nodes(
     return out[:lim]
 
 
+def search_explorer_subgraph(
+    driver: Driver,
+    query: str,
+    *,
+    allowed_labels: Optional[list[str] | tuple[str, ...] | set[str]] = None,
+    label_zones: Optional[Mapping[str, str]] = None,
+    match_mode: str = "fuzzy",
+    hops: int = 1,
+    limit: int = 50,
+    max_nodes: int = 250,
+    max_edges: int = 200,
+) -> dict[str, list[dict[str, Any]]]:
+    """Search Explorer nodes and return one bounded, scope-filtered traversal."""
+    q = (query or "").strip()
+    if not q:
+        return {"hit_nodes": [], "nodes": [], "edges": []}
+
+    restrict_labels = allowed_labels is not None
+    labels: list[str] = []
+    for raw_label in allowed_labels or ():
+        label = str(raw_label).strip()
+        if not _LABEL_TOKEN_RE.fullmatch(label):
+            raise ValueError(f"Invalid Neo4j label: {raw_label!r}")
+        if label not in labels:
+            labels.append(label)
+    labels.sort()
+
+    mode = (match_mode or "fuzzy").strip().lower()
+    if mode not in ("exact", "fuzzy"):
+        raise ValueError("match_mode must be 'exact' or 'fuzzy'")
+    hop_cap = max(1, min(int(hops), 3))
+    seed_cap = max(1, min(int(limit), 200))
+    node_cap = max(0, int(max_nodes))
+    edge_cap = max(0, int(max_edges))
+    if node_cap == 0 or (restrict_labels and not labels):
+        return {"hit_nodes": [], "nodes": [], "edges": []}
+    seed_cap = min(seed_cap, node_cap)
+
+    if mode == "exact":
+        match_filter = "(node.key = $search_query OR node.name = $search_query)"
+    else:
+        match_filter = """(
+            toLower(coalesce(node.key, '')) CONTAINS $search_query_lower
+            OR toLower(coalesce(node.name, '')) CONTAINS $search_query_lower
+            OR toLower(coalesce(node.canonical_name, '')) CONTAINS $search_query_lower
+            OR toLower(coalesce(node.description, '')) CONTAINS $search_query_lower
+            OR any(alias IN coalesce(node.aliases, [])
+                   WHERE toLower(toString(alias)) CONTAINS $search_query_lower)
+        )"""
+
+    hit_query = f"""
+    MATCH (node)
+    WHERE node.key IS NOT NULL
+      AND {match_filter}
+      AND (NOT $restrict_labels OR any(label IN labels(node) WHERE label IN $allowed_labels))
+    WITH node,
+         CASE WHEN $restrict_labels
+              THEN head([label IN $allowed_labels WHERE label IN labels(node)])
+              ELSE head(labels(node)) END AS label
+    RETURN node.key AS key, label,
+           coalesce(node.zone, '') AS zone,
+           coalesce(node.name, node.canonical_name, node.goal, node.key) AS display_name
+    ORDER BY toString(node.key), label
+    LIMIT $limit
+    """
+    params = {
+        "search_query": q,
+        "search_query_lower": q.lower(),
+        "restrict_labels": restrict_labels,
+        "allowed_labels": labels,
+        "limit": seed_cap,
+    }
+    with neo4j_session(driver) as session:
+        hit_rows = session.run(hit_query, **params).data()
+
+    zones = label_zones or {}
+
+    def normalize_node(row: Mapping[str, Any]) -> Optional[dict[str, Any]]:
+        key = row.get("key")
+        if key is None or not str(key):
+            return None
+        label = str(row.get("label") or "")
+        if restrict_labels and label not in labels:
+            return None
+        return {
+            "key": str(key),
+            "label": label,
+            "zone": row.get("zone") or zones.get(label, ""),
+            "display_name": row.get("display_name", ""),
+        }
+
+    hits_by_key: dict[str, dict[str, Any]] = {}
+    for row in hit_rows:
+        node = normalize_node(row)
+        if node is not None:
+            hits_by_key.setdefault(node["key"], node)
+    hit_nodes = sorted(hits_by_key.values(), key=lambda node: node["key"])
+    if not hit_nodes:
+        return {"hit_nodes": [], "nodes": [], "edges": []}
+
+    nodes_by_key = dict(hits_by_key)
+    edges_by_id: dict[tuple[str, str, str], dict[str, Any]] = {}
+    path_limit = max(1, node_cap + edge_cap)
+    traversal_query = f"""
+    MATCH path = (hit)-[*1..{hop_cap}]-(neighbor)
+    WHERE hit.key IN $hit_keys
+      AND neighbor <> hit
+      AND all(path_node IN nodes(path) WHERE path_node.key IS NOT NULL)
+      AND (NOT $restrict_labels OR all(
+            path_node IN nodes(path)
+            WHERE any(label IN labels(path_node) WHERE label IN $allowed_labels)
+          ))
+    WITH path,
+         [path_node IN nodes(path) | toString(path_node.key)] AS path_node_keys,
+         [rel IN relationships(path) | type(rel)] AS path_rel_types
+    ORDER BY length(path), path_node_keys, path_rel_types
+    LIMIT $path_limit
+    RETURN [path_node IN nodes(path) | {{
+             key: path_node.key,
+             label: CASE WHEN $restrict_labels
+                         THEN head([label IN labels(path_node) WHERE label IN $allowed_labels])
+                         ELSE head(labels(path_node)) END,
+             zone: coalesce(path_node.zone, ''),
+             display_name: coalesce(path_node.name, path_node.canonical_name,
+                                    path_node.goal, path_node.key)
+           }}] AS path_nodes,
+           [rel IN relationships(path) | {{
+             source_key: startNode(rel).key,
+             target_key: endNode(rel).key,
+             rel_type: type(rel)
+           }}] AS path_edges
+    """
+    with neo4j_session(driver) as session:
+        path_rows = session.run(
+            traversal_query,
+            hit_keys=[node["key"] for node in hit_nodes],
+            restrict_labels=restrict_labels,
+            allowed_labels=labels,
+            path_limit=path_limit,
+        ).data()
+
+    for row in path_rows:
+        path_nodes: dict[str, dict[str, Any]] = {}
+        for raw_node in row.get("path_nodes") or []:
+            node = normalize_node(raw_node)
+            if node is not None:
+                path_nodes.setdefault(node["key"], node)
+        missing = [node for key, node in path_nodes.items() if key not in nodes_by_key]
+        if len(nodes_by_key) + len(missing) > node_cap:
+            continue
+        for node in missing:
+            nodes_by_key[node["key"]] = node
+        for edge in row.get("path_edges") or []:
+            edge_id = (
+                str(edge.get("source_key") or ""),
+                str(edge.get("target_key") or ""),
+                str(edge.get("rel_type") or ""),
+            )
+            if not all(edge_id) or edge_id in edges_by_id:
+                continue
+            if edge_id[0] not in nodes_by_key or edge_id[1] not in nodes_by_key:
+                continue
+            if len(edges_by_id) >= edge_cap:
+                break
+            edges_by_id[edge_id] = {
+                "source_key": edge_id[0],
+                "target_key": edge_id[1],
+                "rel_type": edge_id[2],
+                "properties": {},
+            }
+
+    return {
+        "hit_nodes": hit_nodes,
+        "nodes": sorted(nodes_by_key.values(), key=lambda node: node["key"]),
+        "edges": [edges_by_id[key] for key in sorted(edges_by_id)],
+    }
+
+
+_GLOBAL_GRAPH_SNAPSHOT_CACHE_TTL_SECONDS = 8.0
+_GLOBAL_GRAPH_SNAPSHOT_CACHE_MAX_ENTRIES = 128
+_GLOBAL_GRAPH_SNAPSHOT_CACHE_LOCK = threading.Lock()
+_GLOBAL_GRAPH_SNAPSHOT_CACHE: OrderedDict[
+    tuple[Any, ...], tuple[float, dict[str, Any]]
+] = OrderedDict()
+_GLOBAL_GRAPH_SNAPSHOT_CACHE_GENERATION = 0
+
+
+def invalidate_global_graph_snapshot_cache() -> None:
+    """Clear all cached global snapshots and invalidate in-flight fills."""
+    global _GLOBAL_GRAPH_SNAPSHOT_CACHE_GENERATION
+    with _GLOBAL_GRAPH_SNAPSHOT_CACHE_LOCK:
+        _GLOBAL_GRAPH_SNAPSHOT_CACHE.clear()
+        _GLOBAL_GRAPH_SNAPSHOT_CACHE_GENERATION += 1
+
+
 def global_graph_snapshot(
+    driver: Driver,
+    *,
+    max_edges: int = 800,
+    max_nodes: int = 600,
+    skeleton: bool = True,
+    domain_roots_only: bool = True,
+    task_roots: bool = False,
+    max_task_roots: int = 10,
+    zone_mode: str = "all",
+) -> dict[str, Any]:
+    """Return a cached global graph snapshot."""
+    cache_key = (
+        id(driver),
+        neo4j_database_ctx.get() or CFG.neo4j_database,
+        max_edges,
+        max_nodes,
+        skeleton,
+        domain_roots_only,
+        task_roots,
+        max_task_roots,
+        zone_mode,
+    )
+    now = time.monotonic()
+    with _GLOBAL_GRAPH_SNAPSHOT_CACHE_LOCK:
+        generation = _GLOBAL_GRAPH_SNAPSHOT_CACHE_GENERATION
+        cached = _GLOBAL_GRAPH_SNAPSHOT_CACHE.get(cache_key)
+        if cached is not None:
+            stored_at, value = cached
+            if now - stored_at < _GLOBAL_GRAPH_SNAPSHOT_CACHE_TTL_SECONDS:
+                _GLOBAL_GRAPH_SNAPSHOT_CACHE.move_to_end(cache_key)
+                return copy.deepcopy(value)
+            del _GLOBAL_GRAPH_SNAPSHOT_CACHE[cache_key]
+
+    value = _global_graph_snapshot_uncached(
+        driver,
+        max_edges=max_edges,
+        max_nodes=max_nodes,
+        skeleton=skeleton,
+        domain_roots_only=domain_roots_only,
+        task_roots=task_roots,
+        max_task_roots=max_task_roots,
+        zone_mode=zone_mode,
+    )
+    cached_value = copy.deepcopy(value)
+    with _GLOBAL_GRAPH_SNAPSHOT_CACHE_LOCK:
+        if generation == _GLOBAL_GRAPH_SNAPSHOT_CACHE_GENERATION:
+            _GLOBAL_GRAPH_SNAPSHOT_CACHE[cache_key] = (time.monotonic(), cached_value)
+            _GLOBAL_GRAPH_SNAPSHOT_CACHE.move_to_end(cache_key)
+            while (
+                len(_GLOBAL_GRAPH_SNAPSHOT_CACHE)
+                > _GLOBAL_GRAPH_SNAPSHOT_CACHE_MAX_ENTRIES
+            ):
+                _GLOBAL_GRAPH_SNAPSHOT_CACHE.popitem(last=False)
+    return value
+
+
+def _global_graph_snapshot_uncached(
     driver: Driver,
     *,
     max_edges: int = 800,
@@ -1588,8 +1904,9 @@ def global_graph_snapshot(
             }
         return key if key in nodes else None
 
-    def add_edge(src: Optional[str], dst: Optional[str], rel: str,
-                 props: Optional[dict] = None) -> None:
+    def add_edge(
+        src: Optional[str], dst: Optional[str], rel: str, props: Optional[dict] = None
+    ) -> None:
         if not (src and dst):
             return
         if len(edges) >= max_edges:
@@ -1722,7 +2039,7 @@ def global_graph_snapshot(
         if counts["domain"] == 0:
             # 无 Domain：Database -[:HAS_TABLE]-> Table
             # Default 物理层：Database -[:HAS_SCHEMA]-> Schema -[:HAS_TABLE]-> Table
-            #（OF_VIEW→Dataset→CONTAINS_TABLE 是 Formula→Table 路径，不能用来数表）
+            # （OF_VIEW→Dataset→CONTAINS_TABLE 是 Formula→Table 路径，不能用来数表）
             db_rows = s.run(
                 "MATCH (db:Database) "
                 "WHERE size($az) = 0 OR coalesce(db.zone, 'metadata') IN $az "
@@ -1748,9 +2065,14 @@ def global_graph_snapshot(
                         "id": synth_key,
                         "label": db_name,
                         "group": "Database",
-                        "props": {**_trim_props(props), "table_count": int(r.get("table_count") or 0)},
+                        "props": {
+                            **_trim_props(props),
+                            "table_count": int(r.get("table_count") or 0),
+                        },
                     }
-            counts["database"] = sum(1 for n in nodes.values() if n["group"] == "Database")
+            counts["database"] = sum(
+                1 for n in nodes.values() if n["group"] == "Database"
+            )
 
             # 如果仍然没有 Database，再试 Schema / Table 根节点
             if counts.get("database", 0) == 0:
@@ -1771,7 +2093,9 @@ def global_graph_snapshot(
                             "group": "Schema",
                             "props": _trim_props(props),
                         }
-                counts["schema"] = sum(1 for n in nodes.values() if n["group"] == "Schema")
+                counts["schema"] = sum(
+                    1 for n in nodes.values() if n["group"] == "Schema"
+                )
 
         # 2) 可选：最近的 N 个 Task（``all`` / ``metadata`` 浏览时追加 trace 入口）
         if effective_task_roots and eff_task_cap > 0:
@@ -1811,7 +2135,9 @@ def global_graph_snapshot(
             for r in rows:
                 a_key = add_node(r["a"], r.get("la") or "Node")
                 b_key = add_node(r["b"], r.get("lb") or "Node")
-                add_edge(a_key, b_key, r["rel"], _trim_props(dict(r.get("rprops") or {})))
+                add_edge(
+                    a_key, b_key, r["rel"], _trim_props(dict(r.get("rprops") or {}))
+                )
 
     return {
         "center": None,
@@ -1819,9 +2145,9 @@ def global_graph_snapshot(
         "edges": edges,
         "raw": {
             "zone_mode": zm,
-            "mode": "domain_roots_only" if domain_roots_only else (
-                "skeleton" if skeleton else "full_sampled"
-            ),
+            "mode": "domain_roots_only"
+            if domain_roots_only
+            else ("skeleton" if skeleton else "full_sampled"),
             "stats": {
                 "node_count": len(nodes),
                 "edge_count": len(edges),
@@ -1882,7 +2208,9 @@ def domain_graph_snapshot(
     for m in metrics:
         m_key = add_node(m, "Metric")
         if dom_key and m_key:
-            edges.append({"from": dom_key, "to": m_key, "type": "HAS_METRIC", "props": {}})
+            edges.append(
+                {"from": dom_key, "to": m_key, "type": "HAS_METRIC", "props": {}}
+            )
 
     return {
         "center": dom_key,
@@ -1890,8 +2218,11 @@ def domain_graph_snapshot(
         "edges": edges,
         "raw": {
             "domain": domain,
-            "stats": {"node_count": len(nodes), "edge_count": len(edges),
-                      "metric_count": len(metrics)},
+            "stats": {
+                "node_count": len(nodes),
+                "edge_count": len(edges),
+                "metric_count": len(metrics),
+            },
         },
     }
 
@@ -1900,8 +2231,8 @@ def _zone_clause(exclude_trace_knowledge: bool) -> str:
     """生成 Cypher 片段：当 ``exclude_trace_knowledge=True`` 时过滤目标节点 zone。"""
     if not exclude_trace_knowledge:
         return ""
-    return (
-        " AND NOT coalesce(nb.zone, 'metadata') IN " + repr(list(_NON_METADATA_ZONES))
+    return " AND NOT coalesce(nb.zone, 'metadata') IN " + repr(
+        list(_NON_METADATA_ZONES)
     )
 
 
@@ -1930,7 +2261,7 @@ def expand_node_snapshot(
     for prefix, (lbl, attr) in _SYNTH_PREFIXES_SNAP.items():
         if node_key.startswith(prefix):
             synth_label_snap = lbl
-            synth_name_snap = node_key[len(prefix):]
+            synth_name_snap = node_key[len(prefix) :]
             break
 
     def add_node(node, group: str, force_key: Optional[str] = None) -> Optional[str]:
@@ -1993,8 +2324,9 @@ def expand_node_snapshot(
         raise ValueError(f"Node {node_key!r} not found")
 
     force_canvas = bool(synth_label_snap) or matched_by_element_id
-    center_key = add_node(rec["a"], rec.get("la") or "Node",
-                          force_key=node_key if force_canvas else None)
+    center_key = add_node(
+        rec["a"], rec.get("la") or "Node", force_key=node_key if force_canvas else None
+    )
     for row in rec["rels"] or []:
         if not row or row.get("nb") is None:
             continue
@@ -2063,7 +2395,7 @@ def expand_node_layer(
     for prefix, (lbl, attr) in _SYNTH_PREFIXES.items():
         if node_key.startswith(prefix):
             synth_label = lbl
-            synth_name = node_key[len(prefix):]
+            synth_name = node_key[len(prefix) :]
             break
 
     if synth_label:
@@ -2133,14 +2465,17 @@ def expand_node_layer(
         raise ValueError(f"Node {node_key!r} not found")
 
     layer_force = bool(synth_label) or matched_by_element_id_layer
-    center_key = add_node(rec["a"], rec.get("la") or "Node", force_key=node_key if layer_force else None)
+    center_key = add_node(
+        rec["a"], rec.get("la") or "Node", force_key=node_key if layer_force else None
+    )
     rels = rec["rels"] or []
 
     if not rels and fallback_neighbors:
         # 该方向无邻居 → 退回到全邻域；这种情况通常是叶子（Column）或
         # 反向只走 _shared 节点（Domain）
         return expand_node_snapshot(
-            driver, node_key,
+            driver,
+            node_key,
             max_edges=max_edges,
             exclude_trace_knowledge=exclude_trace_knowledge,
         )
@@ -2349,7 +2684,9 @@ def recall_strategy_cards(
         sql_template, hit_count, success_rate, memory_tier, composite_score,
         trigger_conditions.
     """
-    from ..graph.strategy_card import StrategyCardRetriever  # avoid circular at module level
+    from ..graph.strategy_card import (
+        StrategyCardRetriever,
+    )  # avoid circular at module level
 
     retriever = StrategyCardRetriever(driver)
     candidates = retriever.recall_top_k(
@@ -2366,10 +2703,16 @@ def recall_strategy_cards(
 #  Phase 2 helpers — node edges, experiences, tags
 # ═══════════════════════════════════════════════════════════════════════ #
 
-_STRIP_KEYS_RETR = frozenset({
-    "embedding", "embedding_hash", "signature_emb",
-    "query_emb", "query_embedding", "strategy_vec",
-})
+_STRIP_KEYS_RETR = frozenset(
+    {
+        "embedding",
+        "embedding_hash",
+        "signature_emb",
+        "query_emb",
+        "query_embedding",
+        "strategy_vec",
+    }
+)
 
 
 def _to_jsonable_retr(obj):
@@ -2440,23 +2783,32 @@ def list_node_edges(
     SKIP $skip LIMIT $limit
     """
     with neo4j_session(driver) as s:
-        total_rec = s.run(count_cypher, **{kk: vv for kk, vv in params.items() if kk not in ("skip", "limit")}).single()
+        total_rec = s.run(
+            count_cypher,
+            **{kk: vv for kk, vv in params.items() if kk not in ("skip", "limit")},
+        ).single()
         total = int(total_rec["total"]) if total_rec else 0
         rows = s.run(data_cypher, **params).data()
 
     edges = []
     for row in rows:
         rp = row.get("properties") or {}
-        rp = {kk: vv for kk, vv in (rp if isinstance(rp, dict) else {}).items() if kk not in _STRIP_KEYS_RETR}
-        edges.append({
-            "rel_type": row.get("rel_type", ""),
-            "direction": row.get("direction", ""),
-            "source_key": row.get("source_key", ""),
-            "target_key": row.get("target_key", ""),
-            "target_label": row.get("target_label", ""),
-            "target_display": row.get("target_display", ""),
-            "properties": _to_jsonable_retr(rp),
-        })
+        rp = {
+            kk: vv
+            for kk, vv in (rp if isinstance(rp, dict) else {}).items()
+            if kk not in _STRIP_KEYS_RETR
+        }
+        edges.append(
+            {
+                "rel_type": row.get("rel_type", ""),
+                "direction": row.get("direction", ""),
+                "source_key": row.get("source_key", ""),
+                "target_key": row.get("target_key", ""),
+                "target_label": row.get("target_label", ""),
+                "target_display": row.get("target_display", ""),
+                "properties": _to_jsonable_retr(rp),
+            }
+        )
     return edges, total
 
 
@@ -2496,7 +2848,10 @@ def list_experiences(
     SKIP $skip LIMIT $limit
     """
     with neo4j_session(driver) as s:
-        total_rec = s.run(count_cypher, **{k: v for k, v in params.items() if k not in ("skip", "limit")}).single()
+        total_rec = s.run(
+            count_cypher,
+            **{k: v for k, v in params.items() if k not in ("skip", "limit")},
+        ).single()
         total = int(total_rec["total"]) if total_rec else 0
         rows = s.run(data_cypher, **params).data()
     return rows, total
@@ -2559,7 +2914,10 @@ def list_tags(
     SKIP $skip LIMIT $limit
     """
     with neo4j_session(driver) as s:
-        total_rec = s.run(count_cypher, **{k: v for k, v in params.items() if k not in ("skip", "limit")}).single()
+        total_rec = s.run(
+            count_cypher,
+            **{k: v for k, v in params.items() if k not in ("skip", "limit")},
+        ).single()
         total = int(total_rec["total"]) if total_rec else 0
         rows = s.run(data_cypher, **params).data()
     return rows, total
@@ -2572,9 +2930,12 @@ __all__ = [
     "expand_node_snapshot",
     "expand_subgraph",
     "global_graph_snapshot",
+    "invalidate_global_graph_snapshot_cache",
     "list_domains",
     "recall_strategy_cards",
     "resolve_metric",
+    "search_events",
+    "search_explorer_subgraph",
     "subgraph_snapshot_from_keys",
     "guess_physical_db_id",
     "topology_insights_for_query",

--- a/packages/qwenpaw-data-context/src/context_manager/api/semantic_api.py
+++ b/packages/qwenpaw-data-context/src/context_manager/api/semantic_api.py
@@ -390,6 +390,9 @@ async def semantic_import(request: SemanticImportRequest, req: Request):
 
     # 按 result.status 触发 HTTP 回调通知调用方
     if result.status == ImportStatus.success:
+        from .retrieval import invalidate_global_graph_snapshot_cache
+
+        invalidate_global_graph_snapshot_cache()
         _callback("SUCCESS")
     else:
         err_msg = "; ".join(e.message for e in result.errors) if result.errors else None
@@ -447,4 +450,7 @@ def delete_domain(
     if count == 0:
         ds_hint = f" @{datasource_id}" if datasource_id else ""
         raise HTTPException(status_code=404, detail=f"domain '{name}'{ds_hint} not found")
+    from .retrieval import invalidate_global_graph_snapshot_cache
+
+    invalidate_global_graph_snapshot_cache()
     return {"deleted": name, "datasource_id": datasource_id or ""}

--- a/packages/qwenpaw-data-context/src/context_manager/api/semantic_io_api.py
+++ b/packages/qwenpaw-data-context/src/context_manager/api/semantic_io_api.py
@@ -55,6 +55,9 @@ def _ser_change(c):
 
 def _post_apply_rebuild(driver) -> list[str]:
     """应用 diff 后重建 embedding + caliber，返回警告列表。"""
+    from .retrieval import invalidate_global_graph_snapshot_cache
+
+    invalidate_global_graph_snapshot_cache()
     warnings: list[str] = []
     try:
         from ..graph.embeddings import index_embeddings
@@ -363,7 +366,11 @@ def import_from_excel_apply(
     等效于先调 ``/import/from-excel`` 得到 JSON，再 POST 到 ``/api/v1/semantic/import``。
     ``target_datasource_id`` 支持一键替换 datasource。
     """
-    from ..contracts.import_models import SemanticImportRequest, SemanticPayload
+    from ..contracts.import_models import (
+        ImportStatus,
+        SemanticImportRequest,
+        SemanticPayload,
+    )
 
     suffix = Path(file.filename or "upload.xlsx").suffix or ".xlsx"
     tmp = save_upload_to_temp(file, suffix=suffix)
@@ -392,7 +399,12 @@ def import_from_excel_apply(
 
     from ..graph.semantic_import_service import run_semantic_import_sync
 
-    return run_semantic_import_sync(_driver(request), sem_req)
+    result = run_semantic_import_sync(_driver(request), sem_req)
+    if result.status == ImportStatus.success:
+        from .retrieval import invalidate_global_graph_snapshot_cache
+
+        invalidate_global_graph_snapshot_cache()
+    return result
 
 
 __all__ = ["router"]

--- a/packages/qwenpaw-data-context/src/context_manager/api/tg_admin_api.py
+++ b/packages/qwenpaw-data-context/src/context_manager/api/tg_admin_api.py
@@ -27,6 +27,14 @@ def _driver(request: Request):
     return request.app.state.driver
 
 
+def _success_after_write(result):
+    """Wrap a successful graph mutation, dropping stale global snapshots."""
+    from .retrieval import invalidate_global_graph_snapshot_cache
+
+    invalidate_global_graph_snapshot_cache()
+    return success(result)
+
+
 # ═══════════════════════════════════════════════════════════════════════ #
 #  Task
 # ═══════════════════════════════════════════════════════════════════════ #
@@ -66,7 +74,7 @@ def update_task_status(key: str, body: UpdateTaskStatusRequest, request: Request
         result = store.update_task_status(
             driver, key, new_status=body.status, reason=body.reason,
         )
-        return success(result)
+        return _success_after_write(result)
     except ValueError as exc:
         fail("VALIDATION_ERROR", str(exc))
 
@@ -81,7 +89,7 @@ def batch_archive_tasks(body: BatchTaskKeysRequest, request: Request):
         fail("VALIDATION_ERROR", "单次最多归档 50 个 Task")
     try:
         result = batch_archive_tasks(driver, body.task_keys, reason=body.reason or "")
-        return success(result)
+        return _success_after_write(result)
     except ValueError as exc:
         fail("VALIDATION_ERROR", str(exc))
 
@@ -94,7 +102,7 @@ def delete_task(key: str, request: Request):
     driver = _driver(request)
     try:
         result = delete_task_cascade(driver, key)
-        return success(result)
+        return _success_after_write(result)
     except ValueError as exc:
         fail("VALIDATION_ERROR", str(exc))
 
@@ -109,7 +117,7 @@ def batch_delete_tasks(body: BatchTaskKeysRequest, request: Request):
         fail("VALIDATION_ERROR", "单次最多删除 50 个 Task")
     try:
         result = batch_delete_tasks(driver, body.task_keys)
-        return success(result)
+        return _success_after_write(result)
     except ValueError as exc:
         fail("VALIDATION_ERROR", str(exc))
 
@@ -165,7 +173,7 @@ def update_claim(key: str, body: UpdateClaimFieldsRequest, request: Request, bg:
         fail("VALIDATION_ERROR", "至少提供一个要编辑的字段")
     try:
         result = store.update_claim_fields(driver, key, updates=updates, background_tasks=bg)
-        return success(result)
+        return _success_after_write(result)
     except ValueError as exc:
         fail("VALIDATION_ERROR", str(exc))
 
@@ -178,7 +186,7 @@ def invalidate_claim(key: str, body: InvalidateRequest, request: Request):
     driver = _driver(request)
     try:
         result = invalidate_claim(driver, key, reason=body.reason)
-        return success(result)
+        return _success_after_write(result)
     except ValueError as exc:
         fail("VALIDATION_ERROR", str(exc))
 
@@ -228,7 +236,7 @@ def update_strategy(key: str, body: UpdateStrategyFieldsRequest, request: Reques
         fail("VALIDATION_ERROR", "至少提供一个要编辑的字段")
     try:
         result = store.update_strategy_card_fields(driver, key, updates=updates)
-        return success(result)
+        return _success_after_write(result)
     except ValueError as exc:
         fail("VALIDATION_ERROR", str(exc))
 
@@ -241,7 +249,7 @@ def invalidate_strategy(key: str, body: InvalidateRequest, request: Request):
     driver = _driver(request)
     try:
         result = invalidate_strategy_card(driver, key, reason=body.reason)
-        return success(result)
+        return _success_after_write(result)
     except ValueError as exc:
         fail("VALIDATION_ERROR", str(exc))
 

--- a/packages/qwenpaw-data-context/src/context_manager/api/trace_api.py
+++ b/packages/qwenpaw-data-context/src/context_manager/api/trace_api.py
@@ -164,6 +164,9 @@ def ingest_trace_events(req: TraceIngestRequest, request: Request):
         oss_raw_key=oss_key,
     )
 
+    from .retrieval import invalidate_global_graph_snapshot_cache
+
+    invalidate_global_graph_snapshot_cache()
     return TraceIngestResponse(
         task_key=result["task_key"],
         step_count=result["step_count"],
@@ -239,6 +242,10 @@ def ingest_trace_file(
                 oss_raw_key=result.get("oss_raw_key", ""),
             ))
 
+        if results:
+            from .retrieval import invalidate_global_graph_snapshot_cache
+
+            invalidate_global_graph_snapshot_cache()
         return results
     finally:
         upload_path.unlink(missing_ok=True)
@@ -597,4 +604,7 @@ def submit_trace(payload: dict[str, Any], request: Request):
             },
         )
 
+    from .retrieval import invalidate_global_graph_snapshot_cache
+
+    invalidate_global_graph_snapshot_cache()
     return {"success": True, "status": "success"}

--- a/packages/qwenpaw-data-context/src/context_manager/api/user_context_api.py
+++ b/packages/qwenpaw-data-context/src/context_manager/api/user_context_api.py
@@ -266,6 +266,10 @@ def create_user_context(
 ) -> dict[str, Any]:
     """Initialize a user's default context after their first login."""
     node = _create_user_node(request.app.state.driver, user_id)
+    if node["created"]:
+        from .retrieval import invalidate_global_graph_snapshot_cache
+
+        invalidate_global_graph_snapshot_cache()
     response.status_code = 201 if node["created"] else 200
     return success(node)
 
@@ -311,6 +315,9 @@ def update_user_context_section(
         fail("MALFORMED_CONTEXT", str(exc), status_code=500)
     if node is None:
         fail("NOT_FOUND", f"User context not found: {user_id}", status_code=404)
+    from .retrieval import invalidate_global_graph_snapshot_cache
+
+    invalidate_global_graph_snapshot_cache()
     return success(_section_response(node, section_name))
 
 
@@ -333,4 +340,7 @@ def reset_user_context_section(
         fail("MALFORMED_CONTEXT", str(exc), status_code=500)
     if node is None:
         fail("NOT_FOUND", f"User context not found: {user_id}", status_code=404)
+    from .retrieval import invalidate_global_graph_snapshot_cache
+
+    invalidate_global_graph_snapshot_cache()
     return success(_section_response(node, section_name))

--- a/packages/qwenpaw-data-context/tests/test_blocking_route_safety.py
+++ b/packages/qwenpaw-data-context/tests/test_blocking_route_safety.py
@@ -52,6 +52,21 @@ def test_sync_endpoint_delegation_is_not_awaited_directly():
     assert not inspect.iscoroutinefunction(tg_admin_api.get_task_graph)
 
 
+def test_retrieval_surfaces_stay_on_the_sync_worker_path():
+    from context_manager.api import explorer_api, retrieval
+
+    for endpoint in (
+        explorer_api.global_graph,
+        explorer_api.search_subgraph,
+        cm_api.cm_search_event,
+    ):
+        assert not inspect.iscoroutinefunction(endpoint)
+
+    retrieval_source = inspect.getsource(retrieval)
+    assert "asyncio.to_thread" not in retrieval_source
+    assert "run_in_executor" not in retrieval_source
+
+
 def test_async_routes_use_the_governor_instead_of_default_to_thread():
     assert "asyncio.to_thread" not in inspect.getsource(doc_api)
     assert "run_in_executor" not in inspect.getsource(doc_api)

--- a/packages/qwenpaw-data-context/tests/test_retrieval_enhancements.py
+++ b/packages/qwenpaw-data-context/tests/test_retrieval_enhancements.py
@@ -1,0 +1,581 @@
+"""Roadmap #10 retrieval behaviors: subgraph search, snapshot cache, event search."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from types import SimpleNamespace
+
+import pytest
+
+from context_manager.api import retrieval
+from context_manager.utils import neo4j_database_ctx
+
+
+class _Rows:
+    def __init__(self, rows):
+        self.rows = rows
+
+    def data(self):
+        return self.rows
+
+
+class _ScriptedSession:
+    """Return queued row batches and record every executed query."""
+
+    def __init__(self, batches):
+        self.batches = list(batches)
+        self.calls: list[tuple[str, dict]] = []
+
+    def run(self, query, **params):
+        self.calls.append((query, params))
+        return _Rows(self.batches.pop(0) if self.batches else [])
+
+
+@contextmanager
+def _session_cm(session):
+    yield session
+
+
+def _patch_session(monkeypatch, session):
+    monkeypatch.setattr(
+        retrieval, "neo4j_session", lambda _driver: _session_cm(session)
+    )
+
+
+def _hit(key, label="Metric", zone="metadata", name=None):
+    return {
+        "key": key,
+        "label": label,
+        "zone": zone,
+        "display_name": name or key,
+    }
+
+
+def _path_row(nodes, edges):
+    return {"path_nodes": nodes, "path_edges": edges}
+
+
+def _edge(src, dst, rel="RELATED_TO"):
+    return {"source_key": src, "target_key": dst, "rel_type": rel}
+
+
+@pytest.fixture(autouse=True)
+def _fresh_cache():
+    retrieval.invalidate_global_graph_snapshot_cache()
+    yield
+    retrieval.invalidate_global_graph_snapshot_cache()
+
+
+# ---------------------------------------------------------------------- #
+# search_explorer_subgraph
+# ---------------------------------------------------------------------- #
+
+
+def test_subgraph_empty_query_returns_empty_shape(monkeypatch):
+    session = _ScriptedSession([])
+    _patch_session(monkeypatch, session)
+
+    result = retrieval.search_explorer_subgraph(object(), "   ")
+
+    assert result == {"hit_nodes": [], "nodes": [], "edges": []}
+    assert session.calls == []
+
+
+def test_subgraph_rejects_invalid_labels():
+    with pytest.raises(ValueError, match="Invalid Neo4j label"):
+        retrieval.search_explorer_subgraph(
+            object(), "gmv", allowed_labels=["Metric) DETACH DELETE"]
+        )
+
+
+def test_subgraph_rejects_unknown_match_mode():
+    with pytest.raises(ValueError, match="match_mode"):
+        retrieval.search_explorer_subgraph(object(), "gmv", match_mode="regex")
+
+
+def test_subgraph_empty_scope_short_circuits(monkeypatch):
+    session = _ScriptedSession([])
+    _patch_session(monkeypatch, session)
+
+    result = retrieval.search_explorer_subgraph(object(), "gmv", allowed_labels=[])
+
+    assert result == {"hit_nodes": [], "nodes": [], "edges": []}
+    assert session.calls == []
+
+
+def test_subgraph_exact_mode_and_hop_clamp(monkeypatch):
+    session = _ScriptedSession([[_hit("met:gmv")], []])
+    _patch_session(monkeypatch, session)
+
+    retrieval.search_explorer_subgraph(
+        object(), "GMV", match_mode="exact", hops=9, limit=999
+    )
+
+    hit_query, hit_params = session.calls[0]
+    assert "node.key = $search_query" in hit_query
+    assert hit_params["limit"] == 200
+    traversal_query, _ = session.calls[1]
+    assert "*1..3" in traversal_query
+
+
+def test_subgraph_dedupes_and_orders_deterministically(monkeypatch):
+    session = _ScriptedSession(
+        [
+            [_hit("met:b"), _hit("met:a"), _hit("met:a")],
+            [
+                _path_row(
+                    [_hit("met:b"), _hit("dim:z", label="Dimension")],
+                    [_edge("met:b", "dim:z", "ANALYZED_BY")],
+                ),
+                _path_row(
+                    [_hit("met:b"), _hit("dim:z", label="Dimension")],
+                    [_edge("met:b", "dim:z", "ANALYZED_BY")],
+                ),
+            ],
+        ]
+    )
+    _patch_session(monkeypatch, session)
+
+    result = retrieval.search_explorer_subgraph(object(), "met")
+
+    assert [node["key"] for node in result["hit_nodes"]] == ["met:a", "met:b"]
+    assert [node["key"] for node in result["nodes"]] == ["dim:z", "met:a", "met:b"]
+    assert result["edges"] == [
+        {
+            "source_key": "met:b",
+            "target_key": "dim:z",
+            "rel_type": "ANALYZED_BY",
+            "properties": {},
+        }
+    ]
+
+
+def test_subgraph_includes_intermediate_path_nodes(monkeypatch):
+    middle = _hit("tbl:mid", label="Table")
+    session = _ScriptedSession(
+        [
+            [_hit("met:gmv")],
+            [
+                _path_row(
+                    [_hit("met:gmv"), middle, _hit("col:leaf", label="Column")],
+                    [
+                        _edge("met:gmv", "tbl:mid", "USES_TABLE"),
+                        _edge("tbl:mid", "col:leaf", "HAS_COLUMN"),
+                    ],
+                )
+            ],
+        ]
+    )
+    _patch_session(monkeypatch, session)
+
+    result = retrieval.search_explorer_subgraph(object(), "gmv", hops=2)
+
+    keys = {node["key"] for node in result["nodes"]}
+    assert keys == {"met:gmv", "tbl:mid", "col:leaf"}
+    assert len(result["edges"]) == 2
+
+
+def test_subgraph_node_cap_keeps_endpoint_closure(monkeypatch):
+    session = _ScriptedSession(
+        [
+            [_hit("met:gmv")],
+            [
+                _path_row(
+                    [_hit("met:gmv"), _hit("dim:a", label="Dimension")],
+                    [_edge("met:gmv", "dim:a")],
+                ),
+                _path_row(
+                    [
+                        _hit("met:gmv"),
+                        _hit("dim:b", label="Dimension"),
+                        _hit("dim:c", label="Dimension"),
+                    ],
+                    [_edge("met:gmv", "dim:b"), _edge("dim:b", "dim:c")],
+                ),
+            ],
+        ]
+    )
+    _patch_session(monkeypatch, session)
+
+    result = retrieval.search_explorer_subgraph(object(), "gmv", hops=2, max_nodes=2)
+
+    assert {node["key"] for node in result["nodes"]} == {"met:gmv", "dim:a"}
+    for edge in result["edges"]:
+        assert edge["source_key"] in {"met:gmv", "dim:a"}
+        assert edge["target_key"] in {"met:gmv", "dim:a"}
+
+
+def test_subgraph_edge_cap_is_enforced(monkeypatch):
+    session = _ScriptedSession(
+        [
+            [_hit("met:gmv")],
+            [
+                _path_row(
+                    [_hit("met:gmv"), _hit("dim:a", label="Dimension")],
+                    [
+                        _edge("met:gmv", "dim:a", "R1"),
+                        _edge("met:gmv", "dim:a", "R2"),
+                        _edge("met:gmv", "dim:a", "R3"),
+                    ],
+                )
+            ],
+        ]
+    )
+    _patch_session(monkeypatch, session)
+
+    result = retrieval.search_explorer_subgraph(object(), "gmv", max_edges=2)
+
+    assert len(result["edges"]) == 2
+
+
+def test_subgraph_scope_excludes_other_label_nodes(monkeypatch):
+    session = _ScriptedSession(
+        [
+            [_hit("met:gmv")],
+            [
+                _path_row(
+                    [_hit("met:gmv"), _hit("task:t1", label="Task", zone="trace")],
+                    [_edge("met:gmv", "task:t1")],
+                )
+            ],
+        ]
+    )
+    _patch_session(monkeypatch, session)
+
+    result = retrieval.search_explorer_subgraph(
+        object(), "gmv", allowed_labels=["Metric", "Dimension"]
+    )
+
+    assert {node["key"] for node in result["nodes"]} == {"met:gmv"}
+    assert result["edges"] == []
+
+
+# ---------------------------------------------------------------------- #
+# global_graph_snapshot cache
+# ---------------------------------------------------------------------- #
+
+
+def _patch_uncached(monkeypatch, payload=None):
+    calls = {"n": 0}
+
+    def fake_uncached(_driver, **_kwargs):
+        calls["n"] += 1
+        return {
+            "center": None,
+            "nodes": [dict(payload or {"id": "dom:a", "group": "Domain"})],
+            "edges": [],
+            "raw": {"fill": calls["n"]},
+        }
+
+    monkeypatch.setattr(retrieval, "_global_graph_snapshot_uncached", fake_uncached)
+    return calls
+
+
+def test_snapshot_cache_hit_skips_second_fill(monkeypatch):
+    calls = _patch_uncached(monkeypatch)
+    driver = object()
+
+    first = retrieval.global_graph_snapshot(driver)
+    second = retrieval.global_graph_snapshot(driver)
+
+    assert calls["n"] == 1
+    assert first == second
+
+
+def test_snapshot_cache_returns_defensive_copies(monkeypatch):
+    _patch_uncached(monkeypatch)
+    driver = object()
+
+    first = retrieval.global_graph_snapshot(driver)
+    first["nodes"].clear()
+    first["raw"]["fill"] = "mutated"
+
+    second = retrieval.global_graph_snapshot(driver)
+    assert second["nodes"] == [{"id": "dom:a", "group": "Domain"}]
+    assert second["raw"]["fill"] == 1
+
+
+def test_snapshot_cache_keys_include_shaping_args(monkeypatch):
+    calls = _patch_uncached(monkeypatch)
+    driver = object()
+
+    retrieval.global_graph_snapshot(driver, zone_mode="all")
+    retrieval.global_graph_snapshot(driver, zone_mode="knowledge")
+    retrieval.global_graph_snapshot(driver, zone_mode="all", max_nodes=5)
+
+    assert calls["n"] == 3
+
+
+def test_snapshot_cache_keys_include_driver_and_database(monkeypatch):
+    calls = _patch_uncached(monkeypatch)
+    first_driver, second_driver = object(), object()
+
+    retrieval.global_graph_snapshot(first_driver)
+    retrieval.global_graph_snapshot(second_driver)
+    token = neo4j_database_ctx.set("other_db")
+    try:
+        retrieval.global_graph_snapshot(second_driver)
+        retrieval.global_graph_snapshot(second_driver)
+    finally:
+        neo4j_database_ctx.reset(token)
+
+    assert calls["n"] == 3
+
+
+def test_snapshot_cache_expires_after_ttl(monkeypatch):
+    calls = _patch_uncached(monkeypatch)
+    driver = object()
+    clock = {"now": 100.0}
+    monkeypatch.setattr(retrieval.time, "monotonic", lambda: clock["now"])
+
+    retrieval.global_graph_snapshot(driver)
+    clock["now"] += retrieval._GLOBAL_GRAPH_SNAPSHOT_CACHE_TTL_SECONDS - 0.5
+    retrieval.global_graph_snapshot(driver)
+    clock["now"] += 1.0
+    retrieval.global_graph_snapshot(driver)
+
+    assert calls["n"] == 2
+
+
+def test_snapshot_cache_explicit_invalidation_forces_refill(monkeypatch):
+    calls = _patch_uncached(monkeypatch)
+    driver = object()
+
+    retrieval.global_graph_snapshot(driver)
+    retrieval.invalidate_global_graph_snapshot_cache()
+    retrieval.global_graph_snapshot(driver)
+
+    assert calls["n"] == 2
+
+
+def test_snapshot_cache_invalidation_during_fill_is_not_stored(monkeypatch):
+    calls = {"n": 0}
+
+    def racing_uncached(_driver, **_kwargs):
+        calls["n"] += 1
+        # A writer commits while this snapshot is being built.
+        retrieval.invalidate_global_graph_snapshot_cache()
+        return {"center": None, "nodes": [], "edges": [], "raw": {"fill": calls["n"]}}
+
+    monkeypatch.setattr(retrieval, "_global_graph_snapshot_uncached", racing_uncached)
+    driver = object()
+
+    retrieval.global_graph_snapshot(driver)
+    retrieval.global_graph_snapshot(driver)
+
+    assert calls["n"] == 2
+
+
+def test_snapshot_cache_is_bounded(monkeypatch):
+    _patch_uncached(monkeypatch)
+
+    for edge_budget in range(retrieval._GLOBAL_GRAPH_SNAPSHOT_CACHE_MAX_ENTRIES + 20):
+        retrieval.global_graph_snapshot(object(), max_edges=edge_budget)
+
+    assert (
+        len(retrieval._GLOBAL_GRAPH_SNAPSHOT_CACHE)
+        <= retrieval._GLOBAL_GRAPH_SNAPSHOT_CACHE_MAX_ENTRIES
+    )
+
+
+# ---------------------------------------------------------------------- #
+# search_events hybrid retrieval
+# ---------------------------------------------------------------------- #
+
+
+def _event_row(key, score, name=None):
+    return {
+        "key": key,
+        "name": name or key,
+        "type": "signal",
+        "scope": "",
+        "description": "",
+        "date_from": "",
+        "date_to": "",
+        "about_entity_key": "",
+        "about_entity_name": "",
+        "score": score,
+    }
+
+
+def test_search_events_empty_query_returns_empty():
+    assert retrieval.search_events(object(), "   ") == []
+
+
+def test_search_events_falls_back_to_fulltext_when_embedding_fails(monkeypatch):
+    fulltext = [_event_row("ev:a", 3.0), _event_row("ev:b", 2.0)]
+    monkeypatch.setattr(
+        retrieval, "_fulltext_search_events", lambda *_a, **_k: list(fulltext)
+    )
+    monkeypatch.setattr(
+        retrieval,
+        "embed_one",
+        lambda _q: (_ for _ in ()).throw(RuntimeError("no model")),
+    )
+
+    rows = retrieval.search_events(object(), "促销", limit=10)
+
+    assert [row["key"] for row in rows] == ["ev:a", "ev:b"]
+    assert all(row["vec_score"] == 0.0 for row in rows)
+
+
+def test_search_events_fuses_rankings_and_keeps_vec_score(monkeypatch):
+    monkeypatch.setattr(
+        retrieval,
+        "_fulltext_search_events",
+        lambda *_a, **_k: [_event_row("ev:a", 3.0), _event_row("ev:b", 2.0)],
+    )
+    monkeypatch.setattr(
+        retrieval,
+        "_vector_search_events",
+        lambda *_a, **_k: [_event_row("ev:b", 0.93), _event_row("ev:c", 0.91)],
+    )
+    monkeypatch.setattr(retrieval, "embed_one", lambda _q: [0.1, 0.2])
+
+    rows = retrieval.search_events(object(), "促销", limit=10)
+
+    assert [row["key"] for row in rows] == ["ev:b", "ev:a", "ev:c"]
+    by_key = {row["key"]: row for row in rows}
+    assert by_key["ev:b"]["vec_score"] == 0.93
+    assert by_key["ev:a"]["vec_score"] == 0.0
+
+
+def test_search_events_caps_limit_at_fifty(monkeypatch):
+    pools = {}
+
+    def fake_fulltext(_driver, _q, k):
+        pools["k"] = k
+        return [_event_row(f"ev:{i}", 100 - i) for i in range(60)]
+
+    monkeypatch.setattr(retrieval, "_fulltext_search_events", fake_fulltext)
+    monkeypatch.setattr(retrieval, "embed_one", lambda _q: None)
+
+    rows = retrieval.search_events(object(), "促销", limit=500)
+
+    assert len(rows) == 50
+    assert pools["k"] == 150
+
+
+def test_event_indexes_stay_declared_in_schema():
+    from context_manager.graph import schema_init
+
+    fulltext = {name: fields for name, _, fields, _ in schema_init._FULLTEXT_INDEXES}
+    vectors = {name: (label, prop) for name, label, prop in schema_init._VECTOR_INDEXES}
+    assert fulltext["event_text"] == ("name", "description")
+    assert vectors["ev_vec"] == ("Event", "embedding")
+
+
+# ---------------------------------------------------------------------- #
+# mutation invalidation wiring
+# ---------------------------------------------------------------------- #
+
+
+def _spy_invalidator(monkeypatch):
+    calls = {"n": 0}
+    real = retrieval.invalidate_global_graph_snapshot_cache
+
+    def spy():
+        calls["n"] += 1
+        real()
+
+    monkeypatch.setattr(retrieval, "invalidate_global_graph_snapshot_cache", spy)
+    return calls
+
+
+def _fake_request(driver=None):
+    return SimpleNamespace(
+        app=SimpleNamespace(state=SimpleNamespace(driver=driver or object()))
+    )
+
+
+def test_kg_upsert_invalidates_snapshot_cache(monkeypatch):
+    from context_manager.api import kg_admin_api
+
+    calls = _spy_invalidator(monkeypatch)
+    monkeypatch.setattr(
+        kg_admin_api.kg_admin, "upsert_entity", lambda *_a, **_k: {"key": "ent:x"}
+    )
+    body = SimpleNamespace(
+        canonical_name="X",
+        type="org",
+        aliases=[],
+        description="",
+        lifecycle_state="active",
+    )
+
+    kg_admin_api.upsert_entity("ent:x", body, _fake_request())
+
+    assert calls["n"] == 1
+
+
+def test_kg_validation_failure_keeps_snapshot_cache(monkeypatch):
+    from context_manager.api import kg_admin_api
+
+    calls = _spy_invalidator(monkeypatch)
+
+    def explode(*_a, **_k):
+        raise ValueError("bad key")
+
+    monkeypatch.setattr(kg_admin_api.kg_admin, "delete_knowledge_node", explode)
+
+    with pytest.raises(Exception):
+        kg_admin_api.delete_entity("ent:x", _fake_request())
+
+    assert calls["n"] == 0
+
+
+def test_tg_task_status_update_invalidates_snapshot_cache(monkeypatch):
+    from context_manager.api import tg_admin_api
+
+    calls = _spy_invalidator(monkeypatch)
+    monkeypatch.setattr(
+        tg_admin_api.store,
+        "update_task_status",
+        lambda *_a, **_k: {"task_key": "task:1"},
+    )
+    body = SimpleNamespace(status="archived", reason="done")
+
+    tg_admin_api.update_task_status("task:1", body, _fake_request())
+
+    assert calls["n"] == 1
+
+
+def test_doc_graph_delete_invalidates_only_on_success(monkeypatch):
+    from context_manager.api import doc_api
+
+    calls = _spy_invalidator(monkeypatch)
+    monkeypatch.setattr(
+        doc_api, "delete_kg_nodes_by_source", lambda *_a, **_k: {"deleted": 2}
+    )
+    doc_api._run_kg_delete_sync(object(), "report.pdf")
+    assert calls["n"] == 1
+
+    def explode(*_a, **_k):
+        raise RuntimeError("neo4j down")
+
+    monkeypatch.setattr(doc_api, "delete_kg_nodes_by_source", explode)
+    doc_api._run_kg_delete_sync(object(), "report.pdf")
+    assert calls["n"] == 1
+
+
+def test_cypher_write_detection_matches_dml_only():
+    from context_manager.api import cypher_api
+
+    assert cypher_api._is_write_statement("MERGE (e:Entity {key: 'ent:x'})")
+    assert cypher_api._is_write_statement(
+        "MATCH (e:Entity) WHERE e.key = 'x' DETACH DELETE e"
+    )
+    assert not cypher_api._is_write_statement("MATCH (n:Metric) RETURN n LIMIT 5")
+    assert not cypher_api._is_write_statement(
+        "MATCH (n) WHERE n.name = 'create' RETURN n"
+    )
+
+
+def test_cypher_endpoint_guards_invalidation_with_write_check():
+    import inspect
+
+    from context_manager.api import cypher_api
+
+    source = inspect.getsource(cypher_api.execute_cypher)
+    assert "_is_write_statement" in source
+    assert "invalidate_global_graph_snapshot_cache" in source


### PR DESCRIPTION
> Stacked on #46 (`feat/biztrace`). Retarget to `main` as predecessors merge.

## Summary
- Sink the explorer search-subgraph query from `explorer_api` into a bounded `retrieval.search_explorer_subgraph` helper: deterministic ordering, endpoint closure, label validation, hops clamped to 1-3, and aggregate node/edge budgets via `cap_graph`.
- Cache `global_graph_snapshot` behind an 8s-TTL, 128-entry LRU (lock-guarded, deepcopy in/out, generation counter discards in-flight stale fills; keyed by driver + logical DB + all shaping args).
- Invalidate the snapshot cache after successful graph mutations across kg/tg admin, trace ingest, import, semantic (+io), doc, user-context, and write Cypher paths; reads stay cached.
- New `test_retrieval_enhancements.py` (29 tests) plus sync-route safety additions; full repo suite 792 passed.

## Test plan
- [x] `uv run pytest` full repo suite (792 passed)
- [x] L3 security review: 0 findings
- [ ] Manual explorer UI smoke against a live Neo4j once the stack merges