### PR TITLE
feat(context): add pluggable graph backend abstraction

### DIFF
--- a/packages/qwenpaw-data-context/src/context_manager/api/server.py
+++ b/packages/qwenpaw-data-context/src/context_manager/api/server.py
@@ -422,6 +422,14 @@ def create_app() -> FastAPI:
                 notifications_min_severity="OFF",
             )
             app.state.driver = driver
+            # 图后端抽象：把 driver 包成 Neo4jBackend 注册为活跃后端
+            # （复用 driver、不拥有其生命周期），graph_session(None) 即可路由。
+            try:
+                from context_manager.graph.backends.registry import init_backend
+
+                init_backend(CFG, neo4j_driver=driver)
+            except Exception as backend_exc:  # noqa: BLE001
+                log.warning("graph backend registration failed: %s", backend_exc)
             app.state.session_store = SessionStore(
                 sqlite_path=CFG.sessions_db_path if CFG.sessions_persist else None,
             )
@@ -476,6 +484,14 @@ def create_app() -> FastAPI:
             try:
                 await governor.aclose()
             finally:
+                try:
+                    from context_manager.graph.backends.registry import (
+                        get_manager as _get_backend_manager,
+                    )
+
+                    _get_backend_manager().close_all()
+                except Exception as backend_exc:  # noqa: BLE001
+                    log.warning("graph backend shutdown failed: %s", backend_exc)
                 try:
                     if driver is not None:
                         await asyncio.to_thread(driver.close)

--- a/packages/qwenpaw-data-context/src/context_manager/config.py
+++ b/packages/qwenpaw-data-context/src/context_manager/config.py
@@ -315,6 +315,8 @@ class Config:
     neo4j_password: str = os.getenv("NEO4J_PASSWORD", "")  # 数据库密码
     # Neo4j 5 逻辑库名；不设则默认库（仅手动调试）；数据集流水线应设 NEO4J_DATABASE
     neo4j_database: Optional[str] = field(default_factory=_neo4j_database)
+    # 图后端类型；社区版内置 'neo4j'，自定义后端经 graph.backends.registry 注册
+    graph_backend: str = os.getenv("GRAPH_BACKEND", "neo4j")
 
     openai_api_key: str = os.getenv("OPENAI_API_KEY", "")  # LLM API Key（空则部分客户端用占位）
     openai_base_url: str = os.getenv("OPENAI_BASE_URL", "https://api.openai.com/v1")  # 可指向兼容服务

--- a/packages/qwenpaw-data-context/src/context_manager/graph/backends/__init__.py
+++ b/packages/qwenpaw-data-context/src/context_manager/graph/backends/__init__.py
@@ -1,0 +1,55 @@
+"""图数据库后端工厂。
+
+根据配置选择后端。社区版内置 Neo4j；其他 openCypher 兼容后端可实现
+``GraphBackend`` 接口后通过 ``registry.get_manager().register()`` 接入。
+"""
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from .base import GraphBackend, GraphSession
+
+if TYPE_CHECKING:
+    from ...config import Config
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "GraphBackend",
+    "GraphSession",
+    "get_backend",
+]
+
+
+def get_backend(cfg: "Config", *, neo4j_driver: Any = None) -> GraphBackend:
+    """根据配置创建图数据库后端。
+
+    Args:
+        cfg: Config 实例
+        neo4j_driver: 外部注入的 Neo4j driver（可选，见 Neo4jBackend）
+
+    Returns:
+        GraphBackend 实例
+
+    Raises:
+        ValueError: 未知的 graph_backend 类型
+    """
+    backend_type = cfg.graph_backend.lower()
+
+    if backend_type == "neo4j":
+        from .neo4j_backend import Neo4jBackend
+
+        return Neo4jBackend(
+            uri=cfg.neo4j_uri,
+            user=cfg.neo4j_user,
+            password=cfg.neo4j_password,
+            default_database=cfg.neo4j_database,
+            driver=neo4j_driver,
+        )
+
+    raise ValueError(
+        f"Unknown graph_backend: {backend_type!r}. Built-in: 'neo4j'. "
+        "自定义后端请实现 GraphBackend 并通过 "
+        "graph.backends.registry.get_manager().register() 注册。"
+    )

--- a/packages/qwenpaw-data-context/src/context_manager/graph/backends/base.py
+++ b/packages/qwenpaw-data-context/src/context_manager/graph/backends/base.py
@@ -1,0 +1,461 @@
+"""图数据库后端抽象层。
+
+为不同图数据库提供统一的会话与写原语接口，通过配置选择后端。
+社区版内置 Neo4j 实现；其他 openCypher 兼容后端可实现同一接口并通过
+``registry.get_manager().register()`` 在运行时接入。
+
+覆盖 12 种写模式：
+- P1: MERGE_NODE → upsert_node()
+- P2: BATCH_MERGE → batch_upsert_nodes()
+- P3: NODE+CHAIN_EDGE → upsert_node() + upsert_edge()
+- P4: BATCH+CHAIN → batch_upsert_nodes() + batch_upsert_edges()
+- P5: FOREACH_GUARD_EDGE → upsert_edge_guarded()
+- P6: UNWIND_GUARD_EDGE → batch_upsert_edges_guarded()
+- P7: MATCH_EDGE → upsert_edge()
+- P8: SIMPLE_SET → update_node()
+- P9: SET_PLUS_EQUALS → update_node_merge_props()
+- P10: CHAIN_REBUILD → delete_edges() + batch_upsert_edges_ordered()
+- P11: EMBEDDING_AWARE → update_node_conditional()
+- P12: COALESCE_PRESERVE → update_node() with conditional logic in caller
+"""
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from contextlib import contextmanager
+from typing import Any, Callable, Iterator, Optional, Sequence
+
+log = logging.getLogger(__name__)
+
+
+class GraphSession(ABC):
+    """统一的图会话接口。
+
+    所有图后端都实现此接口，提供一致的读写操作。
+    """
+
+    @abstractmethod
+    def run(self, cypher: str, **params: Any) -> Any:
+        """执行 Cypher 读查询。
+
+        Args:
+            cypher: Cypher 查询语句
+            **params: 查询参数
+
+        Returns:
+            查询结果（后端特定类型）
+        """
+
+    @abstractmethod
+    def execute_write(self, fn: Callable[..., Any], **kwargs: Any) -> Any:
+        """执行写事务。
+
+        用于需要在单个事务中执行多个写操作的场景。
+
+        Args:
+            fn: 写操作函数，接收一个事务/会话对象和 kwargs
+            **kwargs: 传递给 fn 的参数
+
+        Returns:
+            fn 的返回值
+        """
+
+    # ========================================================================
+    # 节点操作
+    # ========================================================================
+
+    def upsert_node(
+        self,
+        label: str,
+        key: str,
+        props: dict[str, Any],
+        update_props: Optional[dict[str, Any]] = None,
+        match: Optional[dict[str, Any]] = None,
+    ) -> None:
+        """插入或更新节点（MERGE + ON CREATE/ON MATCH SET 语义）。
+
+        如果节点不存在则创建并设置 props；如果已存在则更新 update_props（或 props）。
+
+        Args:
+            label: 节点标签（如 'Person', 'Table'）
+            key: 节点唯一标识（对应 .key 属性）
+            props: 创建时设置的属性字典（ON CREATE SET）
+            update_props: 更新时设置的属性字典（ON MATCH SET）；
+                         若为 None 则使用 props
+            match: 额外匹配属性；MERGE 的复合匹配键。节点按 ``key`` + match
+                   全部字段定位；写入时 match 字段也会落到属性上。
+        """
+        raise NotImplementedError(f"{type(self).__name__} 不支持 upsert_node")
+
+    def upsert_node_identity(
+        self,
+        label: str,
+        identity: dict[str, Any],
+        create_props: dict[str, Any],
+        update_props: Optional[dict[str, Any]] = None,
+    ) -> None:
+        """按任意身份字段 MERGE 节点（非 key 唯一标识场景）。
+
+        与 :meth:`upsert_node` 相同语义，但匹配键由 ``identity`` 全量指定
+        （如 UserMemory 用 ``{id}``），不假定存在 ``key`` 属性。
+        identity 字段也写入节点属性。
+
+        Args:
+            label: 节点标签
+            identity: MERGE 匹配的完整身份属性字典
+            create_props: ON CREATE SET 的属性
+            update_props: ON MATCH SET 的属性；None 则不额外更新（仅 identity）
+        """
+        raise NotImplementedError(f"{type(self).__name__} 不支持 upsert_node_identity")
+
+    def read_node(
+        self,
+        label: str,
+        identity: dict[str, Any],
+        fields: Sequence[str],
+    ) -> Optional[dict[str, Any]]:
+        """按身份字段读单节点的指定字段；不存在返回 None。"""
+        raise NotImplementedError(f"{type(self).__name__} 不支持 read_node")
+
+    def batch_upsert_nodes(
+        self,
+        label: str,
+        nodes: list[dict[str, Any]],
+        key_field: str = "key",
+        match_fields: Optional[Sequence[str]] = None,
+    ) -> None:
+        """批量插入或更新节点（UNWIND + MERGE 语义）。
+
+        Args:
+            label: 节点标签
+            nodes: 节点列表，每个元素是属性字典
+            key_field: 用作唯一标识的字段名（默认 'key'）
+            match_fields: 额外参与 MERGE 匹配的字段名，从每个节点字典取值。
+        """
+        # 默认实现：逐个调用
+        for node in nodes:
+            key = node.get(key_field)
+            if key is None:
+                raise ValueError(f"Node missing '{key_field}': {node}")
+            m = (
+                {f: node.get(f) for f in match_fields if node.get(f) is not None}
+                if match_fields
+                else None
+            )
+            self.upsert_node(label, key, node, match=m or None)
+
+    def update_node(
+        self,
+        label: str,
+        key: str,
+        updates: dict[str, Any],
+        match: Optional[dict[str, Any]] = None,
+    ) -> None:
+        """更新现有节点属性（MATCH + SET 语义）。
+
+        Args:
+            label: 节点标签
+            key: 节点 key
+            updates: 要更新的属性字典
+            match: 额外匹配属性（复合键）
+        """
+        raise NotImplementedError(f"{type(self).__name__} 不支持 update_node")
+
+    def update_node_merge_props(
+        self,
+        label: str,
+        key: str,
+        props: dict[str, Any],
+        match: Optional[dict[str, Any]] = None,
+    ) -> None:
+        """合并属性到现有节点（MATCH + SET n += $props 语义）。
+
+        Args:
+            label: 节点标签
+            key: 节点 key
+            props: 要合并的属性字典（现有属性保留，新属性覆盖或添加）
+            match: 额外匹配属性（复合键）
+        """
+        raise NotImplementedError(f"{type(self).__name__} 不支持 update_node_merge_props")
+
+    def update_node_conditional(
+        self,
+        label: str,
+        key: str,
+        updates: dict[str, Any],
+        condition_field: str,
+        condition_value: Any,
+        match: Optional[dict[str, Any]] = None,
+    ) -> None:
+        """条件更新节点属性（embedding-aware SET 语义）。
+
+        仅当 condition_field 的值与 condition_value 不同时才更新。
+        用于 idempotent embedding 更新：
+        SET emb = CASE WHEN hash <> existing THEN $vec ELSE existing END
+
+        Args:
+            label: 节点标签
+            key: 节点 key
+            updates: 要更新的属性字典
+            condition_field: 条件字段名（如 'embedding_hash'）
+            condition_value: 条件值（如新的 hash）
+            match: 额外匹配属性（复合键）
+        """
+        raise NotImplementedError(f"{type(self).__name__} 不支持 update_node_conditional")
+
+    def delete_node(
+        self,
+        label: str,
+        key: str,
+        match: Optional[dict[str, Any]] = None,
+    ) -> None:
+        """删除节点及其关联边（DETACH DELETE 语义）。
+
+        Args:
+            label: 节点标签
+            key: 节点 key
+            match: 额外匹配属性（复合键）
+        """
+        raise NotImplementedError(f"{type(self).__name__} 不支持 delete_node")
+
+    def delete_nodes_batch(
+        self,
+        label: str,
+        node_ids: Sequence[Any],
+        edge_labels: Optional[Sequence[str]] = None,
+    ) -> None:
+        """按内部 id 批量删除节点及其关联边（DETACH DELETE 语义的批量版）。
+
+        相比逐个 :meth:`delete_node`，实现后端应尽量用少数几条语句完成，
+        避免逐节点逐表删边的 round-trip 风暴。
+
+        Args:
+            label: 节点标签
+            node_ids: 节点内部 id 列表
+            edge_labels: 关联边 label 白名单（可选）。传入时只清理这些边，
+                调用方已知删除涉及面时应收窄；None = 全部边。
+        """
+        raise NotImplementedError(f"{type(self).__name__} 不支持 delete_nodes_batch")
+
+    # ========================================================================
+    # 边操作
+    # ========================================================================
+
+    def upsert_edge(
+        self,
+        rel_type: str,
+        start_label: str,
+        start_key: str,
+        end_label: str,
+        end_key: str,
+        props: Optional[dict[str, Any]] = None,
+        start_match: Optional[dict[str, Any]] = None,
+        end_match: Optional[dict[str, Any]] = None,
+    ) -> None:
+        """插入或更新边（MATCH + MERGE 语义）。
+
+        要求起点和终点都存在，否则抛出异常或跳过。
+
+        Args:
+            rel_type: 关系类型（如 'KNOWS', 'HAS_COLUMN'）
+            start_label: 起点标签
+            start_key: 起点 key
+            end_label: 终点标签
+            end_key: 终点 key
+            props: 边属性字典（可选）
+            start_match: 起点额外匹配属性（复合键）
+            end_match: 终点额外匹配属性（复合键）
+        """
+        raise NotImplementedError(f"{type(self).__name__} 不支持 upsert_edge")
+
+    def upsert_edge_guarded(
+        self,
+        rel_type: str,
+        start_label: str,
+        start_key: str,
+        end_label: str,
+        end_key: str,
+        props: Optional[dict[str, Any]] = None,
+        start_match: Optional[dict[str, Any]] = None,
+        end_match: Optional[dict[str, Any]] = None,
+    ) -> None:
+        """插入或更新边，仅当两端点都存在时（FOREACH guard 语义）。
+
+        如果任一端点不存在则静默跳过（不报错）。
+        用于跨层/可选依赖的边创建。
+
+        Args:
+            rel_type: 关系类型
+            start_label: 起点标签
+            start_key: 起点 key
+            end_label: 终点标签
+            end_key: 终点 key
+            props: 边属性字典（可选）
+            start_match: 起点额外匹配属性（复合键）
+            end_match: 终点额外匹配属性（复合键）
+        """
+        raise NotImplementedError(f"{type(self).__name__} 不支持 upsert_edge_guarded")
+
+    def batch_upsert_edges(
+        self,
+        rel_type: str,
+        edges: list[dict[str, Any]],
+        start_label: str,
+        end_label: str,
+        start_key_field: str = "start_key",
+        end_key_field: str = "end_key",
+        start_match_fields: Optional[Sequence[str]] = None,
+        end_match_fields: Optional[Sequence[str]] = None,
+    ) -> None:
+        """批量插入或更新边（UNWIND + MATCH + MERGE 语义）。
+
+        Args:
+            rel_type: 关系类型
+            edges: 边列表，每个元素包含 start_key, end_key 和可选属性
+            start_label: 起点标签
+            end_label: 终点标签
+            start_key_field: 起点 key 字段名
+            end_key_field: 终点 key 字段名
+            start_match_fields: 边字典中参与起点复合匹配的字段名
+            end_match_fields: 边字典中参与终点复合匹配的字段名
+        """
+        # 默认实现：逐个调用
+        for edge in edges:
+            sk = edge.get(start_key_field)
+            ek = edge.get(end_key_field)
+            if sk is None or ek is None:
+                raise ValueError(f"Edge missing keys: {edge}")
+            props = {k: v for k, v in edge.items() if k not in (start_key_field, end_key_field)}
+            self.upsert_edge(rel_type, start_label, sk, end_label, ek, props)
+
+    def batch_upsert_edges_guarded(
+        self,
+        rel_type: str,
+        edges: list[dict[str, Any]],
+        start_label: str,
+        end_label: str,
+        start_key_field: str = "start_key",
+        end_key_field: str = "end_key",
+        start_match_fields: Optional[Sequence[str]] = None,
+        end_match_fields: Optional[Sequence[str]] = None,
+    ) -> None:
+        """批量插入边，仅当两端点都存在（UNWIND + OPTIONAL MATCH + FOREACH guard 语义）。
+
+        Args:
+            rel_type: 关系类型
+            edges: 边列表
+            start_label: 起点标签
+            end_label: 终点标签
+            start_key_field: 起点 key 字段名
+            end_key_field: 终点 key 字段名
+            start_match_fields: 边字典中参与起点复合匹配的字段名
+            end_match_fields: 边字典中参与终点复合匹配的字段名
+        """
+        # 默认实现：逐个调用 guarded 版本
+        for edge in edges:
+            sk = edge.get(start_key_field)
+            ek = edge.get(end_key_field)
+            if sk is None or ek is None:
+                continue
+            props = {k: v for k, v in edge.items() if k not in (start_key_field, end_key_field)}
+            self.upsert_edge_guarded(rel_type, start_label, sk, end_label, ek, props)
+
+    def delete_edges(
+        self,
+        rel_type: str,
+        from_label: Optional[str] = None,
+        from_key: Optional[str] = None,
+        to_label: Optional[str] = None,
+        to_key: Optional[str] = None,
+        from_match: Optional[dict[str, Any]] = None,
+        to_match: Optional[dict[str, Any]] = None,
+    ) -> None:
+        """删除边（可选按端点过滤）。
+
+        Args:
+            rel_type: 关系类型
+            from_label: 起点标签（可选）
+            from_key: 起点 key（可选）
+            to_label: 终点标签（可选）
+            to_key: 终点 key（可选）
+            from_match: 起点额外匹配属性（复合键）
+            to_match: 终点额外匹配属性（复合键）
+        """
+        raise NotImplementedError(f"{type(self).__name__} 不支持 delete_edges")
+
+    def edge_exists(
+        self,
+        rel_type: str,
+        start_label: str,
+        start_key: str,
+        end_label: str,
+        end_key: str,
+        start_match: Optional[dict[str, Any]] = None,
+        end_match: Optional[dict[str, Any]] = None,
+    ) -> bool:
+        """检查两端点间是否存在 ``rel_type`` 边（MERGE 边幂等守卫用）。"""
+        raise NotImplementedError(f"{type(self).__name__} 不支持 edge_exists")
+
+    def find_node_label(
+        self,
+        key: str,
+        labels: Optional[Sequence[str]] = None,
+        match: Optional[dict[str, Any]] = None,
+    ) -> Optional[str]:
+        """按 key（+复合匹配）跨 label 查找节点所在 label；找不到返回 None。
+
+        供"只知道 key 不知道 label"的边写入场景（如 RELATED_TO 邻居）。
+        ``labels`` 限定候选 label 列表，默认搜全部已知 label。
+        """
+        raise NotImplementedError(f"{type(self).__name__} 不支持 find_node_label")
+
+    def batch_upsert_edges_ordered(
+        self,
+        rel_type: str,
+        nodes: list[dict[str, Any]],
+        label: str,
+        key_field: str = "key",
+        order_field: Optional[str] = None,
+        match_fields: Optional[Sequence[str]] = None,
+    ) -> None:
+        """按顺序创建链式边（CHAIN_REBUILD 语义）。
+
+        先删除现有边，再按 order_field 排序后创建链式边。
+        用于 submit_trace 中的 NEXT 链重建。
+
+        Args:
+            rel_type: 关系类型（如 'NEXT'）
+            nodes: 节点列表
+            label: 节点标签
+            key_field: key 字段名
+            order_field: 排序字段名（如 'ts', 'step_idx'）；None 则按列表顺序
+            match_fields: 节点字典中参与复合匹配的字段名
+        """
+        raise NotImplementedError(f"{type(self).__name__} 不支持 batch_upsert_edges_ordered")
+
+    @abstractmethod
+    def close(self) -> None:
+        """关闭会话。"""
+
+
+class GraphBackend(ABC):
+    """图数据库后端抽象基类。
+
+    管理连接池和会话创建。
+    """
+
+    @abstractmethod
+    @contextmanager
+    def session(self, *, database: Optional[str] = None) -> Iterator[GraphSession]:
+        """创建并返回一个会话上下文管理器。
+
+        Args:
+            database: 逻辑数据库名（可选）
+
+        Yields:
+            GraphSession 实例
+        """
+
+    @abstractmethod
+    def close(self) -> None:
+        """关闭后端连接，释放资源。"""

--- a/packages/qwenpaw-data-context/src/context_manager/graph/backends/neo4j_backend.py
+++ b/packages/qwenpaw-data-context/src/context_manager/graph/backends/neo4j_backend.py
@@ -1,0 +1,547 @@
+"""Neo4j 后端实现。
+
+封装 Neo4j Python driver，提供 GraphBackend/GraphSession 接口。
+"""
+from __future__ import annotations
+
+import logging
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Any, Callable, Iterator, Optional, Sequence
+
+from .base import GraphBackend, GraphSession
+
+if TYPE_CHECKING:
+    from neo4j import Driver, Session
+
+log = logging.getLogger(__name__)
+
+
+class Neo4jSession(GraphSession):
+    """Neo4j 会话实现。
+
+    封装 neo4j.Session，提供统一的 GraphSession 接口。
+    """
+
+    def __init__(self, session: "Session"):
+        self._session = session
+
+    def run(self, cypher: str, **params: Any) -> Any:
+        """执行 Cypher 查询。"""
+        return self._session.run(cypher, **params)
+
+    def execute_write(self, fn: Callable[..., Any], **kwargs: Any) -> Any:
+        """执行写事务。"""
+        return self._session.execute_write(fn, **kwargs)
+
+    # ========================================================================
+    # 节点操作
+    # ========================================================================
+
+    def upsert_node(
+        self,
+        label: str,
+        key: str,
+        props: dict[str, Any],
+        update_props: Optional[dict[str, Any]] = None,
+        match: Optional[dict[str, Any]] = None,
+    ) -> None:
+        """MERGE 节点并设置属性（ON CREATE / ON MATCH SET）。
+
+        ``match`` 携带复合匹配键，
+        会同时进入 MERGE 模式与属性集。
+        """
+        match = match or {}
+        match_clause = "".join(f", {k}: ${k}" for k in match.keys())
+        create_parts = [f"n.{k} = ${k}" for k in props.keys() if k not in match]
+        create_parts += [f"n.{k} = ${k}" for k in match.keys()]
+        create_clause = ", ".join(create_parts)
+
+        if update_props is not None:
+            update_parts = [f"n.{k} = $upd_{k}" for k in update_props.keys()]
+            update_clause = ", ".join(update_parts)
+            params = {
+                "key": key,
+                **match,
+                **{k: v for k, v in props.items() if k not in match},
+                **{f"upd_{k}": v for k, v in update_props.items()},
+            }
+        else:
+            update_clause = create_clause
+            params = {"key": key, **match, **{k: v for k, v in props.items() if k not in match}}
+
+        cypher = f"""
+        MERGE (n:{label} {{key: $key{match_clause}}})
+        ON CREATE SET {create_clause}
+        ON MATCH SET {update_clause}
+        """
+        self._session.run(cypher, **params)
+
+    def batch_upsert_nodes(
+        self,
+        label: str,
+        nodes: list[dict[str, Any]],
+        key_field: str = "key",
+        match_fields: Optional[Sequence[str]] = None,
+    ) -> None:
+        """UNWIND + MERGE 批量插入/更新节点。"""
+        if not nodes:
+            return
+
+        match_fields = list(match_fields or [])
+        # 从第一个节点推断属性列表
+        sample = nodes[0]
+        props_keys = [k for k in sample.keys() if k != key_field and k not in match_fields]
+
+        match_clause = "".join(f", {f}: row.{f}" for f in match_fields)
+        create_parts = [f"n.{k} = row.{k}" for k in props_keys + match_fields]
+        create_clause = ", ".join(create_parts)
+
+        cypher = f"""
+        UNWIND $nodes AS row
+        MERGE (n:{label} {{key: row.{key_field}{match_clause}}})
+        ON CREATE SET {create_clause}
+        ON MATCH SET {create_clause}
+        """
+        self._session.run(cypher, nodes=nodes)
+
+    def update_node(
+        self,
+        label: str,
+        key: str,
+        updates: dict[str, Any],
+        match: Optional[dict[str, Any]] = None,
+    ) -> None:
+        """更新现有节点属性（MATCH + SET）。"""
+        match = match or {}
+        match_clause = "".join(f", {k}: ${k}" for k in match.keys())
+        set_clauses = [f"n.{k} = ${k}" for k in updates.keys()]
+        set_clause = ", ".join(set_clauses)
+
+        cypher = f"""
+        MATCH (n:{label} {{key: $key{match_clause}}})
+        SET {set_clause}
+        """
+        self._session.run(cypher, key=key, **{**match, **updates})
+
+    def update_node_merge_props(
+        self,
+        label: str,
+        key: str,
+        props: dict[str, Any],
+        match: Optional[dict[str, Any]] = None,
+    ) -> None:
+        """合并属性到现有节点（SET n += $props）。"""
+        match = match or {}
+        match_clause = "".join(f", {k}: ${k}" for k in match.keys())
+        cypher = f"""
+        MATCH (n:{label} {{key: $key{match_clause}}})
+        SET n += $props
+        """
+        self._session.run(cypher, key=key, props=props, **match)
+
+    def update_node_conditional(
+        self,
+        label: str,
+        key: str,
+        updates: dict[str, Any],
+        condition_field: str,
+        condition_value: Any,
+        match: Optional[dict[str, Any]] = None,
+    ) -> None:
+        """条件更新（embedding-aware SET）。
+
+        仅当 condition_field 的值与 condition_value 不同时才更新。
+        """
+        match = match or {}
+        match_clause = "".join(f", {k}: ${k}" for k in match.keys())
+        set_clauses = []
+        for k, v in updates.items():
+            if k == condition_field:
+                set_clauses.append(f"n.{k} = ${k}")
+            else:
+                # 条件更新：只有 hash 变化时才更新
+                set_clauses.append(
+                    f"n.{k} = CASE WHEN n.{condition_field} <> ${condition_field} THEN ${k} ELSE n.{k} END"
+                )
+        set_clause = ", ".join(set_clauses)
+
+        cypher = f"""
+        MATCH (n:{label} {{key: $key{match_clause}}})
+        SET {set_clause}
+        """
+        params = {"key": key, condition_field: condition_value, **match, **updates}
+        self._session.run(cypher, **params)
+
+    def delete_node(
+        self,
+        label: str,
+        key: str,
+        match: Optional[dict[str, Any]] = None,
+    ) -> None:
+        """删除节点及其关联边（DETACH DELETE）。"""
+        match = match or {}
+        match_clause = "".join(f", {k}: ${k}" for k in match.keys())
+        cypher = f"""
+        MATCH (n:{label} {{key: $key{match_clause}}})
+        DETACH DELETE n
+        """
+        self._session.run(cypher, key=key, **match)
+
+    # ========================================================================
+    # 边操作
+    # ========================================================================
+
+    def upsert_edge(
+        self,
+        rel_type: str,
+        start_label: str,
+        start_key: str,
+        end_label: str,
+        end_key: str,
+        props: Optional[dict[str, Any]] = None,
+        start_match: Optional[dict[str, Any]] = None,
+        end_match: Optional[dict[str, Any]] = None,
+    ) -> None:
+        """MERGE 边并设置属性。"""
+        props = props or {}
+        start_match = start_match or {}
+        end_match = end_match or {}
+        sm = "".join(f", {k}: $sm_{k}" for k in start_match.keys())
+        em = "".join(f", {k}: $em_{k}" for k in end_match.keys())
+        set_clauses = [f"r.{k} = ${k}" for k in props.keys()]
+        set_clause = ", ".join(set_clauses) if set_clauses else ""
+
+        cypher = f"""
+        MATCH (a:{start_label} {{key: $start_key{sm}}})
+        MATCH (b:{end_label} {{key: $end_key{em}}})
+        MERGE (a)-[r:{rel_type}]->(b)
+        """
+        if set_clause:
+            cypher += f"SET {set_clause}"
+
+        params = {
+            "start_key": start_key,
+            "end_key": end_key,
+            **{f"sm_{k}": v for k, v in start_match.items()},
+            **{f"em_{k}": v for k, v in end_match.items()},
+            **props,
+        }
+        self._session.run(cypher, **params)
+
+    def upsert_edge_guarded(
+        self,
+        rel_type: str,
+        start_label: str,
+        start_key: str,
+        end_label: str,
+        end_key: str,
+        props: Optional[dict[str, Any]] = None,
+        start_match: Optional[dict[str, Any]] = None,
+        end_match: Optional[dict[str, Any]] = None,
+    ) -> None:
+        """FOREACH guard 语义：仅当两端点都存在时才创建边。"""
+        props = props or {}
+        start_match = start_match or {}
+        end_match = end_match or {}
+        sm = "".join(f", {k}: $sm_{k}" for k in start_match.keys())
+        em = "".join(f", {k}: $em_{k}" for k in end_match.keys())
+        set_clauses = [f"r.{k} = ${k}" for k in props.keys()]
+        set_clause = ", ".join(set_clauses) if set_clauses else ""
+
+        cypher = f"""
+        MATCH (a:{start_label} {{key: $start_key{sm}}})
+        OPTIONAL MATCH (b:{end_label} {{key: $end_key{em}}})
+        FOREACH (_ IN CASE WHEN b IS NULL THEN [] ELSE [b] END |
+            MERGE (a)-[r:{rel_type}]->(b)
+        """
+        if set_clause:
+            cypher += f"SET {set_clause}"
+        cypher += ")"
+
+        params = {
+            "start_key": start_key,
+            "end_key": end_key,
+            **{f"sm_{k}": v for k, v in start_match.items()},
+            **{f"em_{k}": v for k, v in end_match.items()},
+            **props,
+        }
+        self._session.run(cypher, **params)
+
+    def batch_upsert_edges(
+        self,
+        rel_type: str,
+        edges: list[dict[str, Any]],
+        start_label: str,
+        end_label: str,
+        start_key_field: str = "start_key",
+        end_key_field: str = "end_key",
+        start_match_fields: Optional[Sequence[str]] = None,
+        end_match_fields: Optional[Sequence[str]] = None,
+    ) -> None:
+        """UNWIND + MATCH + MERGE 批量插入边。"""
+        if not edges:
+            return
+
+        start_match_fields = list(start_match_fields or [])
+        end_match_fields = list(end_match_fields or [])
+        sample = edges[0]
+        reserved = {start_key_field, end_key_field} | set(start_match_fields) | set(end_match_fields)
+        props_keys = [k for k in sample.keys() if k not in reserved]
+
+        sm = "".join(f", {f}: row.{f}" for f in start_match_fields)
+        em = "".join(f", {f}: row.{f}" for f in end_match_fields)
+        set_clauses = [f"r.{k} = row.{k}" for k in props_keys]
+        set_clause = ", ".join(set_clauses) if set_clauses else ""
+
+        cypher = f"""
+        UNWIND $edges AS row
+        MATCH (a:{start_label} {{key: row.{start_key_field}{sm}}})
+        MATCH (b:{end_label} {{key: row.{end_key_field}{em}}})
+        MERGE (a)-[r:{rel_type}]->(b)
+        """
+        if set_clause:
+            cypher += f"SET {set_clause}"
+
+        self._session.run(cypher, edges=edges)
+
+    def batch_upsert_edges_guarded(
+        self,
+        rel_type: str,
+        edges: list[dict[str, Any]],
+        start_label: str,
+        end_label: str,
+        start_key_field: str = "start_key",
+        end_key_field: str = "end_key",
+        start_match_fields: Optional[Sequence[str]] = None,
+        end_match_fields: Optional[Sequence[str]] = None,
+    ) -> None:
+        """UNWIND + OPTIONAL MATCH + FOREACH guard 批量插入边。"""
+        if not edges:
+            return
+
+        start_match_fields = list(start_match_fields or [])
+        end_match_fields = list(end_match_fields or [])
+        sample = edges[0]
+        reserved = {start_key_field, end_key_field} | set(start_match_fields) | set(end_match_fields)
+        props_keys = [k for k in sample.keys() if k not in reserved]
+
+        sm = "".join(f", {f}: row.{f}" for f in start_match_fields)
+        em = "".join(f", {f}: row.{f}" for f in end_match_fields)
+        set_clauses = [f"r.{k} = row.{k}" for k in props_keys]
+        set_clause = ", ".join(set_clauses) if set_clauses else ""
+
+        cypher = f"""
+        UNWIND $edges AS row
+        MATCH (a:{start_label} {{key: row.{start_key_field}{sm}}})
+        OPTIONAL MATCH (b:{end_label} {{key: row.{end_key_field}{em}}})
+        FOREACH (_ IN CASE WHEN b IS NULL THEN [] ELSE [b] END |
+            MERGE (a)-[r:{rel_type}]->(b)
+        """
+        if set_clause:
+            cypher += f"SET {set_clause}"
+        cypher += ")"
+
+        self._session.run(cypher, edges=edges)
+
+    def delete_edges(
+        self,
+        rel_type: str,
+        from_label: Optional[str] = None,
+        from_key: Optional[str] = None,
+        to_label: Optional[str] = None,
+        to_key: Optional[str] = None,
+        from_match: Optional[dict[str, Any]] = None,
+        to_match: Optional[dict[str, Any]] = None,
+    ) -> None:
+        """删除边（可选按端点过滤）。"""
+        from_match = from_match or {}
+        to_match = to_match or {}
+        fm = "".join(f", {k}: $fm_{k}" for k in from_match.keys())
+        tm = "".join(f", {k}: $tm_{k}" for k in to_match.keys())
+        from_match_cypher = (
+            f"(a:{from_label} {{key: $from_key{fm}}})" if from_label and from_key else "(a)"
+        )
+        to_match_cypher = f"(b:{to_label} {{key: $to_key{tm}}})" if to_label and to_key else "(b)"
+
+        cypher = f"""
+        MATCH {from_match_cypher}-[r:{rel_type}]->{to_match_cypher}
+        DELETE r
+        """
+
+        params = {}
+        if from_key:
+            params["from_key"] = from_key
+            params.update({f"fm_{k}": v for k, v in from_match.items()})
+        if to_key:
+            params["to_key"] = to_key
+            params.update({f"tm_{k}": v for k, v in to_match.items()})
+
+        self._session.run(cypher, **params)
+
+    def batch_upsert_edges_ordered(
+        self,
+        rel_type: str,
+        nodes: list[dict[str, Any]],
+        label: str,
+        key_field: str = "key",
+        order_field: Optional[str] = None,
+        match_fields: Optional[Sequence[str]] = None,
+    ) -> None:
+        """按顺序创建链式边（先删除再重建）。"""
+        if len(nodes) < 2:
+            return
+
+        match_fields = list(match_fields or [])
+        # 先删除现有链式边
+        self.delete_edges(rel_type, from_label=label)
+
+        # 按 order_field 排序（如果提供）
+        if order_field:
+            nodes = sorted(nodes, key=lambda n: n.get(order_field, 0))
+
+        # 创建链式边
+        edges = []
+        for i in range(len(nodes) - 1):
+            edge = {
+                "start_key": nodes[i][key_field],
+                "end_key": nodes[i + 1][key_field],
+            }
+            for f in match_fields:
+                edge[f] = nodes[i].get(f)
+            edges.append(edge)
+
+        self.batch_upsert_edges(
+            rel_type,
+            edges,
+            label,
+            label,
+            start_match_fields=match_fields,
+            end_match_fields=match_fields,
+        )
+
+    def node_exists(self, label: str, key: str, match: Optional[dict[str, Any]] = None) -> bool:
+        """检查节点是否存在（供写事务内的前置探测）。"""
+        match = match or {}
+        match_clause = "".join(f", {k}: ${k}" for k in match.keys())
+        rec = self._session.run(
+            f"MATCH (n:{label} {{key: $key{match_clause}}}) RETURN 1 AS x LIMIT 1",
+            key=key, **match,
+        ).single()
+        return rec is not None
+
+    def edge_exists(
+        self,
+        rel_type: str,
+        start_label: str,
+        start_key: str,
+        end_label: str,
+        end_key: str,
+        start_match: Optional[dict[str, Any]] = None,
+        end_match: Optional[dict[str, Any]] = None,
+    ) -> bool:
+        """检查两端点间是否存在 rel_type 边（MERGE 边幂等守卫用）。"""
+        start_match = start_match or {}
+        end_match = end_match or {}
+        sm = "".join(f", {k}: $sm_{k}" for k in start_match.keys())
+        em = "".join(f", {k}: $em_{k}" for k in end_match.keys())
+        rec = self._session.run(
+            f"MATCH (a:{start_label} {{key: $sk{sm}}})-[r:{rel_type}]->"
+            f"(b:{end_label} {{key: $ek{em}}}) RETURN 1 AS x LIMIT 1",
+            sk=start_key, ek=end_key,
+            **{
+                **{f"sm_{k}": v for k, v in start_match.items()},
+                **{f"em_{k}": v for k, v in end_match.items()},
+            },
+        ).single()
+        return rec is not None
+
+    def find_node_label(
+        self,
+        key: str,
+        labels: Optional[Sequence[str]] = None,
+        match: Optional[dict[str, Any]] = None,
+    ) -> Optional[str]:
+        """按 key 跨 label 查找节点所在 label。"""
+        match = match or {}
+        match_clause = "".join(f", {k}: ${k}" for k in match.keys())
+        candidates = list(labels) if labels else []
+        if candidates:
+            label_or = " OR ".join(f"n:{lb}" for lb in candidates)
+            cypher = f"MATCH (n) WHERE n.key = $key{match_clause} AND ({label_or}) RETURN labels(n)[0] AS lb LIMIT 1"
+        else:
+            cypher = f"MATCH (n) WHERE n.key = $key{match_clause} RETURN labels(n)[0] AS lb LIMIT 1"
+        rec = self._session.run(cypher, key=key, **match).single()
+        return rec["lb"] if rec else None
+
+    def close(self) -> None:
+        """关闭会话。"""
+        self._session.close()
+
+
+class Neo4jBackend(GraphBackend):
+    """Neo4j 后端实现。
+
+    使用官方 neo4j Python driver 连接 Neo4j 数据库。
+    """
+
+    def __init__(
+        self,
+        uri: str,
+        user: str,
+        password: str,
+        default_database: Optional[str] = None,
+        driver: Any = None,
+    ):
+        """初始化 Neo4j 后端。
+
+        Args:
+            uri: Neo4j Bolt URI（如 bolt://localhost:7687）
+            user: 用户名
+            password: 密码
+            default_database: 默认逻辑数据库（可选）
+            driver: 外部注入的 driver（可选）。传入时本后端不拥有其生命周期，
+                    ``close()`` 不关闭它（避免与注入方双重关闭，如 server
+                    lifespan 复用 fallback_driver）。
+        """
+        if driver is not None:
+            self._driver: Driver = driver
+            self._owns_driver = False
+        else:
+            from neo4j import GraphDatabase
+
+            self._driver = GraphDatabase.driver(
+                uri,
+                auth=(user, password),
+                notifications_min_severity="OFF",
+            )
+            self._owns_driver = True
+        self._default_database = default_database
+        log.info("Neo4j backend initialized: %s (owns_driver=%s)", uri, self._owns_driver)
+
+    @contextmanager
+    def session(self, *, database: Optional[str] = None) -> Iterator[Neo4jSession]:
+        """创建 Neo4j 会话。
+
+        Args:
+            database: 逻辑数据库名，优先使用此参数；
+                     若为 None，则使用 default_database
+
+        Yields:
+            Neo4jSession 实例
+        """
+        db = database or self._default_database
+        kwargs = {"database": db} if db else {}
+
+        session = self._driver.session(**kwargs)
+        try:
+            yield Neo4jSession(session)
+        finally:
+            session.close()
+
+    def close(self) -> None:
+        """关闭 Neo4j driver（仅当本后端拥有它时）。"""
+        if self._owns_driver:
+            self._driver.close()
+            log.info("Neo4j backend closed")
+        else:
+            log.debug("Neo4j backend closed (driver externally owned; not closing)")

--- a/packages/qwenpaw-data-context/src/context_manager/graph/backends/registry.py
+++ b/packages/qwenpaw-data-context/src/context_manager/graph/backends/registry.py
@@ -1,0 +1,217 @@
+"""图后端注册表：进程内多后端实例 + 运行时切换。
+
+单例 ``BackendManager`` 持有按名注册的 ``GraphBackend`` 实例，支持在
+不重启进程的情况下切换活跃后端。社区版内置 Neo4j；其他后端实现
+``GraphBackend`` 接口后可通过 ``get_manager().register()`` 接入。
+
+设计要点：
+- 线程安全：``switch`` / ``register`` / ``close_all`` 互斥。
+- 切换只换"活跃"指针，已注册的后端实例保留连接池（再次切回是热的）。
+- ``active()`` 返回当前活跃后端；``active_or_none()`` 在未初始化时返回 None，
+  供 ``graph_session()`` 向后兼容路径使用。
+- 单进程单例：用模块级 ``_MANAGER`` + ``get_manager()`` 访问，避免多处实例化。
+"""
+from __future__ import annotations
+
+import logging
+import threading
+from typing import TYPE_CHECKING, Any, Optional
+
+from .base import GraphBackend
+
+if TYPE_CHECKING:
+    from ...config import Config
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "BackendManager",
+    "get_manager",
+    "init_backend",
+    "reset_manager",
+]
+
+
+class BackendManager:
+    """进程级图后端管理器（线程安全单例）。
+
+    持有多个已创建的 ``GraphBackend`` 实例并维护一个"活跃"指针，
+    供 ``utils.graph_session()`` 使用。
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._backends: dict[str, GraphBackend] = {}
+        self._active: Optional[str] = None
+
+    # ------------------------------------------------------------------ #
+    # 注册 / 注销
+    # ------------------------------------------------------------------ #
+    def register(self, name: str, backend: GraphBackend) -> None:
+        """注册（或覆盖同名）后端实例。
+
+        覆盖时会先关闭旧实例的连接池。若当前活跃后端正是被覆盖的 name，
+        活跃指针自动指向新实例。
+        """
+        with self._lock:
+            old = self._backends.get(name)
+            if old is not None and old is not backend:
+                try:
+                    old.close()
+                except Exception as exc:  # noqa: BLE001
+                    log.warning("关闭旧后端 %s 失败: %s", name, exc)
+            self._backends[name] = backend
+            if self._active is None:
+                self._active = name
+            log.info("已注册图后端: %s (active=%s)", name, self._active)
+
+    def unregister(self, name: str) -> None:
+        """注销并关闭指定后端。若它是活跃后端，活跃指针回退。"""
+        with self._lock:
+            backend = self._backends.pop(name, None)
+            if backend is None:
+                return
+            try:
+                backend.close()
+            except Exception as exc:  # noqa: BLE001
+                log.warning("关闭后端 %s 失败: %s", name, exc)
+            if self._active == name:
+                # 回退到任意一个仍注册的后端，没有则置空
+                self._active = next(iter(self._backends), None)
+            log.info("已注销图后端: %s (active=%s)", name, self._active)
+
+    # ------------------------------------------------------------------ #
+    # 查询
+    # ------------------------------------------------------------------ #
+    def get(self, name: str) -> Optional[GraphBackend]:
+        with self._lock:
+            return self._backends.get(name)
+
+    def active_name(self) -> Optional[str]:
+        with self._lock:
+            return self._active
+
+    def active(self) -> GraphBackend:
+        """返回当前活跃后端。未初始化时抛 RuntimeError。"""
+        with self._lock:
+            if self._active is None:
+                raise RuntimeError(
+                    "BackendManager 尚未初始化：没有已注册的图后端。"
+                    " 请在启动时调用 init_backend(CFG)。"
+                )
+            return self._backends[self._active]
+
+    def active_or_none(self) -> Optional[GraphBackend]:
+        """同 ``active()`` 但未初始化时返回 None（供向后兼容路径）。"""
+        with self._lock:
+            if self._active is None:
+                return None
+            return self._backends[self._active]
+
+    def names(self) -> list[str]:
+        with self._lock:
+            return list(self._backends)
+
+    def info(self) -> dict[str, object]:
+        """返回可序列化的状态摘要。"""
+        with self._lock:
+            return {
+                "active": self._active,
+                "registered": list(self._backends),
+            }
+
+    # ------------------------------------------------------------------ #
+    # 运行时切换
+    # ------------------------------------------------------------------ #
+    def switch(self, name: str) -> str:
+        """切换活跃后端到已注册的 ``name``。
+
+        Returns:
+            切换后的活跃后端名。
+
+        Raises:
+            KeyError: ``name`` 未注册。
+        """
+        with self._lock:
+            if name not in self._backends:
+                raise KeyError(
+                    f"后端 {name!r} 未注册；已注册: {list(self._backends)}"
+                )
+            prev = self._active
+            self._active = name
+            log.info("图后端切换: %s → %s", prev, name)
+            return name
+
+    # ------------------------------------------------------------------ #
+    # 生命周期
+    # ------------------------------------------------------------------ #
+    def close_all(self) -> None:
+        """关闭并清空所有后端实例（供应用 shutdown）。"""
+        with self._lock:
+            names = list(self._backends)
+            for name in names:
+                backend = self._backends.pop(name, None)
+                if backend is None:
+                    continue
+                try:
+                    backend.close()
+                except Exception as exc:  # noqa: BLE001
+                    log.warning("关闭后端 %s 失败: %s", name, exc)
+            self._active = None
+            log.info("已关闭全部图后端: %s", names)
+
+
+# ---------------------------------------------------------------------- #
+# 模块级单例
+# ---------------------------------------------------------------------- #
+_MANAGER: Optional[BackendManager] = None
+_MANAGER_LOCK = threading.Lock()
+
+
+def get_manager() -> BackendManager:
+    """获取（惰性创建）进程级 BackendManager 单例。"""
+    global _MANAGER
+    if _MANAGER is None:
+        with _MANAGER_LOCK:
+            if _MANAGER is None:
+                _MANAGER = BackendManager()
+    return _MANAGER
+
+
+def reset_manager() -> None:
+    """重置单例（仅供测试）。会关闭所有已注册后端。"""
+    global _MANAGER
+    with _MANAGER_LOCK:
+        if _MANAGER is not None:
+            _MANAGER.close_all()
+        _MANAGER = None
+
+
+def init_backend(
+    cfg: "Config",
+    *,
+    name: Optional[str] = None,
+    neo4j_driver: Any = None,
+) -> str:
+    """按配置创建后端并注册到 manager。
+
+    Args:
+        cfg: Config 实例。
+        name: 注册名；默认用 ``cfg.graph_backend``（社区版内置 'neo4j'）。
+        neo4j_driver: 外部已创建的 Neo4j driver（如 server lifespan 的
+            driver）。传入时 Neo4jBackend 复用而不新建，且不拥有其
+            生命周期，避免与注入方双重关闭。
+
+    Returns:
+        注册名。
+    """
+    from . import get_backend
+
+    reg_name = (name or cfg.graph_backend).lower()
+    backend = get_backend(cfg, neo4j_driver=neo4j_driver)
+    mgr = get_manager()
+    mgr.register(reg_name, backend)
+    # 首次注册自动成为活跃后端；后续显式 switch 才切。
+    if mgr.active_name() is None or reg_name == cfg.graph_backend:
+        mgr.switch(reg_name)
+    return reg_name

--- a/packages/qwenpaw-data-context/src/context_manager/utils.py
+++ b/packages/qwenpaw-data-context/src/context_manager/utils.py
@@ -75,8 +75,60 @@ def neo4j_session(driver: Any, *, database: Optional[str] = None) -> Iterator[An
         sess.close()
 
 
-# 语义层导入等模块沿用 graph_session 旧名；与 neo4j_session 行为完全一致。
-graph_session = neo4j_session
+@contextmanager
+def graph_session(
+    backend: Any,
+    *,
+    database: Optional[str] = None,
+) -> Iterator[Any]:
+    """打开图数据库会话（后端可插拔）。
+
+    优先级链：
+    1. ``backend`` 是 ``GraphBackend`` 实例 → 走后端的 ``session()``；
+    2. ``backend`` 非 None（Neo4j driver）→ 向后兼容走 ``neo4j_session``；
+    3. ``backend`` 为 ``None`` → 从 ``BackendManager.active_or_none()`` 取
+       当前活跃后端（运行时切换的落点）；若 manager 也未初始化，
+       抛 ``RuntimeError`` 提示调用方。
+
+    逻辑库解析与 :func:`neo4j_session` 一致：显式 ``database`` > 请求上下文 >
+    ``CFG.neo4j_database``。
+
+    Args:
+        backend: GraphBackend 实例 / Neo4j driver / None（走 BackendManager）
+
+    Yields:
+        会话对象（GraphSession 或 neo4j.Session）
+    """
+    from .graph.backends.base import GraphBackend
+
+    if isinstance(backend, GraphBackend):
+        from .config import CFG
+
+        db = database
+        if db is None:
+            db = neo4j_database_ctx.get()
+        if db is None:
+            db = CFG.neo4j_database
+        with backend.session(database=db) as session:
+            yield session
+        return
+
+    if backend is not None:
+        # 向后兼容：裸 Neo4j driver
+        with neo4j_session(backend, database=database) as session:
+            yield session
+        return
+
+    from .graph.backends.registry import get_manager
+
+    active = get_manager().active_or_none()
+    if active is None:
+        raise RuntimeError(
+            "graph_session(None)：BackendManager 未初始化。"
+            " 请传入 driver/backend，或在启动时调用 init_backend(CFG)。"
+        )
+    with graph_session(active, database=database) as session:
+        yield session
 
 
 def strip_sql(sql: str) -> str:

--- a/packages/qwenpaw-data-context/tests/test_graph_backends.py
+++ b/packages/qwenpaw-data-context/tests/test_graph_backends.py
@@ -1,0 +1,373 @@
+# -*- coding: utf-8 -*-
+"""Graph backend abstraction: manager registry, Neo4j session primitives, dispatch."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from types import SimpleNamespace
+from typing import Any, Optional
+
+import pytest
+
+from context_manager.graph.backends import GraphBackend, get_backend
+from context_manager.graph.backends.base import GraphSession
+from context_manager.graph.backends.neo4j_backend import Neo4jBackend, Neo4jSession
+from context_manager.graph.backends.registry import (
+    BackendManager,
+    get_manager,
+    init_backend,
+    reset_manager,
+)
+from context_manager.utils import graph_session, neo4j_database_ctx
+
+
+@pytest.fixture(autouse=True)
+def _clean_manager():
+    reset_manager()
+    yield
+    reset_manager()
+
+
+# --- fakes --------------------------------------------------------------------
+
+
+class FakeResult:
+    def __init__(self, record: Any = None) -> None:
+        self._record = record
+
+    def single(self) -> Any:
+        return self._record
+
+
+class FakeNeo4jSession:
+    """Stands in for neo4j.Session: records run() calls."""
+
+    def __init__(self, single_record: Any = None) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+        self.closed = False
+        self.single_record = single_record
+
+    def run(self, cypher: str, **params: Any) -> FakeResult:
+        self.calls.append((" ".join(cypher.split()), params))
+        return FakeResult(self.single_record)
+
+    def execute_write(self, fn, **kwargs):
+        return fn(self, **kwargs)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class FakeDriver:
+    def __init__(self) -> None:
+        self.session_kwargs: list[dict[str, Any]] = []
+        self.sessions: list[FakeNeo4jSession] = []
+        self.closed = False
+
+    def session(self, **kwargs: Any) -> FakeNeo4jSession:
+        self.session_kwargs.append(kwargs)
+        sess = FakeNeo4jSession()
+        self.sessions.append(sess)
+        return sess
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class FakeBackend(GraphBackend):
+    def __init__(self, name: str = "fake") -> None:
+        self.name = name
+        self.closed = False
+        self.databases: list[Optional[str]] = []
+
+    @contextmanager
+    def session(self, *, database: Optional[str] = None):
+        self.databases.append(database)
+        yield SimpleNamespace(backend=self.name, database=database)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _cfg(**overrides: Any) -> SimpleNamespace:
+    base = dict(
+        graph_backend="neo4j",
+        neo4j_uri="bolt://example:7687",
+        neo4j_user="neo4j",
+        neo4j_password="pw",
+        neo4j_database=None,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+# --- BackendManager ------------------------------------------------------------
+
+
+def test_first_register_becomes_active_and_switch() -> None:
+    mgr = BackendManager()
+    a, b = FakeBackend("a"), FakeBackend("b")
+    mgr.register("a", a)
+    mgr.register("b", b)
+    assert mgr.active_name() == "a"
+    assert mgr.active() is a
+    assert mgr.switch("b") == "b"
+    assert mgr.active() is b
+    assert set(mgr.names()) == {"a", "b"}
+    assert mgr.info() == {"active": "b", "registered": ["a", "b"]}
+    with pytest.raises(KeyError):
+        mgr.switch("missing")
+
+
+def test_register_override_closes_old_instance() -> None:
+    mgr = BackendManager()
+    old, new = FakeBackend("old"), FakeBackend("new")
+    mgr.register("x", old)
+    mgr.register("x", new)
+    assert old.closed is True
+    assert mgr.active() is new
+
+
+def test_unregister_falls_back_and_close_all() -> None:
+    mgr = BackendManager()
+    a, b = FakeBackend("a"), FakeBackend("b")
+    mgr.register("a", a)
+    mgr.register("b", b)
+    mgr.unregister("a")
+    assert a.closed is True
+    assert mgr.active_name() == "b"
+    mgr.close_all()
+    assert b.closed is True
+    assert mgr.active_or_none() is None
+    with pytest.raises(RuntimeError):
+        mgr.active()
+
+
+def test_manager_singleton_reset() -> None:
+    mgr = get_manager()
+    assert get_manager() is mgr
+    backend = FakeBackend()
+    mgr.register("fake", backend)
+    reset_manager()
+    assert backend.closed is True
+    assert get_manager() is not mgr
+
+
+# --- factory / init_backend ----------------------------------------------------
+
+
+def test_get_backend_neo4j_with_injected_driver() -> None:
+    driver = FakeDriver()
+    backend = get_backend(_cfg(), neo4j_driver=driver)
+    assert isinstance(backend, Neo4jBackend)
+    backend.close()
+    assert driver.closed is False  # injected driver is externally owned
+
+
+def test_get_backend_unknown_type() -> None:
+    with pytest.raises(ValueError, match="Unknown graph_backend"):
+        get_backend(_cfg(graph_backend="mystery"))
+
+
+def test_init_backend_registers_and_activates() -> None:
+    driver = FakeDriver()
+    name = init_backend(_cfg(), neo4j_driver=driver)
+    assert name == "neo4j"
+    mgr = get_manager()
+    assert mgr.active_name() == "neo4j"
+    assert isinstance(mgr.active(), Neo4jBackend)
+
+
+# --- Neo4jBackend sessions -------------------------------------------------------
+
+
+def test_backend_session_database_resolution() -> None:
+    driver = FakeDriver()
+    backend = Neo4jBackend(
+        uri="bolt://x", user="u", password="p",
+        default_database="defaultdb", driver=driver,
+    )
+    with backend.session() as sess:
+        assert isinstance(sess, Neo4jSession)
+    with backend.session(database="explicit"):
+        pass
+    assert driver.session_kwargs == [
+        {"database": "defaultdb"},
+        {"database": "explicit"},
+    ]
+    assert all(s.closed for s in driver.sessions)
+
+
+# --- Neo4jSession cypher generation ---------------------------------------------
+
+
+def _session() -> tuple[Neo4jSession, FakeNeo4jSession]:
+    raw = FakeNeo4jSession()
+    return Neo4jSession(raw), raw
+
+
+def test_upsert_node_create_and_update_clauses() -> None:
+    sess, raw = _session()
+    sess.upsert_node(
+        "Table",
+        "t1",
+        {"name": "orders"},
+        update_props={"name": "orders_v2"},
+        match={"ds": "d1"},
+    )
+    cypher, params = raw.calls[0]
+    assert "MERGE (n:Table {key: $key, ds: $ds})" in cypher
+    assert "ON CREATE SET n.name = $name, n.ds = $ds" in cypher
+    assert "ON MATCH SET n.name = $upd_name" in cypher
+    assert params == {"key": "t1", "ds": "d1", "name": "orders", "upd_name": "orders_v2"}
+
+
+def test_batch_upsert_nodes_unwind() -> None:
+    sess, raw = _session()
+    sess.batch_upsert_nodes("Col", [{"key": "c1", "typ": "int"}], match_fields=["ws"])
+    cypher, params = raw.calls[0]
+    assert "UNWIND $nodes AS row" in cypher
+    assert "MERGE (n:Col {key: row.key, ws: row.ws})" in cypher
+    assert params["nodes"][0]["key"] == "c1"
+    # empty batch is a no-op
+    sess.batch_upsert_nodes("Col", [])
+    assert len(raw.calls) == 1
+
+
+def test_update_node_variants() -> None:
+    sess, raw = _session()
+    sess.update_node("Table", "t1", {"a": 1})
+    sess.update_node_merge_props("Table", "t1", {"b": 2})
+    sess.update_node_conditional(
+        "Table", "t1", {"emb": [0.1], "emb_hash": "h2"},
+        condition_field="emb_hash", condition_value="h2",
+    )
+    assert "SET n.a = $a" in raw.calls[0][0]
+    assert "SET n += $props" in raw.calls[1][0]
+    cond_cypher = raw.calls[2][0]
+    assert "CASE WHEN n.emb_hash <> $emb_hash THEN $emb ELSE n.emb END" in cond_cypher
+
+
+def test_delete_node_detach() -> None:
+    sess, raw = _session()
+    sess.delete_node("Table", "t1", match={"ws": "w"})
+    cypher, params = raw.calls[0]
+    assert "MATCH (n:Table {key: $key, ws: $ws})" in cypher
+    assert "DETACH DELETE n" in cypher
+    assert params == {"key": "t1", "ws": "w"}
+
+
+def test_upsert_edge_and_guarded() -> None:
+    sess, raw = _session()
+    sess.upsert_edge("HAS_COLUMN", "Table", "t1", "Col", "c1", props={"idx": 1})
+    plain = raw.calls[0][0]
+    assert "MATCH (a:Table {key: $start_key})" in plain
+    assert "MERGE (a)-[r:HAS_COLUMN]->(b)" in plain
+    assert "SET r.idx = $idx" in plain
+
+    sess.upsert_edge_guarded("REL", "A", "a1", "B", "b1")
+    guarded = raw.calls[1][0]
+    assert "OPTIONAL MATCH (b:B {key: $end_key})" in guarded
+    assert "FOREACH (_ IN CASE WHEN b IS NULL THEN [] ELSE [b] END |" in guarded
+
+
+def test_batch_edges_and_ordered_chain() -> None:
+    sess, raw = _session()
+    sess.batch_upsert_edges(
+        "NEXT", [{"start_key": "s1", "end_key": "e1", "w": 2}], "Step", "Step"
+    )
+    assert "UNWIND $edges AS row" in raw.calls[0][0]
+    assert "SET r.w = row.w" in raw.calls[0][0]
+
+    sess.batch_upsert_edges_guarded(
+        "NEXT", [{"start_key": "s1", "end_key": "e1"}], "Step", "Step"
+    )
+    assert "FOREACH" in raw.calls[1][0]
+
+    raw.calls.clear()
+    nodes = [
+        {"key": "n2", "ts": 2},
+        {"key": "n1", "ts": 1},
+        {"key": "n3", "ts": 3},
+    ]
+    sess.batch_upsert_edges_ordered("NEXT", nodes, "Event", order_field="ts")
+    # first deletes the existing chain, then rebuilds in ts order
+    assert "DELETE r" in raw.calls[0][0]
+    rebuilt = raw.calls[1][1]["edges"]
+    assert [(e["start_key"], e["end_key"]) for e in rebuilt] == [
+        ("n1", "n2"),
+        ("n2", "n3"),
+    ]
+    # short chains are a no-op
+    raw.calls.clear()
+    sess.batch_upsert_edges_ordered("NEXT", [{"key": "only"}], "Event")
+    assert raw.calls == []
+
+
+def test_exists_and_find_label_helpers() -> None:
+    hit = Neo4jSession(FakeNeo4jSession(single_record={"lb": "Table"}))
+    assert hit.node_exists("Table", "t1") is True
+    assert hit.edge_exists("REL", "A", "a1", "B", "b1") is True
+    assert hit.find_node_label("t1", labels=["Table", "Col"]) == "Table"
+
+    miss = Neo4jSession(FakeNeo4jSession(single_record=None))
+    assert miss.node_exists("Table", "t1") is False
+    assert miss.edge_exists("REL", "A", "a1", "B", "b1") is False
+    assert miss.find_node_label("t1") is None
+
+
+def test_base_defaults_reject_unimplemented() -> None:
+    class Minimal(GraphSession):
+        def run(self, cypher: str, **params: Any) -> Any:
+            return None
+
+        def execute_write(self, fn, **kwargs):
+            return None
+
+        def close(self) -> None:
+            pass
+
+    with pytest.raises(NotImplementedError):
+        Minimal().upsert_node("L", "k", {})
+
+
+# --- graph_session dispatch -------------------------------------------------------
+
+
+def test_graph_session_with_backend_instance() -> None:
+    backend = FakeBackend()
+    with graph_session(backend, database="db1") as sess:
+        assert sess.database == "db1"
+    assert backend.databases == ["db1"]
+
+
+def test_graph_session_backend_respects_database_ctx() -> None:
+    backend = FakeBackend()
+    token = neo4j_database_ctx.set("neo4j")
+    try:
+        with graph_session(backend) as sess:
+            assert sess.database == "neo4j"
+    finally:
+        neo4j_database_ctx.reset(token)
+
+
+def test_graph_session_driver_back_compat() -> None:
+    driver = FakeDriver()
+    with graph_session(driver, database="neo4j") as sess:
+        assert isinstance(sess, FakeNeo4jSession)
+    assert driver.session_kwargs == [{"database": "neo4j"}]
+    assert driver.sessions[0].closed is True
+
+
+def test_graph_session_none_routes_to_active_backend() -> None:
+    backend = FakeBackend()
+    get_manager().register("fake", backend)
+    with graph_session(None, database="db2") as sess:
+        assert sess.backend == "fake"
+        assert sess.database == "db2"
+
+
+def test_graph_session_none_without_manager_raises() -> None:
+    with pytest.raises(RuntimeError, match="BackendManager"):
+        with graph_session(None):
+            pass


### PR DESCRIPTION
> Stacked on #48 (`feat/settlement`). Retarget to `main` as predecessors merge.

## Summary
- New `context_manager/graph/backends/` package: `GraphSession`/`GraphBackend` ABCs covering the 12 write patterns the graph layer uses (merge/batch/guarded edges, conditional embedding-aware updates, ordered chain rebuild), plus a `Neo4jBackend`/`Neo4jSession` implementation. External driver injection is supported so the backend can wrap a caller-owned driver without double-closing it.
- Thread-safe `BackendManager` registry (register / switch / unregister / close_all, module singleton with `get_manager()`/`reset_manager()`) so alternative openCypher-compatible backends can be registered and switched at runtime instead of hard-wiring Neo4j.
- `CFG.graph_backend` (`GRAPH_BACKEND` env, default `neo4j`) and a `get_backend(cfg)` factory with a clear extension error for unknown types.
- `utils.graph_session()` upgraded from a `neo4j_session` alias to a dispatcher: `GraphBackend` instance → backend session (same logical-DB resolution chain), raw Neo4j driver → back-compat path (all ~250 existing call sites unchanged), `None` → manager-active backend or a clear RuntimeError.
- API server lifespan registers its driver as the active `neo4j` backend (fail-soft) and shuts the registry down before closing the driver.

## Test plan
- [x] 21 new tests: manager lifecycle/switching, factory + init_backend, Neo4j session cypher generation for the write primitives, graph_session dispatch incl. ContextVar DB resolution and uninitialized-manager error
- [x] Full repo suite: 862 passed
- [x] L3 security review: 0 findings
- [ ] Community-backend smoke (register a custom GraphBackend at runtime) once the stack merges