### PR TITLE
feat(host-core): list and download session artifacts over the API

### DIFF
--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/app.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/app.py
@@ -26,6 +26,7 @@ from qwenpaw_data.host.core.agent.middleware import (
 from qwenpaw_data.host.core.api.auth import install_api_token_auth
 from qwenpaw_data.host.core.api.deps import ServiceState
 from qwenpaw_data.host.core.api.errors import http_exception_handler
+from qwenpaw_data.host.core.api.routers import artifacts as artifacts_router
 from qwenpaw_data.host.core.api.routers import channels as channels_router
 from qwenpaw_data.host.core.api.routers import chats as chats_router
 from qwenpaw_data.host.core.api.routers import clarification as clarification_router
@@ -258,6 +259,7 @@ def create_app(
     app.include_router(cron_router.router, prefix="/api/v1")
     app.include_router(settlement_router.router, prefix="/api/v1")
     app.include_router(channels_router.router, prefix="/api/v1")
+    app.include_router(artifacts_router.router, prefix="/api/v1")
     app.include_router(channels_router.config_router, prefix="/api/v1")
 
     @app.get("/health")

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/errors.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/errors.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+from typing import NoReturn
+
 from fastapi import HTTPException, Request
 from fastapi.responses import JSONResponse
 
@@ -14,7 +16,7 @@ def raise_api(
     *,
     status: int,
     details: dict | None = None,
-) -> None:
+) -> NoReturn:
     raise HTTPException(
         status_code=status,
         detail=ErrorBodySchema(

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/routers/artifacts.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/routers/artifacts.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+"""Session artifact listing and download."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, Depends, Query
+from fastapi.responses import FileResponse
+
+from qwenpaw_data.host.core.api.deps import ServiceState, get_identity, get_state
+from qwenpaw_data.host.core.api.errors import map_domain_error, raise_api
+from qwenpaw_data.host.core.domain.identity import Identity
+from qwenpaw_data.host.core.utils.workspace import list_session_files
+
+router = APIRouter(prefix="/sessions/{session_id}/artifacts", tags=["artifacts"])
+
+
+def _artifact_dir(state: ServiceState, session_id: str) -> Path:
+    return Path(state.hosts.get(session_id=session_id).paths.artifact_dir)
+
+
+@router.get("")
+async def list_artifacts(
+    session_id: str,
+    identity: Identity = Depends(get_identity),
+    state: ServiceState = Depends(get_state),
+) -> dict[str, Any]:
+    _ = identity
+    try:
+        await state.sessions.get(session_id)
+        items = list_session_files(_artifact_dir(state, session_id))
+    except Exception as exc:
+        http = map_domain_error(exc)
+        if http:
+            raise http from exc
+        raise
+    return {"items": items, "count": len(items)}
+
+
+@router.get("/file")
+async def download_artifact(
+    session_id: str,
+    path: str = Query(..., description="rel_path from the artifact listing"),
+    identity: Identity = Depends(get_identity),
+    state: ServiceState = Depends(get_state),
+) -> FileResponse:
+    _ = identity
+    try:
+        await state.sessions.get(session_id)
+    except Exception as exc:
+        http = map_domain_error(exc)
+        if http:
+            raise http from exc
+        raise
+    root = _artifact_dir(state, session_id).resolve()
+    candidate = (root / path).resolve()
+    # Containment check: the resolved file must stay inside the artifact dir.
+    if candidate == root or root not in candidate.parents:
+        raise_api("NOT_FOUND", "artifact not found", status=404)
+    if not candidate.is_file():
+        raise_api("NOT_FOUND", "artifact not found", status=404)
+    return FileResponse(candidate, filename=candidate.name)

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/routers/artifacts.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/routers/artifacts.py
@@ -65,15 +65,12 @@ async def download_artifact(
         or any(segment in {"", ".", ".."} for segment in path.split("/"))
     ):
         raise_api("NOT_FOUND", "artifact not found", status=404)
-    # Recognized normpath+prefix barrier first, then a symlink-safe resolve
-    # containment check on top.
+    # Normpath+prefix barrier; the response is only reachable inside the
+    # guarded branch, with a symlink-safe resolve containment check on top.
     root = _artifact_dir(state, session_id).resolve()
     normalized = os.path.normpath(os.path.join(str(root), path))
-    if not normalized.startswith(str(root) + os.sep):
-        raise_api("NOT_FOUND", "artifact not found", status=404)
-    candidate = Path(normalized).resolve()
-    if candidate == root or root not in candidate.parents:
-        raise_api("NOT_FOUND", "artifact not found", status=404)
-    if not candidate.is_file():
-        raise_api("NOT_FOUND", "artifact not found", status=404)
-    return FileResponse(candidate, filename=candidate.name)
+    if normalized.startswith(str(root) + os.sep):
+        candidate = Path(normalized).resolve()
+        if candidate != root and root in candidate.parents and candidate.is_file():
+            return FileResponse(candidate, filename=candidate.name)
+    raise_api("NOT_FOUND", "artifact not found", status=404)

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/routers/artifacts.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/routers/artifacts.py
@@ -53,6 +53,17 @@ async def download_artifact(
         if http:
             raise http from exc
         raise
+    # Defense in depth: reject escape characters and dot segments in the raw
+    # value before any filesystem resolution. Listings only emit plain
+    # forward-slash relative paths.
+    if (
+        not path
+        or path.startswith(("/", "~"))
+        or "\\" in path
+        or "\x00" in path
+        or any(segment in {"", ".", ".."} for segment in path.split("/"))
+    ):
+        raise_api("NOT_FOUND", "artifact not found", status=404)
     root = _artifact_dir(state, session_id).resolve()
     candidate = (root / path).resolve()
     # Containment check: the resolved file must stay inside the artifact dir.

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/routers/artifacts.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/routers/artifacts.py
@@ -2,6 +2,7 @@
 """Session artifact listing and download."""
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import Any
 
@@ -64,9 +65,13 @@ async def download_artifact(
         or any(segment in {"", ".", ".."} for segment in path.split("/"))
     ):
         raise_api("NOT_FOUND", "artifact not found", status=404)
+    # Recognized normpath+prefix barrier first, then a symlink-safe resolve
+    # containment check on top.
     root = _artifact_dir(state, session_id).resolve()
-    candidate = (root / path).resolve()
-    # Containment check: the resolved file must stay inside the artifact dir.
+    normalized = os.path.normpath(os.path.join(str(root), path))
+    if not normalized.startswith(str(root) + os.sep):
+        raise_api("NOT_FOUND", "artifact not found", status=404)
+    candidate = Path(normalized).resolve()
     if candidate == root or root not in candidate.parents:
         raise_api("NOT_FOUND", "artifact not found", status=404)
     if not candidate.is_file():

--- a/packages/qwenpaw-data-host-core/tests/test_artifacts_api.py
+++ b/packages/qwenpaw-data-host-core/tests/test_artifacts_api.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+"""Artifact list/download routes over the live service app."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+import httpx  # noqa: E402
+
+from qwenpaw_data.host.core.api.app import create_app  # noqa: E402
+
+
+@asynccontextmanager
+async def artifacts_client(tmp_path: Path, monkeypatch):
+    monkeypatch.delenv("QWENPAW_DATA_API_TOKEN", raising=False)
+    monkeypatch.delenv("QWENPAW_DATA_DB_URL", raising=False)
+    monkeypatch.delenv("QWENPAW_DATA_STORE", raising=False)
+    app = create_app(home=tmp_path, model=object())
+    async with app.router.lifespan_context(app):
+        transport = httpx.ASGITransport(app=app, client=("127.0.0.1", 1234))
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://testserver",
+        ) as http:
+            created = await http.post("/api/v1/sessions", json={"title": "产物"})
+            assert created.status_code == 200, created.text
+            session_id = created.json()["session"]["id"]
+            state = app.state.service
+            artifact_dir = Path(
+                state.hosts.get(session_id=session_id).paths.artifact_dir
+            )
+            artifact_dir.mkdir(parents=True, exist_ok=True)
+            (artifact_dir / "chart.png").write_bytes(b"png-bytes")
+            (artifact_dir / "sub").mkdir()
+            (artifact_dir / "sub" / "rows.csv").write_text("a,b\n1,2\n")
+            (tmp_path / "secret.txt").write_text("nope")
+            yield http, session_id
+
+
+async def test_list_and_download(tmp_path, monkeypatch) -> None:
+    async with artifacts_client(tmp_path, monkeypatch) as (http, session_id):
+        listed = await http.get(f"/api/v1/sessions/{session_id}/artifacts")
+        assert listed.status_code == 200, listed.text
+        body = listed.json()
+        assert body["count"] == 2
+        rel_paths = {item["rel_path"] for item in body["items"]}
+        assert rel_paths == {"chart.png", "sub/rows.csv"}
+
+        downloaded = await http.get(
+            f"/api/v1/sessions/{session_id}/artifacts/file",
+            params={"path": "chart.png"},
+        )
+        assert downloaded.status_code == 200
+        assert downloaded.content == b"png-bytes"
+        assert "chart.png" in downloaded.headers.get("content-disposition", "")
+
+        nested = await http.get(
+            f"/api/v1/sessions/{session_id}/artifacts/file",
+            params={"path": "sub/rows.csv"},
+        )
+        assert nested.status_code == 200
+        assert nested.text == "a,b\n1,2\n"
+
+
+async def test_download_rejects_traversal_and_missing(
+    tmp_path, monkeypatch
+) -> None:
+    async with artifacts_client(tmp_path, monkeypatch) as (http, session_id):
+        for bad in ("../secret.txt", "../../secret.txt", "..%2Fsecret.txt", ""):
+            response = await http.get(
+                f"/api/v1/sessions/{session_id}/artifacts/file",
+                params={"path": bad},
+            )
+            assert response.status_code in (404, 422), (bad, response.text)
+
+        missing = await http.get(
+            f"/api/v1/sessions/{session_id}/artifacts/file",
+            params={"path": "nope.bin"},
+        )
+        assert missing.status_code == 404
+
+
+async def test_unknown_session_is_not_found(tmp_path, monkeypatch) -> None:
+    async with artifacts_client(tmp_path, monkeypatch) as (http, _session_id):
+        response = await http.get("/api/v1/sessions/ses_missing/artifacts")
+        assert response.status_code == 404

--- a/packages/qwenpaw-data-host-core/tests/test_artifacts_api.py
+++ b/packages/qwenpaw-data-host-core/tests/test_artifacts_api.py
@@ -70,7 +70,18 @@ async def test_download_rejects_traversal_and_missing(
     tmp_path, monkeypatch
 ) -> None:
     async with artifacts_client(tmp_path, monkeypatch) as (http, session_id):
-        for bad in ("../secret.txt", "../../secret.txt", "..%2Fsecret.txt", ""):
+        for bad in (
+            "../secret.txt",
+            "../../secret.txt",
+            "..%2Fsecret.txt",
+            "",
+            "/etc/hosts",
+            "~/secret.txt",
+            "sub/../../secret.txt",
+            "sub\\..\\secret.txt",
+            "./chart.png",
+            "sub//rows.csv",
+        ):
             response = await http.get(
                 f"/api/v1/sessions/{session_id}/artifacts/file",
                 params={"path": bad},

--- a/packages/qwenpaw-data-host-core/tests/test_artifacts_api.py
+++ b/packages/qwenpaw-data-host-core/tests/test_artifacts_api.py
@@ -36,7 +36,7 @@ async def artifacts_client(tmp_path: Path, monkeypatch):
             artifact_dir.mkdir(parents=True, exist_ok=True)
             (artifact_dir / "chart.png").write_bytes(b"png-bytes")
             (artifact_dir / "sub").mkdir()
-            (artifact_dir / "sub" / "rows.csv").write_text("a,b\n1,2\n")
+            (artifact_dir / "sub" / "rows.csv").write_bytes(b"a,b\n1,2\n")
             (tmp_path / "secret.txt").write_text("nope")
             yield http, session_id
 


### PR DESCRIPTION
## Summary
- Add `GET /sessions/{id}/artifacts` (workspace listing) and `GET /sessions/{id}/artifacts/file?path=` download for the app's artifact panel.
- Downloads are containment-checked (resolved path must stay inside the artifact dir) with defense-in-depth rejection of dot segments, absolute/`~` paths, backslashes and NUL before resolution; session ids are validated against the store first.

## Test plan
- [x] Route tests incl. traversal matrix (`../`, encoded, embedded, backslash, dot segments): 3 passed
- [x] Full repo suite: 891 passed
- [x] L3 security review: finding remediated (dot-segment pre-check), re-scan 0 findings