### PR TITLE
fix(context): repair CORS allow-header token broken by the brand rename

### DIFF
--- a/packages/qwenpaw-data-context/src/context_manager/api/server.py
+++ b/packages/qwenpaw-data-context/src/context_manager/api/server.py
@@ -681,7 +681,7 @@ def create_app() -> FastAPI:
             "Last-Event-ID",
             "Mcp-Protocol-Version",
             "Mcp-Session-Id",
-            "X-QwenPaw Data-Run",
+            "X-Qwenpaw-Data-Run",
             "X-Neo4j-Database",
             "X-Request-ID",
         ],

--- a/packages/qwenpaw-data-context/src/context_manager/mcp/cm_server.py
+++ b/packages/qwenpaw-data-context/src/context_manager/mcp/cm_server.py
@@ -710,7 +710,7 @@ def standalone_http_app() -> Any:
             "Last-Event-ID",
             "Mcp-Protocol-Version",
             "Mcp-Session-Id",
-            "X-QwenPaw Data-Run",
+            "X-Qwenpaw-Data-Run",
             "X-Request-ID",
         ],
         expose_headers=[

--- a/packages/qwenpaw-data-context/tests/test_cors_header_tokens.py
+++ b/packages/qwenpaw-data-context/tests/test_cors_header_tokens.py
@@ -1,0 +1,61 @@
+"""CORS 头字段合法性回归测试。
+
+背景：品牌重命名曾把 allow_headers 里的 ``X-Datapaw-Run`` 误替换成含空格的
+``X-QwenPaw Data-Run``。空格不是合法的 header token 字符，浏览器会因此拒绝
+解析整个 ``Access-Control-Allow-Headers``，导致所有需要预检的跨源请求
+（如前端的 JSON POST）全部失败。本测试静态扫描包内所有 CORS 头配置，
+确保每个 token 合法。
+"""
+from __future__ import annotations
+
+import ast
+import string
+from pathlib import Path
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[1] / "src"
+
+# RFC 7230 token 字符集（header 名称合法字符）。
+_TOKEN_CHARS = set("!#$%&'*+-.^_`|~" + string.ascii_letters + string.digits)
+
+_HEADER_LIST_KWARGS = {"allow_headers", "expose_headers"}
+
+
+def _is_valid_header_token(value: str) -> bool:
+    return bool(value) and all(ch in _TOKEN_CHARS for ch in value)
+
+
+def _iter_header_tokens() -> list[tuple[Path, str]]:
+    found: list[tuple[Path, str]] = []
+    for path in sorted(PACKAGE_ROOT.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            for keyword in node.keywords:
+                if keyword.arg not in _HEADER_LIST_KWARGS:
+                    continue
+                if not isinstance(keyword.value, (ast.List, ast.Tuple)):
+                    continue
+                for element in keyword.value.elts:
+                    if isinstance(element, ast.Constant) and isinstance(
+                        element.value, str
+                    ):
+                        found.append((path, element.value))
+    return found
+
+
+def test_cors_header_configs_are_discovered() -> None:
+    tokens = _iter_header_tokens()
+    assert tokens, "expected at least one allow_headers/expose_headers config"
+
+
+def test_cors_header_tokens_are_valid() -> None:
+    invalid = [
+        f"{path.relative_to(PACKAGE_ROOT)}: {value!r}"
+        for path, value in _iter_header_tokens()
+        if not _is_valid_header_token(value)
+    ]
+    assert not invalid, (
+        "CORS header lists contain invalid header tokens (browsers reject the "
+        "entire preflight response over these): " + "; ".join(invalid)
+    )


### PR DESCRIPTION
## Summary
- The datapaw → qwenpaw-data rename corrupted the `X-Datapaw-Run` entry in both CORS `allow_headers` lists into `X-QwenPaw Data-Run`. A space is not a valid RFC 7230 header token, so Chrome rejects the entire `Access-Control-Allow-Headers` preflight response — every cross-origin JSON POST from the DataBridge frontend fails (e.g. weave-task submit), while plain GETs keep working.
- Restores the canonical `X-Qwenpaw-Data-Run` token in `context_manager/api/server.py` and `context_manager/mcp/cm_server.py`.
- Adds `test_cors_header_tokens.py`: statically validates every `allow_headers`/`expose_headers` token in the package against the RFC 7230 token charset so a future rename cannot silently break preflight again.

## Test plan
- [x] New regression test passes (and fails on the pre-fix source)
- [x] Verified live: headless-browser weave submit from the DataBridge UI got 405→200 after the fix (preflight parses again)
- [x] `tests/test_open_source_hygiene.py` green on the staged tree