### PR TITLE
fix(context): commit semantic-config writes before the response is sent

### DIFF
--- a/packages/qwenpaw-data-context/src/semantic_config/db.py
+++ b/packages/qwenpaw-data-context/src/semantic_config/db.py
@@ -41,6 +41,11 @@ async def get_db() -> AsyncIterator[aiosqlite.Connection]:
     """FastAPI 依赖：每请求一个连接、一个事务。
 
     正常结束 -> commit；抛异常 -> rollback（整请求原子，Excel 导入据此实现整体回滚）。
+
+    必须以 ``Depends(get_db, scope="function")`` 使用：commit 在 teardown 里，
+    request 作用域的 teardown 在响应发出**之后**才执行，客户端拿到 200 后立刻
+    发起的下一个请求会用新连接读到未提交的数据（写后读竞态，CI 上 metric
+    create→update 曾因此偶发 404）。function 作用域保证 commit 先于响应发送。
     """
     settings = get_settings()
     conn = await aiosqlite.connect(settings.db_path)

--- a/packages/qwenpaw-data-context/src/semantic_config/routers/biz_domain_router.py
+++ b/packages/qwenpaw-data-context/src/semantic_config/routers/biz_domain_router.py
@@ -12,13 +12,13 @@ router = APIRouter(prefix="/api/semantic-config/biz-domain", tags=["biz-domain"]
 
 
 @router.post("", response_model=BizDomainResponse)
-async def create_biz_domain(payload: BizDomainCreate, db: aiosqlite.Connection = Depends(get_db)):
+async def create_biz_domain(payload: BizDomainCreate, db: aiosqlite.Connection = Depends(get_db, scope="function")):
     return await service.create(db, payload)
 
 
 @router.put("/{domain_id}", response_model=BizDomainResponse)
 async def update_biz_domain(
-    domain_id: int, payload: BizDomainUpdate, db: aiosqlite.Connection = Depends(get_db)
+    domain_id: int, payload: BizDomainUpdate, db: aiosqlite.Connection = Depends(get_db, scope="function")
 ):
     return await service.update(db, domain_id, payload)
 
@@ -29,16 +29,16 @@ async def list_biz_domain(
     domain_name: str | None = Query(default=None),
     page: int = Query(default=1, ge=1),
     size: int = Query(default=20, ge=1),
-    db: aiosqlite.Connection = Depends(get_db),
+    db: aiosqlite.Connection = Depends(get_db, scope="function"),
 ):
     return await service.list_page(db, datasource_id, domain_name, page, size)
 
 
 @router.get("/{domain_id}", response_model=BizDomainResponse)
-async def get_biz_domain(domain_id: int, db: aiosqlite.Connection = Depends(get_db)):
+async def get_biz_domain(domain_id: int, db: aiosqlite.Connection = Depends(get_db, scope="function")):
     return await service.get_one(db, domain_id)
 
 
 @router.delete("/{domain_id}")
-async def delete_biz_domain(domain_id: int, db: aiosqlite.Connection = Depends(get_db)):
+async def delete_biz_domain(domain_id: int, db: aiosqlite.Connection = Depends(get_db, scope="function")):
     return await service.delete(db, domain_id)

--- a/packages/qwenpaw-data-context/src/semantic_config/routers/dataset_column_meta_router.py
+++ b/packages/qwenpaw-data-context/src/semantic_config/routers/dataset_column_meta_router.py
@@ -12,22 +12,22 @@ router = APIRouter(prefix="/api/semantic-config/dataset-column-meta", tags=["dat
 
 
 @router.post("", response_model=ColumnResponse)
-async def create_column(payload: ColumnCreate, db: aiosqlite.Connection = Depends(get_db)):
+async def create_column(payload: ColumnCreate, db: aiosqlite.Connection = Depends(get_db, scope="function")):
     return await service.create(db, payload)
 
 
 @router.put("/{col_id}", response_model=ColumnResponse)
-async def update_column(col_id: int, payload: ColumnUpdate, db: aiosqlite.Connection = Depends(get_db)):
+async def update_column(col_id: int, payload: ColumnUpdate, db: aiosqlite.Connection = Depends(get_db, scope="function")):
     return await service.update(db, col_id, payload)
 
 
 @router.get("/dataset/{dataset_id}", response_model=list[ColumnResponse])
-async def list_columns_by_dataset(dataset_id: int, db: aiosqlite.Connection = Depends(get_db)):
+async def list_columns_by_dataset(dataset_id: int, db: aiosqlite.Connection = Depends(get_db, scope="function")):
     return await service.list_by_dataset(db, dataset_id)
 
 
 @router.get("/{col_id}", response_model=ColumnResponse)
-async def get_column(col_id: int, db: aiosqlite.Connection = Depends(get_db)):
+async def get_column(col_id: int, db: aiosqlite.Connection = Depends(get_db, scope="function")):
     return await service.get_one(db, col_id)
 
 
@@ -38,11 +38,11 @@ async def list_columns(
     dataset_id: int | None = Query(default=None),
     page: int = Query(default=1, ge=1),
     size: int = Query(default=20, ge=1),
-    db: aiosqlite.Connection = Depends(get_db),
+    db: aiosqlite.Connection = Depends(get_db, scope="function"),
 ):
     return await service.list_page(db, datasource_id, domain_id, dataset_id, page, size)
 
 
 @router.delete("/{col_id}")
-async def delete_column(col_id: int, db: aiosqlite.Connection = Depends(get_db)):
+async def delete_column(col_id: int, db: aiosqlite.Connection = Depends(get_db, scope="function")):
     return await service.delete(db, col_id)

--- a/packages/qwenpaw-data-context/src/semantic_config/routers/dataset_dimension_router.py
+++ b/packages/qwenpaw-data-context/src/semantic_config/routers/dataset_dimension_router.py
@@ -16,24 +16,24 @@ router = APIRouter(prefix="/api/semantic-config/dataset-dimension", tags=["datas
 
 
 @router.post("", response_model=DatasetDimensionResponse)
-async def create_binding(payload: DatasetDimensionCreate, db: aiosqlite.Connection = Depends(get_db)):
+async def create_binding(payload: DatasetDimensionCreate, db: aiosqlite.Connection = Depends(get_db, scope="function")):
     return await service.create(db, payload)
 
 
 @router.put("/{dd_id}", response_model=DatasetDimensionResponse)
 async def update_binding(
-    dd_id: int, payload: DatasetDimensionUpdate, db: aiosqlite.Connection = Depends(get_db)
+    dd_id: int, payload: DatasetDimensionUpdate, db: aiosqlite.Connection = Depends(get_db, scope="function")
 ):
     return await service.update(db, dd_id, payload)
 
 
 @router.get("/dataset/{dataset_id}", response_model=list[DatasetDimensionResponse])
-async def list_by_dataset(dataset_id: int, db: aiosqlite.Connection = Depends(get_db)):
+async def list_by_dataset(dataset_id: int, db: aiosqlite.Connection = Depends(get_db, scope="function")):
     return await service.list_by_dataset(db, dataset_id)
 
 
 @router.get("/{dd_id}", response_model=DatasetDimensionResponse)
-async def get_binding(dd_id: int, db: aiosqlite.Connection = Depends(get_db)):
+async def get_binding(dd_id: int, db: aiosqlite.Connection = Depends(get_db, scope="function")):
     return await service.get_one(db, dd_id)
 
 
@@ -46,7 +46,7 @@ async def list_binding(
     dimension_name: str | None = Query(default=None),
     page: int = Query(default=1, ge=1),
     size: int = Query(default=20, ge=1),
-    db: aiosqlite.Connection = Depends(get_db),
+    db: aiosqlite.Connection = Depends(get_db, scope="function"),
 ):
     return await service.list_page(
         db, datasource_id, domain_id, dataset_id, dataset_name, dimension_name, page, size
@@ -54,10 +54,10 @@ async def list_binding(
 
 
 @router.delete("/dataset/{dataset_id}")
-async def delete_bindings_by_dataset(dataset_id: int, db: aiosqlite.Connection = Depends(get_db)):
+async def delete_bindings_by_dataset(dataset_id: int, db: aiosqlite.Connection = Depends(get_db, scope="function")):
     return await service.delete_by_dataset(db, dataset_id)
 
 
 @router.delete("/{dd_id}")
-async def delete_binding(dd_id: int, db: aiosqlite.Connection = Depends(get_db)):
+async def delete_binding(dd_id: int, db: aiosqlite.Connection = Depends(get_db, scope="function")):
     return await service.delete(db, dd_id)

--- a/packages/qwenpaw-data-context/src/semantic_config/routers/dataset_meta_router.py
+++ b/packages/qwenpaw-data-context/src/semantic_config/routers/dataset_meta_router.py
@@ -12,19 +12,19 @@ router = APIRouter(prefix="/api/semantic-config/dataset-meta", tags=["dataset-me
 
 
 @router.post("", response_model=DatasetMetaResponse)
-async def create_dataset(payload: DatasetMetaCreate, db: aiosqlite.Connection = Depends(get_db)):
+async def create_dataset(payload: DatasetMetaCreate, db: aiosqlite.Connection = Depends(get_db, scope="function")):
     return await service.create(db, payload)
 
 
 @router.put("/{dataset_id}", response_model=DatasetMetaResponse)
 async def update_dataset(
-    dataset_id: int, payload: DatasetMetaUpdate, db: aiosqlite.Connection = Depends(get_db)
+    dataset_id: int, payload: DatasetMetaUpdate, db: aiosqlite.Connection = Depends(get_db, scope="function")
 ):
     return await service.update(db, dataset_id, payload)
 
 
 @router.get("/{dataset_id}", response_model=DatasetMetaResponse)
-async def get_dataset(dataset_id: int, db: aiosqlite.Connection = Depends(get_db)):
+async def get_dataset(dataset_id: int, db: aiosqlite.Connection = Depends(get_db, scope="function")):
     return await service.get_one(db, dataset_id)
 
 
@@ -36,11 +36,11 @@ async def list_dataset(
     dataset_type: str | None = Query(default=None),
     page: int = Query(default=1, ge=1),
     size: int = Query(default=20, ge=1),
-    db: aiosqlite.Connection = Depends(get_db),
+    db: aiosqlite.Connection = Depends(get_db, scope="function"),
 ):
     return await service.list_page(db, datasource_id, domain_id, dataset_name, dataset_type, page, size)
 
 
 @router.delete("/{dataset_id}")
-async def delete_dataset(dataset_id: int, db: aiosqlite.Connection = Depends(get_db)):
+async def delete_dataset(dataset_id: int, db: aiosqlite.Connection = Depends(get_db, scope="function")):
     return await service.delete(db, dataset_id)

--- a/packages/qwenpaw-data-context/src/semantic_config/routers/datasource_router.py
+++ b/packages/qwenpaw-data-context/src/semantic_config/routers/datasource_router.py
@@ -26,7 +26,7 @@ async def list_datasource_metadata(
     datasource_type: str | None = Query(default=None),
     page: int = Query(default=1, ge=1),
     size: int = Query(default=20, ge=1),
-    db: aiosqlite.Connection = Depends(get_db),
+    db: aiosqlite.Connection = Depends(get_db, scope="function"),
 ):
     """List datasource identity/type without returning connection config."""
     return await service.list_metadata_page(
@@ -35,7 +35,7 @@ async def list_datasource_metadata(
 
 
 @router.post("", response_model=DatasourceResponse)
-async def create_datasource(payload: DatasourceCreate, db: aiosqlite.Connection = Depends(get_db)):
+async def create_datasource(payload: DatasourceCreate, db: aiosqlite.Connection = Depends(get_db, scope="function")):
     return await service.create(db, payload)
 
 
@@ -46,7 +46,7 @@ async def list_datasource(
     datasource_type: str | None = Query(default=None),
     page: int = Query(default=1, ge=1),
     size: int = Query(default=20, ge=1),
-    db: aiosqlite.Connection = Depends(get_db),
+    db: aiosqlite.Connection = Depends(get_db, scope="function"),
 ):
     return await service.list_page(db, datasource_id, datasource_name, datasource_type, page, size)
 
@@ -58,26 +58,26 @@ async def test_connection(payload: ConnectionTestRequest):
 
 
 @router.get("/{datasource_id}", response_model=DatasourceResponse)
-async def get_datasource(datasource_id: str, db: aiosqlite.Connection = Depends(get_db)):
+async def get_datasource(datasource_id: str, db: aiosqlite.Connection = Depends(get_db, scope="function")):
     return await service.get_one(db, datasource_id)
 
 
 @router.put("/{datasource_id}", response_model=DatasourceResponse)
 async def update_datasource(
-    datasource_id: str, payload: DatasourceUpdate, db: aiosqlite.Connection = Depends(get_db)
+    datasource_id: str, payload: DatasourceUpdate, db: aiosqlite.Connection = Depends(get_db, scope="function")
 ):
     return await service.update(db, datasource_id, payload)
 
 
 @router.post("/{datasource_id}/test-connection", response_model=ConnectionTestResponse)
-async def test_connection_by_id(datasource_id: str, db: aiosqlite.Connection = Depends(get_db)):
+async def test_connection_by_id(datasource_id: str, db: aiosqlite.Connection = Depends(get_db, scope="function")):
     """测试已保存数据源的连接。"""
     return await service.test_connection_by_id(db, datasource_id)
 
 
 @router.delete("/{datasource_id}")
 async def delete_datasource(
-    datasource_id: str, request: Request, db: aiosqlite.Connection = Depends(get_db)
+    datasource_id: str, request: Request, db: aiosqlite.Connection = Depends(get_db, scope="function")
 ):
     driver = getattr(request.app.state, "driver", None)
     return await service.delete(db, datasource_id, driver=driver)

--- a/packages/qwenpaw-data-context/src/semantic_config/routers/dimension_router.py
+++ b/packages/qwenpaw-data-context/src/semantic_config/routers/dimension_router.py
@@ -12,12 +12,12 @@ router = APIRouter(prefix="/api/semantic-config/dimension", tags=["dimension"])
 
 
 @router.post("", response_model=DimensionResponse)
-async def create_dimension(payload: DimensionCreate, db: aiosqlite.Connection = Depends(get_db)):
+async def create_dimension(payload: DimensionCreate, db: aiosqlite.Connection = Depends(get_db, scope="function")):
     return await service.create(db, payload)
 
 
 @router.put("/{dim_id}", response_model=DimensionResponse)
-async def update_dimension(dim_id: int, payload: DimensionUpdate, db: aiosqlite.Connection = Depends(get_db)):
+async def update_dimension(dim_id: int, payload: DimensionUpdate, db: aiosqlite.Connection = Depends(get_db, scope="function")):
     return await service.update(db, dim_id, payload)
 
 
@@ -28,16 +28,16 @@ async def list_dimension(
     dimension_name: str | None = Query(default=None),
     page: int = Query(default=1, ge=1),
     size: int = Query(default=20, ge=1),
-    db: aiosqlite.Connection = Depends(get_db),
+    db: aiosqlite.Connection = Depends(get_db, scope="function"),
 ):
     return await service.list_page(db, datasource_id, domain_id, dimension_name, page, size)
 
 
 @router.get("/{dim_id}", response_model=DimensionResponse)
-async def get_dimension(dim_id: int, db: aiosqlite.Connection = Depends(get_db)):
+async def get_dimension(dim_id: int, db: aiosqlite.Connection = Depends(get_db, scope="function")):
     return await service.get_one(db, dim_id)
 
 
 @router.delete("/{dim_id}")
-async def delete_dimension(dim_id: int, db: aiosqlite.Connection = Depends(get_db)):
+async def delete_dimension(dim_id: int, db: aiosqlite.Connection = Depends(get_db, scope="function")):
     return await service.delete(db, dim_id)

--- a/packages/qwenpaw-data-context/src/semantic_config/routers/import_router.py
+++ b/packages/qwenpaw-data-context/src/semantic_config/routers/import_router.py
@@ -15,7 +15,7 @@ router = APIRouter(prefix="/api/semantic-config/import", tags=["import"])
 @router.post("/excel")
 async def import_excel(
     file: UploadFile | None = File(default=None),
-    db: aiosqlite.Connection = Depends(get_db),
+    db: aiosqlite.Connection = Depends(get_db, scope="function"),
 ):
     if file is None:
         raise BadRequestError("上传文件不能为空")

--- a/packages/qwenpaw-data-context/src/semantic_config/routers/metric_formula_lib_router.py
+++ b/packages/qwenpaw-data-context/src/semantic_config/routers/metric_formula_lib_router.py
@@ -12,22 +12,22 @@ router = APIRouter(prefix="/api/semantic-config/metric-formula-lib", tags=["metr
 
 
 @router.post("", response_model=FormulaResponse)
-async def create_formula(payload: FormulaCreate, db: aiosqlite.Connection = Depends(get_db)):
+async def create_formula(payload: FormulaCreate, db: aiosqlite.Connection = Depends(get_db, scope="function")):
     return await service.create(db, payload)
 
 
 @router.put("/{fid}", response_model=FormulaResponse)
-async def update_formula(fid: int, payload: FormulaUpdate, db: aiosqlite.Connection = Depends(get_db)):
+async def update_formula(fid: int, payload: FormulaUpdate, db: aiosqlite.Connection = Depends(get_db, scope="function")):
     return await service.update(db, fid, payload)
 
 
 @router.get("/dataset/{dataset_id}", response_model=list[FormulaResponse])
-async def list_formulas_by_dataset(dataset_id: int, db: aiosqlite.Connection = Depends(get_db)):
+async def list_formulas_by_dataset(dataset_id: int, db: aiosqlite.Connection = Depends(get_db, scope="function")):
     return await service.list_by_dataset(db, dataset_id)
 
 
 @router.get("/{fid}", response_model=FormulaResponse)
-async def get_formula(fid: int, db: aiosqlite.Connection = Depends(get_db)):
+async def get_formula(fid: int, db: aiosqlite.Connection = Depends(get_db, scope="function")):
     return await service.get_one(db, fid)
 
 
@@ -39,16 +39,16 @@ async def list_formula(
     dataset_id: int | None = Query(default=None),
     page: int = Query(default=1, ge=1),
     size: int = Query(default=20, ge=1),
-    db: aiosqlite.Connection = Depends(get_db),
+    db: aiosqlite.Connection = Depends(get_db, scope="function"),
 ):
     return await service.list_page(db, datasource_id, domain_id, metric_id, dataset_id, page, size)
 
 
 @router.delete("/dataset/{dataset_id}")
-async def delete_formulas_by_dataset(dataset_id: int, db: aiosqlite.Connection = Depends(get_db)):
+async def delete_formulas_by_dataset(dataset_id: int, db: aiosqlite.Connection = Depends(get_db, scope="function")):
     return await service.delete_by_dataset(db, dataset_id)
 
 
 @router.delete("/{fid}")
-async def delete_formula(fid: int, db: aiosqlite.Connection = Depends(get_db)):
+async def delete_formula(fid: int, db: aiosqlite.Connection = Depends(get_db, scope="function")):
     return await service.delete(db, fid)

--- a/packages/qwenpaw-data-context/src/semantic_config/routers/metric_lib_router.py
+++ b/packages/qwenpaw-data-context/src/semantic_config/routers/metric_lib_router.py
@@ -12,17 +12,17 @@ router = APIRouter(prefix="/api/semantic-config/metric-lib", tags=["metric-lib"]
 
 
 @router.post("", response_model=MetricResponse)
-async def create_metric(payload: MetricCreate, db: aiosqlite.Connection = Depends(get_db)):
+async def create_metric(payload: MetricCreate, db: aiosqlite.Connection = Depends(get_db, scope="function")):
     return await service.create(db, payload)
 
 
 @router.put("/{metric_id}", response_model=MetricResponse)
-async def update_metric(metric_id: int, payload: MetricUpdate, db: aiosqlite.Connection = Depends(get_db)):
+async def update_metric(metric_id: int, payload: MetricUpdate, db: aiosqlite.Connection = Depends(get_db, scope="function")):
     return await service.update(db, metric_id, payload)
 
 
 @router.get("/{metric_id}", response_model=MetricResponse)
-async def get_metric(metric_id: int, db: aiosqlite.Connection = Depends(get_db)):
+async def get_metric(metric_id: int, db: aiosqlite.Connection = Depends(get_db, scope="function")):
     return await service.get_one(db, metric_id)
 
 
@@ -33,11 +33,11 @@ async def list_metric(
     metric_name: str | None = Query(default=None),
     page: int = Query(default=1, ge=1),
     size: int = Query(default=20, ge=1),
-    db: aiosqlite.Connection = Depends(get_db),
+    db: aiosqlite.Connection = Depends(get_db, scope="function"),
 ):
     return await service.list_page(db, datasource_id, domain_id, metric_name, page, size)
 
 
 @router.delete("/{metric_id}")
-async def delete_metric(metric_id: int, db: aiosqlite.Connection = Depends(get_db)):
+async def delete_metric(metric_id: int, db: aiosqlite.Connection = Depends(get_db, scope="function")):
     return await service.delete(db, metric_id)

--- a/packages/qwenpaw-data-context/src/semantic_config/routers/weave_task_router.py
+++ b/packages/qwenpaw-data-context/src/semantic_config/routers/weave_task_router.py
@@ -15,7 +15,7 @@ router = APIRouter(prefix="/api/semantic-config/weave-task", tags=["weave-task"]
 async def submit_task(
     payload: WeaveTaskSubmit,
     request: Request,
-    db: aiosqlite.Connection = Depends(get_db),
+    db: aiosqlite.Connection = Depends(get_db, scope="function"),
 ):
     driver = getattr(request.app.state, "driver", None)
     governor = getattr(request.app.state, "blocking_io", None)
@@ -28,16 +28,16 @@ async def list_task(
     task_name: str | None = Query(default=None),
     page: int = Query(default=1, ge=1),
     size: int = Query(default=20, ge=1),
-    db: aiosqlite.Connection = Depends(get_db),
+    db: aiosqlite.Connection = Depends(get_db, scope="function"),
 ):
     return await service.list_page(db, datasource_name, task_name, page, size)
 
 
 @router.post("/{task_id}/kill", response_model=WeaveTaskResponse)
-async def kill_task(task_id: str, db: aiosqlite.Connection = Depends(get_db)):
+async def kill_task(task_id: str, db: aiosqlite.Connection = Depends(get_db, scope="function")):
     return await service.kill(db, task_id)
 
 
 @router.post("/callback", response_model=WeaveTaskResponse)
-async def callback_task(payload: WeaveTaskCallback, db: aiosqlite.Connection = Depends(get_db)):
+async def callback_task(payload: WeaveTaskCallback, db: aiosqlite.Connection = Depends(get_db, scope="function")):
     return await service.callback(db, payload)

--- a/packages/qwenpaw-data-context/tests/test_semantic_db_dependency_scope.py
+++ b/packages/qwenpaw-data-context/tests/test_semantic_db_dependency_scope.py
@@ -1,0 +1,57 @@
+"""semantic_config DB 依赖作用域回归测试。
+
+``get_db`` 的 commit 在依赖 teardown 里执行。FastAPI 默认（request 作用域）
+在响应发出**之后**才运行 teardown，客户端拿到 200 后立刻发起的下一个请求会
+用新连接读不到未提交的写入（CI 上 metric create→update 偶发 404 的根因）。
+所有 ``Depends(get_db)`` 必须显式 ``scope="function"``，让 commit 先于响应。
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ROUTERS_DIR = (
+    Path(__file__).resolve().parents[1] / "src" / "semantic_config" / "routers"
+)
+
+
+def _iter_get_db_depends() -> list[tuple[Path, int, str | None]]:
+    found: list[tuple[Path, int, str | None]] = []
+    for path in sorted(ROUTERS_DIR.glob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            if not (isinstance(node.func, ast.Name) and node.func.id == "Depends"):
+                continue
+            if not (
+                node.args
+                and isinstance(node.args[0], ast.Name)
+                and node.args[0].id == "get_db"
+            ):
+                continue
+            scope = None
+            for keyword in node.keywords:
+                if keyword.arg == "scope" and isinstance(
+                    keyword.value, ast.Constant
+                ):
+                    scope = keyword.value.value
+            found.append((path, node.lineno, scope))
+    return found
+
+
+def test_get_db_dependencies_are_discovered() -> None:
+    assert _iter_get_db_depends(), "expected Depends(get_db) usages in routers"
+
+
+def test_get_db_dependencies_use_function_scope() -> None:
+    offenders = [
+        f"{path.name}:{line} scope={scope!r}"
+        for path, line, scope in _iter_get_db_depends()
+        if scope != "function"
+    ]
+    assert not offenders, (
+        "Depends(get_db) must pass scope=\"function\" so the per-request "
+        "commit runs before the response is sent (read-after-write race "
+        "otherwise): " + "; ".join(offenders)
+    )


### PR DESCRIPTION
## Summary
- Root-causes the flaky **Deterministic CLI demo smoke** failures (first seen on the merge run of #54, also hit PR #56): `semantic metric create` → `update` intermittently 404s with `指标不存在: id=2` on loaded runners.
- `get_db` commits in its teardown, and FastAPI's default (request-scoped) teardown runs **after** the response is sent — so the CLI's next call can open a fresh SQLite connection before the previous write commits (classic read-after-write race; WAL readers see the pre-commit snapshot).
- Every `Depends(get_db)` in the semantic-config routers (52 sites) now passes `scope="function"`, which closes the dependency — and commits — before the response goes out. No semantic-config endpoint streams from the connection, so the earlier close is safe.
- Adds an AST regression test enforcing the scope contract for future routers.

## Test plan
- [x] `test_semantic_db_dependency_scope.py` (new) passes and fails when a router drops the scope
- [x] Full context package suite: 214 passed
- [x] `examples/semantic_smoke_test.py` green locally against the demo Postgres