### PR TITLE
feat(host-core): session file uploads and console-shaped chat routes

### DIFF
--- a/packages/qwenpaw-data-host-core/pyproject.toml
+++ b/packages/qwenpaw-data-host-core/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
 [project.optional-dependencies]
 service = [
   "fastapi>=0.115,<1.0",
+  "python-multipart>=0.0.18,<1.0",
   "sqlalchemy[asyncio]>=2.0,<3.0",
   "aiosqlite>=0.20,<1.0",
   "cryptography>=44,<51",

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/app.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/app.py
@@ -30,6 +30,7 @@ from qwenpaw_data.host.core.api.routers import artifacts as artifacts_router
 from qwenpaw_data.host.core.api.routers import channels as channels_router
 from qwenpaw_data.host.core.api.routers import chats as chats_router
 from qwenpaw_data.host.core.api.routers import clarification as clarification_router
+from qwenpaw_data.host.core.api.routers import console as console_router
 from qwenpaw_data.host.core.api.routers import cron as cron_router
 from qwenpaw_data.host.core.api.routers import datasources as datasources_router
 from qwenpaw_data.host.core.api.routers import events as events_router
@@ -46,6 +47,7 @@ from qwenpaw_data.host.core.registry import QwenPawDataHostRegistry
 from qwenpaw_data.host.core.runtime.registry import reset_runtime_registry
 from qwenpaw_data.host.core.channels import ChannelManager, ChannelServices
 from qwenpaw_data.host.core.store.json_store import (
+    JSONAttachmentStore,
     JSONChannelBindingStore,
     JSONChannelConfigStore,
     JSONChatEventStore,
@@ -111,6 +113,7 @@ def create_app(
             settlement_store: Any = JSONSettlementStore(store_root)
             channel_config_store: Any = JSONChannelConfigStore(store_root)
             channel_binding_store: Any = JSONChannelBindingStore(store_root)
+            attachment_store: Any = JSONAttachmentStore(store_root)
         else:
             from qwenpaw_data.host.core.db.engine import (
                 create_engine_and_factory,
@@ -118,6 +121,7 @@ def create_app(
                 resolve_db_url,
             )
             from qwenpaw_data.host.core.store.sql_store import (
+                SQLAttachmentStore,
                 SQLChannelBindingStore,
                 SQLChannelConfigStore,
                 SQLChatEventStore,
@@ -140,6 +144,7 @@ def create_app(
             settlement_store = SQLSettlementStore(factory)
             channel_config_store = SQLChannelConfigStore(factory)
             channel_binding_store = SQLChannelBindingStore(factory)
+            attachment_store = SQLAttachmentStore(factory)
 
         async def resolve_model() -> Any:
             """Prefer the local user's configured default model over env."""
@@ -171,6 +176,7 @@ def create_app(
             settlement=settlement_store,
             channel_configs=channel_config_store,
             channel_bindings=channel_binding_store,
+            attachments=attachment_store,
             hosts=QwenPawDataHostRegistry(
                 home=resolved_home,
                 model=model,
@@ -251,6 +257,7 @@ def create_app(
     app.add_exception_handler(HTTPException, http_exception_handler)
     app.include_router(sessions_router.router, prefix="/api/v1")
     app.include_router(chats_router.router, prefix="/api/v1")
+    app.include_router(console_router.router, prefix="/api/v1")
     app.include_router(events_router.router, prefix="/api/v1")
     app.include_router(steer_router.router, prefix="/api/v1")
     app.include_router(clarification_router.router, prefix="/api/v1")

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/deps.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/deps.py
@@ -10,6 +10,7 @@ from fastapi import Request
 from qwenpaw_data.host.core.domain.identity import Identity
 from qwenpaw_data.host.core.registry import QwenPawDataHostRegistry
 from qwenpaw_data.host.core.store.protocols import (
+    AttachmentStore,
     ChannelBindingStore,
     ChannelConfigStore,
     ChatEventStore,
@@ -31,6 +32,7 @@ class ServiceState:
     settlement: SettlementStore
     channel_configs: ChannelConfigStore
     channel_bindings: ChannelBindingStore
+    attachments: AttachmentStore
     hosts: QwenPawDataHostRegistry
     cron_manager: Any = None
     channel_manager: Any = None

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/mappers.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/mappers.py
@@ -130,4 +130,6 @@ def chat_to_schema(chat: Chat) -> dict[str, Any]:
         active_duration_ms=chat.active_duration_ms,
         error=ChatErrorSchema(**chat.error) if chat.error else None,
         plan=chat.plan,
+        artifact_comments=chat.artifact_comments,  # type: ignore[arg-type]
+        attachments=chat.attachments,  # type: ignore[arg-type]
     ).model_dump(mode="json")

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/models/artifact.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/models/artifact.py
@@ -14,3 +14,10 @@ class ArtifactSchema(ApiModel):
     path: str
     created_at: datetime
     updated_at: datetime
+
+
+class ArtifactCommentSchema(ApiModel):
+    path: str
+    line_start: int
+    line_end: int
+    comment: str

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/models/chat.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/models/chat.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Literal
 
-from qwenpaw_data.host.core.api.models.common import ApiModel
+from qwenpaw_data.host.core.api.models.artifact import ArtifactCommentSchema
+from qwenpaw_data.host.core.api.models.common import ApiModel, AttachmentRefSchema
 
 
 class ChatErrorSchema(ApiModel):
@@ -61,3 +62,5 @@ class ChatSchema(ApiModel):
     active_duration_ms: int = 0
     error: ChatErrorSchema | None = None
     plan: dict[str, Any] | None = None
+    artifact_comments: list[ArtifactCommentSchema] = []
+    attachments: list[AttachmentRefSchema] = []

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/models/common.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/models/common.py
@@ -16,6 +16,11 @@ class ErrorBodySchema(ApiModel):
     details: dict[str, Any] | None = None
 
 
+class AttachmentRefSchema(ApiModel):
+    attachment_id: str
+    filename: str
+
+
 class DatasourceOptionSchema(ApiModel):
     id: str
     name: str

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/models/requests.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/models/requests.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+from qwenpaw_data.host.core.api.models.artifact import ArtifactCommentSchema
 from qwenpaw_data.host.core.api.models.chat import (
     AskUserQuestionAnsweredResultSchema,
     AskUserQuestionTimeoutResultSchema,
 )
-from qwenpaw_data.host.core.api.models.common import ApiModel
+from qwenpaw_data.host.core.api.models.common import ApiModel, AttachmentRefSchema
 
 
 class CreateSessionRequest(ApiModel):
@@ -21,6 +22,15 @@ class PatchSessionRequest(ApiModel):
 class CreateChatRequest(ApiModel):
     text: str
     datasource_id: str | None = None
+
+
+class ConsoleChatRequest(ApiModel):
+    session_id: str
+    text: str
+    datasource_id: str | None = None
+    attachment_ids: list[str] = []
+    attachments: list[AttachmentRefSchema] | None = None
+    artifact_comments: list[ArtifactCommentSchema] = []
 
 
 class SteerRequest(ApiModel):

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/routers/console.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/routers/console.py
@@ -1,0 +1,157 @@
+# -*- coding: utf-8 -*-
+"""Console-shaped compat routes: uploads and attachment-aware chat."""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, Depends, File, Form, Query, UploadFile
+from fastapi.responses import Response
+
+from qwenpaw_data.host.core.api.deps import ServiceState, get_identity, get_state
+from qwenpaw_data.host.core.api.errors import map_domain_error
+from qwenpaw_data.host.core.api.mappers import chat_to_schema
+from qwenpaw_data.host.core.api.models.common import AttachmentRefSchema
+from qwenpaw_data.host.core.api.models.requests import ConsoleChatRequest
+from qwenpaw_data.host.core.domain.attachment import Attachment
+from qwenpaw_data.host.core.domain.identity import Identity
+from qwenpaw_data.host.core.runtime.chat_runtime import ChatRuntime
+from qwenpaw_data.host.core.runtime.registry import get_runtime_registry
+from qwenpaw_data.host.core.stream.output_stream import OutputStream
+
+router = APIRouter(prefix="/console", tags=["console"])
+
+
+def _workspace(state: ServiceState, session_id: str) -> Path:
+    return Path(state.hosts.get(session_id=session_id).paths.workspace)
+
+
+def _uploads_dir(state: ServiceState, session_id: str) -> Path:
+    return _workspace(state, session_id) / "uploads" / session_id
+
+
+def _raise(exc: Exception) -> None:
+    http = map_domain_error(exc)
+    if http:
+        raise http from exc
+    raise exc
+
+
+@router.post("/upload")
+async def upload_attachment(
+    session_id: str = Form(...),
+    file: UploadFile = File(...),
+    identity: Identity = Depends(get_identity),
+    state: ServiceState = Depends(get_state),
+) -> dict[str, Any]:
+    try:
+        if not file.filename:
+            raise ValueError("filename is required")
+        session = await state.sessions.get(session_id)
+        filename = Path(file.filename).name
+        if await state.attachments.find_by_filename(
+            session.identity.user_id, session.id, filename
+        ):
+            raise ValueError(f"duplicate filename: {filename}")
+        attachment = await asyncio.to_thread(
+            Attachment.receive,
+            session_id=session.id,
+            identity=identity,
+            filename=filename,
+            data=await file.read(),
+            dest_dir=_uploads_dir(state, session.id),
+        )
+        await state.attachments.add(attachment)
+    except Exception as exc:
+        _raise(exc)
+    return {"attachment": AttachmentRefSchema.model_validate(attachment.to_ref())}
+
+
+@router.delete("/attachments/{attachment_id}", status_code=204)
+async def delete_attachment(
+    attachment_id: str,
+    identity: Identity = Depends(get_identity),
+    state: ServiceState = Depends(get_state),
+) -> Response:
+    try:
+        attachment = await state.attachments.get(identity.user_id, attachment_id)
+        session = await state.sessions.get(attachment.session_id)
+        chats = await state.chats.list_for_session(session.id)
+        if any(chat.references_attachment(attachment.id) for chat in chats):
+            raise RuntimeError("CONFLICT: attachment is used by a chat")
+        await asyncio.to_thread(
+            attachment.remove_file, _workspace(state, session.id)
+        )
+        await state.attachments.delete(identity.user_id, attachment.id)
+    except Exception as exc:
+        _raise(exc)
+    return Response(status_code=204)
+
+
+@router.post("/chat")
+async def console_chat(
+    body: ConsoleChatRequest,
+    identity: Identity = Depends(get_identity),
+    state: ServiceState = Depends(get_state),
+) -> dict[str, Any]:
+    try:
+        session = await state.sessions.get(body.session_id)
+        attachments = await state.attachments.require_for_session(
+            session.identity.user_id,
+            session.id,
+            body.attachment_ids,
+            workspace=_workspace(state, session.id),
+        )
+        chat = session.open_chat(
+            text=body.text,
+            datasource_id=body.datasource_id,
+            has_active_chat=await state.sessions.has_active_chat(session.id),
+            artifact_comments=[
+                item.model_dump(mode="json") for item in body.artifact_comments
+            ],
+            attachments=[item.to_ref() for item in attachments],
+        )
+        await state.sessions.save(session)
+        await state.chats.add(chat)
+    except Exception as exc:
+        _raise(exc)
+    runtime = ChatRuntime(
+        chats=state.chats,
+        events=state.events,
+        hosts=state.hosts,
+        prefs=state.prefs,
+        sessions=state.sessions,
+        settlement=state.settlement,
+    )
+    state.track(asyncio.create_task(runtime.run(chat.id, identity=identity)))
+    return {"chat": chat_to_schema(chat)}
+
+
+@router.post("/chat/stop")
+async def stop_chat(
+    session_id: str = Query(...),
+    chat_id: str = Query(...),
+    identity: Identity = Depends(get_identity),
+    state: ServiceState = Depends(get_state),
+) -> dict[str, Any]:
+    _ = identity
+    try:
+        chat = await state.chats.get(chat_id, session_id=session_id)
+        runtime = get_runtime_registry().get(chat_id)
+        if runtime is not None:
+            await runtime.cancel()
+            chat = await state.chats.get(chat_id, session_id=session_id)
+        elif chat.status == "running":
+            await OutputStream(
+                state.events,
+                session_id=session_id,
+                chat_id=chat_id,
+                identity=chat.identity,
+            ).response_cancelled()
+            chat.cancel()
+            await state.chats.reload_event_watermark(chat)
+            await state.chats.save(chat)
+    except Exception as exc:
+        _raise(exc)
+    return {"chat": chat_to_schema(chat)}

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/db/tables.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/db/tables.py
@@ -70,10 +70,26 @@ class ChatRow(UserIdColumn, Base):
     active_duration_ms: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     error_json: Mapped[dict | None] = mapped_column(JSON, nullable=True)
     plan: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    artifact_comments_json: Mapped[list] = mapped_column(
+        JSON, nullable=False, default=list
+    )
+    attachments_json: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=utcnow
     )
     updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=utcnow
+    )
+
+
+class AttachmentRow(UserIdColumn, Base):
+    __tablename__ = "attachments"
+
+    attachment_id: Mapped[str] = mapped_column(String, primary_key=True)
+    session_id: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    filename: Mapped[str] = mapped_column(String, nullable=False)
+    storage_path: Mapped[str] = mapped_column(String, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=utcnow
     )
 

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/domain/attachment.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/domain/attachment.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from qwenpaw_data.host.core.domain.identity import Identity
+from qwenpaw_data.host.core.utils.ids import create_id
+from qwenpaw_data.host.core.utils.safe_name import require_safe_name
+from qwenpaw_data.host.core.utils.time import utcnow
+
+MAX_SIZE_BYTES = 20 * 1024 * 1024
+
+
+def uploads_relative_path(session_id: str, filename: str) -> str:
+    return f"uploads/{session_id}/{filename}"
+
+
+@dataclass
+class Attachment:
+    id: str
+    session_id: str
+    identity: Identity
+    filename: str
+    storage_path: str
+    created_at: datetime
+
+    @classmethod
+    def receive(
+        cls,
+        *,
+        session_id: str,
+        identity: Identity,
+        filename: str,
+        data: bytes,
+        dest_dir: Path,
+    ) -> Attachment:
+        name = require_safe_name(filename)
+        if not data:
+            raise ValueError("file is empty")
+        if len(data) > MAX_SIZE_BYTES:
+            raise ValueError("file exceeds 20MB")
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        dest = dest_dir / name
+        if dest.exists():
+            raise ValueError(f"duplicate filename: {name}")
+        dest.write_bytes(data)
+        return cls(
+            id=create_id("att"),
+            session_id=session_id,
+            identity=identity,
+            filename=name,
+            storage_path=uploads_relative_path(session_id, name),
+            created_at=utcnow(),
+        )
+
+    def to_ref(self) -> dict[str, Any]:
+        return {"attachment_id": self.id, "filename": self.filename}
+
+    def require_file(self, workspace: Path) -> Path:
+        path = (workspace / self.storage_path).resolve()
+        root = workspace.resolve()
+        if not path.is_relative_to(root):
+            raise ValueError("attachment path escapes workspace")
+        if not path.is_file():
+            raise LookupError("attachment file not found")
+        return path
+
+    def remove_file(self, workspace: Path) -> None:
+        path = workspace / self.storage_path
+        if path.is_file():
+            path.unlink()

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/domain/chat.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/domain/chat.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any
 
@@ -31,6 +31,8 @@ class Chat:
     plan: dict[str, Any] | None
     created_at: datetime
     updated_at: datetime
+    artifact_comments: list[dict[str, Any]] = field(default_factory=list)
+    attachments: list[dict[str, Any]] = field(default_factory=list)
 
     @classmethod
     def start(
@@ -41,8 +43,11 @@ class Chat:
         sequence: int,
         datasource_id: str | None,
         text: str,
+        artifact_comments: list[dict[str, Any]] | None = None,
+        attachments: list[dict[str, Any]] | None = None,
     ) -> Chat:
-        if not text.strip():
+        refs = list(attachments or [])
+        if not text.strip() and not refs:
             raise ValueError("text is required")
 
         now = utcnow()
@@ -63,6 +68,13 @@ class Chat:
             plan=None,
             created_at=now,
             updated_at=now,
+            artifact_comments=list(artifact_comments or []),
+            attachments=refs,
+        )
+
+    def references_attachment(self, attachment_id: str) -> bool:
+        return any(
+            item.get("attachment_id") == attachment_id for item in self.attachments
         )
 
     def cancel(self) -> None:

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/domain/session.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/domain/session.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 from qwenpaw_data.host.core.domain.chat import Chat
 from qwenpaw_data.host.core.domain.identity import Identity
@@ -71,6 +72,8 @@ class Session:
         text: str,
         datasource_id: str | None,
         has_active_chat: bool,
+        artifact_comments: list[dict[str, Any]] | None = None,
+        attachments: list[dict[str, Any]] | None = None,
     ) -> Chat:
         if has_active_chat:
             raise RuntimeError("CONFLICT: session already has an active chat")
@@ -84,6 +87,8 @@ class Session:
             sequence=sequence,
             datasource_id=self.datasource_id,
             text=text,
+            artifact_comments=artifact_comments,
+            attachments=attachments,
         )
 
     def register_chat(self) -> int:

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/runtime/executor.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/runtime/executor.py
@@ -17,7 +17,7 @@ from agentscope.message import UserMsg
 from qwenpaw_data.host.core.agent.middleware import SteerMiddleware
 from qwenpaw_data.host.core.domain.clarification import ClarificationWithExecutor
 from qwenpaw_data.host.core.runtime.envelope import Envelope
-from qwenpaw_data.host.core.runtime.turn import TurnInput
+from qwenpaw_data.host.core.runtime.turn import TurnInput, compose_agent_input
 from qwenpaw_data.host.core.utils.agent import close_interrupted_tool_calls
 
 
@@ -63,7 +63,12 @@ class AgentExecutor:
     ) -> None:
         inputs: Any = UserMsg(
             name="user",
-            content=turn.user_input,
+            content=compose_agent_input(
+                turn.user_input,
+                turn.artifact_comments,
+                turn.attachments,
+                session_id=turn.session_id,
+            ),
         )
 
         while True:

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/runtime/turn.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/runtime/turn.py
@@ -1,16 +1,79 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import Any
 
+from qwenpaw_data.host.core.domain.attachment import uploads_relative_path
 from qwenpaw_data.host.core.domain.chat import Chat
+
+_COMMENT_KEYS = ("path", "line_start", "line_end", "comment")
+_ATTACHMENT_KEYS = ("attachment_id", "filename")
+
+
+def compose_agent_input(
+    text: str,
+    artifact_comments: list[dict[str, Any]] | None,
+    attachments: list[dict[str, Any]] | None = None,
+    *,
+    session_id: str | None = None,
+) -> str:
+    parts: list[str] = []
+    refs = list(attachments or [])
+    if refs:
+        if not session_id:
+            raise ValueError("session_id is required")
+        parts.append(_compose_attachments(refs, session_id))
+    comments = list(artifact_comments or [])
+    if comments:
+        parts.append(_compose_comments(comments))
+    if text.strip():
+        parts.append(text)
+    if not parts:
+        return text
+    return "\n\n".join(parts)
+
+
+def _compose_comments(comments: list[dict[str, Any]]) -> str:
+    lines = ["用户对成果文件的评论："]
+    for item in comments:
+        missing = [key for key in _COMMENT_KEYS if item.get(key) is None]
+        if missing:
+            raise ValueError(f"artifact comment missing {', '.join(missing)}")
+        start = item["line_start"]
+        end = item["line_end"]
+        loc = f"第 {start} 行" if start == end else f"第 {start}-{end} 行"
+        lines.append(f"- 文件 `{item['path']}` {loc}：{item['comment']}")
+    return "\n".join(lines)
+
+
+def _compose_attachments(attachments: list[dict[str, Any]], session_id: str) -> str:
+    lines = [
+        "用户上传了以下附件（路径相对 workspace 根目录，请用 Read / Glob / Bash 等工具读取，不要凭文件名臆造内容）："
+    ]
+    for item in attachments:
+        missing = [key for key in _ATTACHMENT_KEYS if item.get(key) is None]
+        if missing:
+            raise ValueError(f"attachment missing {', '.join(missing)}")
+        path = uploads_relative_path(session_id, item["filename"])
+        lines.append(f"- `{path}`")
+    return "\n".join(lines)
 
 
 @dataclass(frozen=True)
 class TurnInput:
     chat_id: str
     user_input: str
+    artifact_comments: list[dict[str, Any]] = field(default_factory=list)
+    attachments: list[dict[str, Any]] = field(default_factory=list)
+    session_id: str = ""
 
     @classmethod
     def from_chat(cls, chat: Chat) -> TurnInput:
-        return cls(chat_id=chat.id, user_input=chat.user_input)
+        return cls(
+            chat_id=chat.id,
+            user_input=chat.user_input,
+            artifact_comments=list(chat.artifact_comments),
+            attachments=list(chat.attachments),
+            session_id=chat.session_id,
+        )

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/store/json_store.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/store/json_store.py
@@ -20,6 +20,7 @@ from qwenpaw_data.host.core.api.models.stream_objects import (
     parse_stream_object,
 )
 from qwenpaw_data.host.core.api.models.cron import CronJobWrite, ScheduleSpec
+from qwenpaw_data.host.core.domain.attachment import Attachment
 from qwenpaw_data.host.core.domain.chat import ACTIVE, Chat
 from qwenpaw_data.host.core.domain.identity import Identity
 from qwenpaw_data.host.core.domain.preference import (
@@ -361,6 +362,8 @@ def _chat_to_dict(chat: Chat) -> dict[str, Any]:
         "active_duration_ms": chat.active_duration_ms,
         "error": chat.error,
         "plan": chat.plan,
+        "artifact_comments": list(chat.artifact_comments),
+        "attachments": list(chat.attachments),
         "created_at": _dt_to_json(chat.created_at),
         "updated_at": _dt_to_json(chat.updated_at),
     }
@@ -386,6 +389,8 @@ def _chat_from_dict(data: dict[str, Any]) -> Chat:
         active_duration_ms=data.get("active_duration_ms", 0),
         error=data.get("error"),
         plan=data.get("plan"),
+        artifact_comments=data.get("artifact_comments") or [],
+        attachments=data.get("attachments") or [],
         created_at=_dt_from_json(data["created_at"]),
         updated_at=_dt_from_json(data["updated_at"]),
     )
@@ -1004,3 +1009,116 @@ class JSONChannelBindingStore:
     async def exists(self, user_id: str, channel: str, external_key: str) -> bool:
         doc = await asyncio.to_thread(self._read, user_id)
         return external_key in (doc.get(channel) or {})
+
+
+def _attachment_to_dict(attachment: Attachment) -> dict[str, Any]:
+    return {
+        "id": attachment.id,
+        "session_id": attachment.session_id,
+        "identity": {
+            "user_id": attachment.identity.user_id,
+            "attrs": dict(attachment.identity.attrs),
+        },
+        "filename": attachment.filename,
+        "storage_path": attachment.storage_path,
+        "created_at": _dt_to_json(attachment.created_at),
+    }
+
+
+def _attachment_from_dict(data: dict[str, Any]) -> Attachment:
+    identity = data["identity"]
+    return Attachment(
+        id=data["id"],
+        session_id=data["session_id"],
+        identity=Identity(
+            user_id=identity["user_id"],
+            attrs=identity.get("attrs") or {},
+        ),
+        filename=data["filename"],
+        storage_path=data["storage_path"],
+        created_at=_dt_from_json(data["created_at"]),
+    )
+
+
+class JSONAttachmentStore:
+    """Layout: ``<root>/attachments/<attachment_id>.json``."""
+
+    def __init__(self, root: Path) -> None:
+        self._attachments_root = Path(root).expanduser().resolve() / "attachments"
+
+    def _path(self, attachment_id: str) -> Path:
+        return self._attachments_root / f"{attachment_id}.json"
+
+    @staticmethod
+    def _read(path: Path) -> dict[str, Any] | None:
+        with file_lock(path):
+            if not path.exists():
+                return None
+            return json.loads(path.read_text(encoding="utf-8"))
+
+    @staticmethod
+    def _write(path: Path, doc: dict[str, Any]) -> None:
+        with file_lock(path):
+            write_atomic(path, doc)
+
+    def _scan(self) -> list[dict[str, Any]]:
+        if not self._attachments_root.exists():
+            return []
+        docs = []
+        for path in self._attachments_root.glob("*.json"):
+            doc = self._read(path)
+            if doc is not None:
+                docs.append(doc)
+        return docs
+
+    async def add(self, attachment: Attachment) -> None:
+        path = self._path(attachment.id)
+        if await asyncio.to_thread(path.exists):
+            raise RuntimeError(f"CONFLICT: attachment already exists: {attachment.id}")
+        await asyncio.to_thread(self._write, path, _attachment_to_dict(attachment))
+
+    async def get(self, user_id: str, attachment_id: str) -> Attachment:
+        doc = await asyncio.to_thread(self._read, self._path(attachment_id))
+        if doc is None or doc["identity"]["user_id"] != user_id:
+            raise LookupError("attachment not found")
+        return _attachment_from_dict(doc)
+
+    async def find_by_filename(
+        self,
+        user_id: str,
+        session_id: str,
+        filename: str,
+    ) -> Attachment | None:
+        for doc in await asyncio.to_thread(self._scan):
+            if (
+                doc["session_id"] == session_id
+                and doc["filename"] == filename
+                and doc["identity"]["user_id"] == user_id
+            ):
+                return _attachment_from_dict(doc)
+        return None
+
+    async def require_for_session(
+        self,
+        user_id: str,
+        session_id: str,
+        attachment_ids: list[str],
+        *,
+        workspace: Path,
+    ) -> list[Attachment]:
+        seen: set[str] = set()
+        items: list[Attachment] = []
+        for attachment_id in attachment_ids:
+            if attachment_id in seen:
+                raise ValueError(f"duplicate attachment_id: {attachment_id}")
+            seen.add(attachment_id)
+            attachment = await self.get(user_id, attachment_id)
+            if attachment.session_id != session_id:
+                raise LookupError("attachment not found")
+            attachment.require_file(workspace)
+            items.append(attachment)
+        return items
+
+    async def delete(self, user_id: str, attachment_id: str) -> None:
+        await self.get(user_id, attachment_id)
+        await asyncio.to_thread(self._path(attachment_id).unlink)

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/store/protocols.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/store/protocols.py
@@ -8,10 +8,12 @@ runtime.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any, Protocol
 
 from qwenpaw_data.host.core.api.models.cron import CronJobWrite
 from qwenpaw_data.host.core.api.models.stream_objects import StreamObject
+from qwenpaw_data.host.core.domain.attachment import Attachment
 from qwenpaw_data.host.core.domain.chat import Chat
 from qwenpaw_data.host.core.domain.preference import UserPreferences
 from qwenpaw_data.host.core.domain.session import Session
@@ -142,6 +144,32 @@ class ChatStore(Protocol):
     async def update_plan(self, chat_id: str, plan: dict[str, Any]) -> None: ...
 
     async def reload_event_watermark(self, chat: Chat) -> None: ...
+
+
+class AttachmentStore(Protocol):
+    """Uploaded-file metadata; payload bytes live under the shared workspace."""
+
+    async def add(self, attachment: Attachment) -> None: ...
+
+    async def get(self, user_id: str, attachment_id: str) -> Attachment: ...
+
+    async def find_by_filename(
+        self,
+        user_id: str,
+        session_id: str,
+        filename: str,
+    ) -> Attachment | None: ...
+
+    async def require_for_session(
+        self,
+        user_id: str,
+        session_id: str,
+        attachment_ids: list[str],
+        *,
+        workspace: Path,
+    ) -> list[Attachment]: ...
+
+    async def delete(self, user_id: str, attachment_id: str) -> None: ...
 
 
 class ChatEventStore(Protocol):

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/store/sql_store.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/store/sql_store.py
@@ -11,6 +11,7 @@ the routers rely on.
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
 from typing import Any
 
 from sqlalchemy import exists, func, select
@@ -23,6 +24,7 @@ from qwenpaw_data.host.core.api.models.stream_objects import (
 )
 from qwenpaw_data.host.core.api.models.cron import CronJobWrite, ScheduleSpec
 from qwenpaw_data.host.core.db.tables import (
+    AttachmentRow,
     ChannelBindingRow,
     ChannelConfigRow,
     ChatEventRow,
@@ -34,6 +36,7 @@ from qwenpaw_data.host.core.db.tables import (
     UserProviderModelRow,
     UserProviderRow,
 )
+from qwenpaw_data.host.core.domain.attachment import Attachment
 from qwenpaw_data.host.core.domain.chat import ACTIVE, Chat
 from qwenpaw_data.host.core.domain.identity import Identity
 from qwenpaw_data.host.core.domain.preference import (
@@ -421,6 +424,8 @@ def _chat_from_row(row: ChatRow) -> Chat:
         active_duration_ms=row.active_duration_ms,
         error=row.error_json,
         plan=row.plan,
+        artifact_comments=list(row.artifact_comments_json or []),
+        attachments=list(row.attachments_json or []),
         created_at=row.created_at,
         updated_at=row.updated_at,
     )
@@ -436,6 +441,8 @@ def _apply_chat(row: ChatRow, chat: Chat) -> None:
     row.active_duration_ms = chat.active_duration_ms
     row.error_json = chat.error
     row.plan = chat.plan
+    row.artifact_comments_json = list(chat.artifact_comments)
+    row.attachments_json = list(chat.attachments)
     row.updated_at = chat.updated_at
 
 
@@ -464,6 +471,8 @@ class SQLChatStore:
                     active_duration_ms=chat.active_duration_ms,
                     error_json=chat.error,
                     plan=chat.plan,
+                    artifact_comments_json=list(chat.artifact_comments),
+                    attachments_json=list(chat.attachments),
                     created_at=chat.created_at,
                     updated_at=chat.updated_at,
                 )
@@ -1026,3 +1035,92 @@ class SQLChannelBindingStore:
             return (
                 await db.get(ChannelBindingRow, (user_id, channel, external_key))
             ) is not None
+
+
+def _attachment_from_row(row: AttachmentRow) -> Attachment:
+    return Attachment(
+        id=row.attachment_id,
+        session_id=row.session_id,
+        identity=Identity(user_id=row.user_id),
+        filename=row.filename,
+        storage_path=row.storage_path,
+        created_at=row.created_at,
+    )
+
+
+class SQLAttachmentStore:
+    def __init__(self, session_factory: async_sessionmaker[AsyncSession]) -> None:
+        self._sessions = session_factory
+
+    async def add(self, attachment: Attachment) -> None:
+        async with self._sessions() as db:
+            existing = await db.get(AttachmentRow, attachment.id)
+            if existing is not None:
+                raise RuntimeError(
+                    f"CONFLICT: attachment already exists: {attachment.id}"
+                )
+            db.add(
+                AttachmentRow(
+                    attachment_id=attachment.id,
+                    user_id=attachment.identity.user_id,
+                    session_id=attachment.session_id,
+                    filename=attachment.filename,
+                    storage_path=attachment.storage_path,
+                    created_at=attachment.created_at,
+                )
+            )
+            await db.commit()
+
+    async def get(self, user_id: str, attachment_id: str) -> Attachment:
+        async with self._sessions() as db:
+            row = await db.get(AttachmentRow, attachment_id)
+            if row is None or row.user_id != user_id:
+                raise LookupError("attachment not found")
+            return _attachment_from_row(row)
+
+    async def find_by_filename(
+        self,
+        user_id: str,
+        session_id: str,
+        filename: str,
+    ) -> Attachment | None:
+        async with self._sessions() as db:
+            row = (
+                await db.scalars(
+                    select(AttachmentRow).where(
+                        AttachmentRow.session_id == session_id,
+                        AttachmentRow.filename == filename,
+                        AttachmentRow.user_id == user_id,
+                    )
+                )
+            ).first()
+            return _attachment_from_row(row) if row is not None else None
+
+    async def require_for_session(
+        self,
+        user_id: str,
+        session_id: str,
+        attachment_ids: list[str],
+        *,
+        workspace: Path,
+    ) -> list[Attachment]:
+        seen: set[str] = set()
+        items: list[Attachment] = []
+        for attachment_id in attachment_ids:
+            if attachment_id in seen:
+                raise ValueError(f"duplicate attachment_id: {attachment_id}")
+            seen.add(attachment_id)
+            attachment = await self.get(user_id, attachment_id)
+            if attachment.session_id != session_id:
+                raise LookupError("attachment not found")
+            attachment.require_file(workspace)
+            items.append(attachment)
+        return items
+
+    async def delete(self, user_id: str, attachment_id: str) -> None:
+        async with self._sessions() as db:
+            row = await db.get(AttachmentRow, attachment_id)
+            if row is None or row.user_id != user_id:
+                raise LookupError("attachment not found")
+            await db.delete(row)
+            await db.commit()

--- a/packages/qwenpaw-data-host-core/tests/test_console_attachments.py
+++ b/packages/qwenpaw-data-host-core/tests/test_console_attachments.py
@@ -1,0 +1,383 @@
+# -*- coding: utf-8 -*-
+"""Attachments: domain rules, store conformance, console routes, turn input."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import pytest
+
+from qwenpaw_data.host.core.domain.attachment import Attachment
+from qwenpaw_data.host.core.domain.chat import Chat
+from qwenpaw_data.host.core.domain.identity import Identity
+from qwenpaw_data.host.core.runtime.turn import TurnInput, compose_agent_input
+from qwenpaw_data.host.core.store.json_store import (
+    JSONAttachmentStore,
+    JSONChatStore,
+)
+
+sqlalchemy = pytest.importorskip("sqlalchemy")
+
+from qwenpaw_data.host.core.db.engine import (  # noqa: E402
+    create_engine_and_factory,
+    init_db,
+)
+from qwenpaw_data.host.core.store.sql_store import (  # noqa: E402
+    SQLAttachmentStore,
+    SQLChatStore,
+)
+
+
+# ---------------------------------------------------------------------------
+# Domain
+
+
+def _receive(tmp_path: Path, filename: str = "data.csv", data: bytes = b"a,b\n"):
+    return Attachment.receive(
+        session_id="ses1",
+        identity=Identity.anonymous(),
+        filename=filename,
+        data=data,
+        dest_dir=tmp_path / "uploads" / "ses1",
+    )
+
+
+def test_receive_writes_file_and_ref(tmp_path: Path) -> None:
+    attachment = _receive(tmp_path)
+    assert attachment.storage_path == "uploads/ses1/data.csv"
+    assert (tmp_path / attachment.storage_path).read_bytes() == b"a,b\n"
+    ref = attachment.to_ref()
+    assert ref == {"attachment_id": attachment.id, "filename": "data.csv"}
+    assert attachment.require_file(tmp_path).name == "data.csv"
+
+
+def test_receive_rejects_empty_and_duplicates(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="empty"):
+        _receive(tmp_path, data=b"")
+    _receive(tmp_path)
+    with pytest.raises(ValueError, match="duplicate filename"):
+        _receive(tmp_path)
+
+
+def test_receive_rejects_unsafe_names(tmp_path: Path) -> None:
+    for bad in ("..", "a/b.csv", "a\\b.csv", " padded.csv", ""):
+        with pytest.raises(ValueError):
+            _receive(tmp_path, filename=bad)
+
+
+def test_require_file_rejects_escape(tmp_path: Path) -> None:
+    attachment = _receive(tmp_path)
+    attachment.storage_path = "../outside.csv"
+    with pytest.raises(ValueError, match="escapes workspace"):
+        attachment.require_file(tmp_path)
+
+
+def test_receive_rejects_oversize(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "qwenpaw_data.host.core.domain.attachment.MAX_SIZE_BYTES", 4
+    )
+    with pytest.raises(ValueError, match="exceeds"):
+        _receive(tmp_path, data=b"12345")
+
+
+# ---------------------------------------------------------------------------
+# Turn composition
+
+
+def test_compose_plain_text_is_unchanged() -> None:
+    assert compose_agent_input("hi", None, None) == "hi"
+
+
+def test_compose_includes_attachments_and_comments() -> None:
+    text = compose_agent_input(
+        "分析一下",
+        [{"path": "out/a.md", "line_start": 1, "line_end": 2, "comment": "改这里"}],
+        [{"attachment_id": "att_1", "filename": "data.csv"}],
+        session_id="ses1",
+    )
+    assert "uploads/ses1/data.csv" in text
+    assert "out/a.md" in text and "改这里" in text
+    assert text.endswith("分析一下")
+
+
+def test_compose_requires_session_id_for_attachments() -> None:
+    with pytest.raises(ValueError, match="session_id"):
+        compose_agent_input(
+            "hi", None, [{"attachment_id": "a", "filename": "f"}]
+        )
+
+
+def test_compose_rejects_incomplete_items() -> None:
+    with pytest.raises(ValueError, match="attachment missing"):
+        compose_agent_input("hi", None, [{"filename": "f"}], session_id="s")
+    with pytest.raises(ValueError, match="artifact comment missing"):
+        compose_agent_input("hi", [{"path": "p"}], None)
+
+
+def test_turn_input_carries_chat_fields() -> None:
+    chat = Chat.start(
+        session_id="ses1",
+        identity=Identity.anonymous(),
+        sequence=1,
+        datasource_id=None,
+        text="",
+        artifact_comments=[
+            {"path": "p", "line_start": 1, "line_end": 1, "comment": "c"}
+        ],
+        attachments=[{"attachment_id": "att_1", "filename": "f.csv"}],
+    )
+    turn = TurnInput.from_chat(chat)
+    assert turn.session_id == "ses1"
+    assert turn.attachments == [{"attachment_id": "att_1", "filename": "f.csv"}]
+    assert turn.artifact_comments[0]["comment"] == "c"
+    assert chat.references_attachment("att_1")
+    assert not chat.references_attachment("att_2")
+
+
+def test_chat_start_requires_text_or_attachment() -> None:
+    with pytest.raises(ValueError, match="text is required"):
+        Chat.start(
+            session_id="s",
+            identity=Identity.anonymous(),
+            sequence=1,
+            datasource_id=None,
+            text="  ",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Store conformance (both backends)
+
+
+class Backend:
+    def __init__(self, name, attachments, chats) -> None:
+        self.name = name
+        self.attachments = attachments
+        self.chats = chats
+
+
+@pytest.fixture(params=["json", "sql"])
+async def backend(request, tmp_path: Path):
+    if request.param == "json":
+        yield Backend(
+            "json", JSONAttachmentStore(tmp_path), JSONChatStore(tmp_path)
+        )
+        return
+    engine, factory = create_engine_and_factory(
+        f"sqlite+aiosqlite:///{tmp_path / 'host.db'}",
+    )
+    await init_db(engine)
+    yield Backend("sql", SQLAttachmentStore(factory), SQLChatStore(factory))
+    await engine.dispose()
+
+
+async def test_store_roundtrip_and_scoping(backend: Backend, tmp_path) -> None:
+    attachment = _receive(tmp_path)
+    await backend.attachments.add(attachment)
+
+    loaded = await backend.attachments.get("local", attachment.id)
+    assert loaded.filename == "data.csv"
+    assert loaded.storage_path == attachment.storage_path
+    assert loaded.session_id == "ses1"
+
+    with pytest.raises(LookupError):
+        await backend.attachments.get("other-user", attachment.id)
+    with pytest.raises(RuntimeError, match="CONFLICT"):
+        await backend.attachments.add(attachment)
+
+
+async def test_store_find_by_filename(backend: Backend, tmp_path) -> None:
+    attachment = _receive(tmp_path)
+    await backend.attachments.add(attachment)
+
+    found = await backend.attachments.find_by_filename("local", "ses1", "data.csv")
+    assert found is not None and found.id == attachment.id
+    assert (
+        await backend.attachments.find_by_filename("local", "ses2", "data.csv")
+        is None
+    )
+    assert (
+        await backend.attachments.find_by_filename("local", "ses1", "other.csv")
+        is None
+    )
+    assert (
+        await backend.attachments.find_by_filename("nobody", "ses1", "data.csv")
+        is None
+    )
+
+
+async def test_store_require_for_session(backend: Backend, tmp_path) -> None:
+    attachment = _receive(tmp_path)
+    await backend.attachments.add(attachment)
+
+    items = await backend.attachments.require_for_session(
+        "local", "ses1", [attachment.id], workspace=tmp_path
+    )
+    assert [item.id for item in items] == [attachment.id]
+
+    with pytest.raises(ValueError, match="duplicate attachment_id"):
+        await backend.attachments.require_for_session(
+            "local", "ses1", [attachment.id, attachment.id], workspace=tmp_path
+        )
+    with pytest.raises(LookupError):
+        await backend.attachments.require_for_session(
+            "local", "ses2", [attachment.id], workspace=tmp_path
+        )
+    (tmp_path / attachment.storage_path).unlink()
+    with pytest.raises(LookupError, match="file not found"):
+        await backend.attachments.require_for_session(
+            "local", "ses1", [attachment.id], workspace=tmp_path
+        )
+
+
+async def test_store_delete(backend: Backend, tmp_path) -> None:
+    attachment = _receive(tmp_path)
+    await backend.attachments.add(attachment)
+    with pytest.raises(LookupError):
+        await backend.attachments.delete("other", attachment.id)
+    await backend.attachments.delete("local", attachment.id)
+    with pytest.raises(LookupError):
+        await backend.attachments.get("local", attachment.id)
+
+
+async def test_chat_persists_attachment_fields(backend: Backend) -> None:
+    chat = Chat.start(
+        session_id="ses1",
+        identity=Identity.anonymous(),
+        sequence=1,
+        datasource_id=None,
+        text="hi",
+        artifact_comments=[
+            {"path": "p", "line_start": 1, "line_end": 2, "comment": "c"}
+        ],
+        attachments=[{"attachment_id": "att_1", "filename": "f.csv"}],
+    )
+    await backend.chats.add(chat)
+    loaded = await backend.chats.get(chat.id)
+    assert loaded.attachments == [{"attachment_id": "att_1", "filename": "f.csv"}]
+    assert loaded.artifact_comments[0]["line_end"] == 2
+
+    loaded.mark_status("completed")
+    await backend.chats.save(loaded)
+    again = await backend.chats.get(chat.id)
+    assert again.attachments == loaded.attachments
+
+
+# ---------------------------------------------------------------------------
+# Console routes
+
+pytest.importorskip("fastapi")
+import httpx  # noqa: E402
+
+from qwenpaw_data.host.core.api.app import create_app  # noqa: E402
+
+
+@asynccontextmanager
+async def console_client(tmp_path: Path, monkeypatch):
+    monkeypatch.delenv("QWENPAW_DATA_API_TOKEN", raising=False)
+    monkeypatch.delenv("QWENPAW_DATA_DB_URL", raising=False)
+    monkeypatch.delenv("QWENPAW_DATA_STORE", raising=False)
+    app = create_app(home=tmp_path, model=object())
+    async with app.router.lifespan_context(app):
+        transport = httpx.ASGITransport(app=app, client=("127.0.0.1", 1234))
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://testserver",
+        ) as http:
+            created = await http.post("/api/v1/sessions", json={"title": "附件"})
+            assert created.status_code == 200, created.text
+            yield http, created.json()["session"]["id"]
+
+
+async def _upload(http, session_id: str, filename: str = "data.csv"):
+    return await http.post(
+        "/api/v1/console/upload",
+        data={"session_id": session_id},
+        files={"file": (filename, b"a,b\n1,2\n", "text/csv")},
+    )
+
+
+async def test_upload_and_duplicate(tmp_path, monkeypatch) -> None:
+    async with console_client(tmp_path, monkeypatch) as (http, session_id):
+        uploaded = await _upload(http, session_id)
+        assert uploaded.status_code == 200, uploaded.text
+        ref = uploaded.json()["attachment"]
+        assert ref["filename"] == "data.csv"
+        assert ref["attachment_id"].startswith("att")
+
+        again = await _upload(http, session_id)
+        assert again.status_code in (400, 422), again.text
+
+        missing = await _upload(http, "ses_missing")
+        assert missing.status_code == 404
+
+
+async def test_delete_attachment(tmp_path, monkeypatch) -> None:
+    async with console_client(tmp_path, monkeypatch) as (http, session_id):
+        ref = (await _upload(http, session_id)).json()["attachment"]
+        deleted = await http.delete(
+            f"/api/v1/console/attachments/{ref['attachment_id']}"
+        )
+        assert deleted.status_code == 204
+        again = await http.delete(
+            f"/api/v1/console/attachments/{ref['attachment_id']}"
+        )
+        assert again.status_code == 404
+        # File removed too; the same name can be uploaded again.
+        assert (await _upload(http, session_id)).status_code == 200
+
+
+async def test_console_chat_carries_attachments(tmp_path, monkeypatch) -> None:
+    async with console_client(tmp_path, monkeypatch) as (http, session_id):
+        ref = (await _upload(http, session_id)).json()["attachment"]
+        response = await http.post(
+            "/api/v1/console/chat",
+            json={
+                "session_id": session_id,
+                "text": "看看这个文件",
+                "attachment_ids": [ref["attachment_id"]],
+                "artifact_comments": [
+                    {
+                        "path": "out/report.md",
+                        "line_start": 3,
+                        "line_end": 4,
+                        "comment": "补充口径",
+                    }
+                ],
+            },
+        )
+        assert response.status_code == 200, response.text
+        chat = response.json()["chat"]
+        assert chat["attachments"] == [ref]
+        assert chat["artifact_comments"][0]["comment"] == "补充口径"
+
+        # The attachment is now referenced: deletion must conflict.
+        conflicted = await http.delete(
+            f"/api/v1/console/attachments/{ref['attachment_id']}"
+        )
+        assert conflicted.status_code == 409
+
+        stopped = await http.post(
+            "/api/v1/console/chat/stop",
+            params={"session_id": session_id, "chat_id": chat["id"]},
+        )
+        assert stopped.status_code == 200, stopped.text
+        assert stopped.json()["chat"]["status"] in (
+            "canceled",
+            "failed",
+            "completed",
+        )
+
+
+async def test_console_chat_unknown_attachment(tmp_path, monkeypatch) -> None:
+    async with console_client(tmp_path, monkeypatch) as (http, session_id):
+        response = await http.post(
+            "/api/v1/console/chat",
+            json={
+                "session_id": session_id,
+                "text": "hi",
+                "attachment_ids": ["att_missing"],
+            },
+        )
+        assert response.status_code == 404

--- a/uv.lock
+++ b/uv.lock
@@ -3485,6 +3485,7 @@ service = [
     { name = "apscheduler" },
     { name = "cryptography" },
     { name = "fastapi" },
+    { name = "python-multipart" },
     { name = "sqlalchemy", extra = ["asyncio"] },
 ]
 
@@ -3501,6 +3502,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28,<0.29" },
     { name = "lark-oapi", marker = "extra == 'channels'", specifier = ">=1.5.3" },
     { name = "pydantic", specifier = ">=2.13,<3.0" },
+    { name = "python-multipart", marker = "extra == 'service'", specifier = ">=0.0.18,<1.0" },
     { name = "pyyaml", specifier = ">=6.0,<7.0" },
     { name = "qwenpaw-data-skills", editable = "packages/qwenpaw-data-skills" },
     { name = "shortuuid", specifier = ">=1.0,<2.0" },


### PR DESCRIPTION
## Summary
- New `AttachmentStore` protocol with JSON and SQL backends (shared conformance suite): 20MB-capped uploads land under the shared workspace at `uploads/<session_id>/` and their references compose into the agent turn (`runtime/turn.py`), so tools read real files instead of guessing.
- New `/console/*` routes mirroring the enterprise console client's request shapes: `POST /console/upload`, `DELETE /console/attachments/{id}`, `POST /console/chat` (accepts `attachment_ids` + `artifact_comments`), `POST /console/chat/stop`.
- `Chat`/`ChatRow` persist attachment refs and artifact comments across both store backends; `python-multipart` added to the `[service]` extra.

First of a 4-PR stack that gives the OSS engine full API parity with the enterprise console frontend.

## Test plan
- [x] Full suite green (940 passed) including 25 new tests: attachment domain rules, dual-backend store conformance, console route behavior (upload/duplicate/delete-conflict/chat-with-attachments/stop), turn composition
- [x] Live-verified end-to-end through the embedded console (multipart upload via gateway → 200, agent receives file references)