### PR TITLE
feat(host-core): steer artifact comments and wholesale plan editing

### DIFF
--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/agent/middleware/steer.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/agent/middleware/steer.py
@@ -11,6 +11,7 @@ from agentscope.message import AssistantMsg, HintBlock
 from agentscope.middleware import MiddlewareBase
 
 from qwenpaw_data.host.core.domain.steer import SteerQueue
+from qwenpaw_data.host.core.runtime.turn import compose_agent_input
 
 
 class SteerMiddleware(MiddlewareBase):
@@ -37,9 +38,13 @@ class SteerMiddleware(MiddlewareBase):
         """Start a fresh queue; cancel_all() closes a queue terminally."""
         self.queue = SteerQueue()
 
-    async def steer(self, text: str) -> None:
+    async def steer(
+        self,
+        text: str,
+        artifact_comments: list[dict] | None = None,
+    ) -> None:
         """Enqueue steer text and wait until it is injected."""
-        await self.queue.wait_until_injected(text)
+        await self.queue.wait_until_injected(text, artifact_comments)
 
     async def cancel(self) -> None:
         """Release every pending steer waiter."""
@@ -54,17 +59,22 @@ class SteerMiddleware(MiddlewareBase):
         pending = await self.queue.take_pending()
         if pending:
             hint_blocks = [
-                HintBlock(hint=item.text, source="steer") for item in pending
+                HintBlock(
+                    hint=compose_agent_input(item.text, item.artifact_comments),
+                    source="steer",
+                )
+                for item in pending
             ]
             self._append_hints(agent, hint_blocks)
             for item in pending:
                 await self.queue.mark_injected(item)
-            for hint in hint_blocks:
+            for hint, item in zip(hint_blocks, pending):
                 yield HintBlockEvent(
                     reply_id=agent.state.reply_id,
                     block_id=hint.id,
                     source="steer",
-                    hint=hint.hint,
+                    hint=item.text,
+                    metadata={"artifact_comments": item.artifact_comments},
                 )
 
         async for event in next_handler(**input_kwargs):

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/agent/qwenpaw_data_agent.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/agent/qwenpaw_data_agent.py
@@ -140,6 +140,38 @@ class QwenPawDataAgent(Agent):
             )
         return nodes_to_sop(rs._nodes, graph_id, rs._graph_registry)
 
+    def get_plan_states(self) -> dict[str, str]:
+        """当前活跃图的 ``node_id → state`` 快照。"""
+        rs = self._runtime_state
+        graph_id = rs.current_graph_id
+        if not graph_id:
+            return {}
+        return {n.id: n.state for n in graph_nodes(rs._nodes, graph_id)}
+
+    async def replace_plan(
+        self,
+        sop: SOP | dict | str,
+        *,
+        reason: str | None = None,
+    ) -> SOP:
+        """整体替换当前计划；节点运行态重置为 todo，由后续执行重新推进。"""
+        rs = self._runtime_state
+        graph_id, nodes, graph_meta = sop_to_nodes(sop)
+        rs._graph_registry[graph_id] = graph_meta
+        await rs.load_graph_from_nodes(graph_id, nodes)
+        self.state.context.append(self._plan_changed_message(reason))
+        return nodes_to_sop(rs._nodes, graph_id, rs._graph_registry)
+
+    @staticmethod
+    def _plan_changed_message(reason: str | None = None) -> Msg:
+        lines = [
+            "[用户更新了当前计划]",
+            "当前计划已被完整替换，请依据最新的 system plan hint 继续。",
+        ]
+        if reason:
+            lines.append(f"修改原因：{reason}")
+        return user_msg("\n".join(lines))
+
     async def execute_sop(
         self,
         sop: SOP | dict | str,

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/app.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/app.py
@@ -34,6 +34,7 @@ from qwenpaw_data.host.core.api.routers import console as console_router
 from qwenpaw_data.host.core.api.routers import cron as cron_router
 from qwenpaw_data.host.core.api.routers import datasources as datasources_router
 from qwenpaw_data.host.core.api.routers import events as events_router
+from qwenpaw_data.host.core.api.routers import plan as plan_router
 from qwenpaw_data.host.core.api.routers import preferences as preferences_router
 from qwenpaw_data.host.core.api.routers import sessions as sessions_router
 from qwenpaw_data.host.core.api.routers import settlement as settlement_router
@@ -259,6 +260,7 @@ def create_app(
     app.include_router(chats_router.router, prefix="/api/v1")
     app.include_router(console_router.router, prefix="/api/v1")
     app.include_router(events_router.router, prefix="/api/v1")
+    app.include_router(plan_router.router, prefix="/api/v1")
     app.include_router(steer_router.router, prefix="/api/v1")
     app.include_router(clarification_router.router, prefix="/api/v1")
     app.include_router(preferences_router.router, prefix="/api/v1")

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/mappers.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/mappers.py
@@ -16,6 +16,7 @@ from qwenpaw_data.host.core.domain.chat import Chat
 from qwenpaw_data.host.core.domain.preference import UserPreferences
 from qwenpaw_data.host.core.domain.session import Session
 from qwenpaw_data.host.core.providers.registry import ProviderRegistry
+from qwenpaw_data.host.core.utils.plan import sop_plan_to_schema
 from qwenpaw_data.host.core.utils.secrets import mask_api_key
 
 
@@ -129,7 +130,7 @@ def chat_to_schema(chat: Chat) -> dict[str, Any]:
         completed_at=chat.completed_at,
         active_duration_ms=chat.active_duration_ms,
         error=ChatErrorSchema(**chat.error) if chat.error else None,
-        plan=chat.plan,
+        plan=sop_plan_to_schema(chat.plan),
         artifact_comments=chat.artifact_comments,  # type: ignore[arg-type]
         attachments=chat.attachments,  # type: ignore[arg-type]
     ).model_dump(mode="json")

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/models/plan.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/models/plan.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import Field
+
+from qwenpaw_data.host.core.api.models.common import ApiModel
+
+
+class TaskSchema(ApiModel):
+    id: str
+    subject: str
+    description: str
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    created_at: str = Field(default_factory=lambda: datetime.now().isoformat())
+    state: Literal["pending", "in_progress", "completed"] = "pending"
+    owner: str | None = None
+    blocks: list[str] = Field(default_factory=list)
+    blocked_by: list[str] = Field(default_factory=list)
+
+
+class PlanSchema(ApiModel):
+    tasks: list[TaskSchema] = Field(default_factory=list)

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/models/requests.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/models/requests.py
@@ -7,6 +7,7 @@ from qwenpaw_data.host.core.api.models.chat import (
     AskUserQuestionTimeoutResultSchema,
 )
 from qwenpaw_data.host.core.api.models.common import ApiModel, AttachmentRefSchema
+from qwenpaw_data.host.core.api.models.plan import PlanSchema
 
 
 class CreateSessionRequest(ApiModel):
@@ -35,6 +36,12 @@ class ConsoleChatRequest(ApiModel):
 
 class SteerRequest(ApiModel):
     text: str
+    artifact_comments: list[ArtifactCommentSchema] = []
+
+
+class PlanEditRequest(ApiModel):
+    reason: str | None = None
+    plan: PlanSchema | None
 
 
 class ClarificationAnswerRequest(ApiModel):

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/routers/plan.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/routers/plan.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+"""Wholesale plan replacement for live and idle chats."""
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends
+
+from qwenpaw_data.host.core.api.deps import ServiceState, get_identity, get_state
+from qwenpaw_data.host.core.api.errors import map_domain_error, raise_api
+from qwenpaw_data.host.core.api.models.requests import PlanEditRequest
+from qwenpaw_data.host.core.domain.chat import ACTIVE
+from qwenpaw_data.host.core.domain.identity import Identity
+from qwenpaw_data.host.core.runtime.registry import get_runtime_registry
+from qwenpaw_data.host.core.utils.plan import plan_schema_to_sop, sop_plan_to_schema
+from qwenpaw_data.host.core.utils.time import utcnow
+
+router = APIRouter(
+    prefix="/sessions/{session_id}/chats/{chat_id}/plan",
+    tags=["plan"],
+)
+
+
+@router.post("/edit")
+async def plan_edit(
+    session_id: str,
+    chat_id: str,
+    body: PlanEditRequest,
+    identity: Identity = Depends(get_identity),
+    state: ServiceState = Depends(get_state),
+) -> dict[str, Any]:
+    _ = identity
+    try:
+        await state.sessions.get(session_id)
+        chat = await state.chats.get(chat_id, session_id=session_id)
+        payload = None if body.plan is None else body.plan.model_dump(mode="json")
+        sop = plan_schema_to_sop(payload, previous=chat.plan)
+
+        if chat.status in ACTIVE:
+            runtime = get_runtime_registry().get(chat_id)
+            if runtime is None:
+                raise RuntimeError(
+                    "CONFLICT: active chat runtime is unavailable",
+                )
+            if sop is None or not sop["nodes"]:
+                raise_api(
+                    "VALIDATION",
+                    "a running chat requires a non-empty plan",
+                    status=400,
+                )
+            snapshot = await runtime.replace_plan(sop, reason=body.reason)
+        else:
+            snapshot = sop or {}
+            chat.plan = snapshot or None
+            chat.updated_at = utcnow()
+            await state.chats.save(chat)
+    except Exception as exc:
+        http = map_domain_error(exc)
+        if http:
+            raise http from exc
+        raise
+    return {"plan": sop_plan_to_schema(snapshot)}

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/routers/steer.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/routers/steer.py
@@ -30,7 +30,10 @@ async def steer(
         runtime = get_runtime_registry().get(chat_id)
         if runtime is None:
             raise SteerChatEndedError()
-        await runtime.steer(body.text)
+        await runtime.steer(
+            body.text,
+            [item.model_dump(mode="json") for item in body.artifact_comments],
+        )
     except Exception as exc:
         http = map_domain_error(exc)
         if http:

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/domain/steer.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/domain/steer.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass, field
-from typing import Literal
+from typing import Any, Literal
 
 from qwenpaw_data.host.core.utils.ids import create_id
 
@@ -33,6 +33,7 @@ class PendingSteer:
     id: str = field(default_factory=lambda: create_id("steer"))
     status: SteerStatus = "waiting"
     done: asyncio.Event = field(default_factory=asyncio.Event)
+    artifact_comments: list[dict[str, Any]] = field(default_factory=list)
 
 
 class SteerQueue:
@@ -53,11 +54,18 @@ class SteerQueue:
     def closed(self) -> bool:
         return self._closed
 
-    async def wait_until_injected(self, text: str) -> None:
+    async def wait_until_injected(
+        self,
+        text: str,
+        artifact_comments: list[dict[str, Any]] | None = None,
+    ) -> None:
         """Enqueue ``text`` and wait until it is injected (or cancelled)."""
         if not text.strip():
             raise ValueError("text is required")
-        item = PendingSteer(text=text)
+        item = PendingSteer(
+            text=text,
+            artifact_comments=list(artifact_comments or []),
+        )
         if self._closed:
             raise SteerChatEndedError()
         self._items.append(item)

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/runtime/chat_runtime.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/runtime/chat_runtime.py
@@ -98,9 +98,13 @@ class ChatRuntime:
             result=result,
         )
 
-    async def steer(self, text: str) -> None:
+    async def steer(
+        self,
+        text: str,
+        artifact_comments: list[dict] | None = None,
+    ) -> None:
         """Enqueue steer text and wait until it is injected into the agent."""
-        await self._executor.steer(text)
+        await self._executor.steer(text, artifact_comments)
 
     async def run(self, chat_id: str, *, identity: Identity) -> None:
         registry = get_runtime_registry()
@@ -418,20 +422,37 @@ class ChatRuntime:
             stamps[path] = (stat.st_size, stat.st_mtime_ns)
         return stamps
 
-    async def _save_plan(self) -> None:
+    async def replace_plan(
+        self,
+        plan: dict[str, Any],
+        *,
+        reason: str | None = None,
+    ) -> dict[str, Any]:
+        """Replace the live plan wholesale; persists and streams the snapshot."""
+        agent = self.agent
+        await agent.replace_plan(plan, reason=reason)
+        return await self._save_plan() or {}
+
+    async def _save_plan(self) -> dict[str, Any] | None:
         ctx = self._run_context
         stream = self._stream
         if self._agent is None or ctx is None or stream is None:
-            return
+            return None
         try:
             snapshot = self._agent.get_plan().model_dump(mode="json")
         except RuntimeError:
-            return
+            return None
+        states = self._agent.get_plan_states()
+        for node in snapshot.get("nodes") or []:
+            state = states.get(node.get("node_id"))
+            if state is not None:
+                node["state"] = state
         await self.chats.update_plan(ctx.chat_id, snapshot)
         await stream.task_status(
             event_type="graph_updated",
             graph_snapshot=snapshot,
         )
+        return snapshot
 
     async def _finish(
         self,

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/runtime/envelope.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/runtime/envelope.py
@@ -651,9 +651,16 @@ class Envelope:
         msg_id = create_id("msg")
         seq = self._next_seq()
         source = getattr(event, "source", None)
-        metadata: dict[str, Any] | None = (
-            {"source": source} if source is not None else None
-        )
+        comments = (getattr(event, "metadata", None) or {}).get(
+            "artifact_comments"
+        ) or []
+        metadata: dict[str, Any] | None = {}
+        if source is not None:
+            metadata["source"] = source
+        if comments:
+            metadata["artifact_comments"] = list(comments)
+        if not metadata:
+            metadata = None
         content = [
             {
                 "object": "content",

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/runtime/executor.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/runtime/executor.py
@@ -41,11 +41,15 @@ class AgentExecutor:
             result=result,
         )
 
-    async def steer(self, text: str) -> None:
+    async def steer(
+        self,
+        text: str,
+        artifact_comments: list[dict] | None = None,
+    ) -> None:
         """Enqueue steer text and wait until it is injected into the agent."""
         if self._agent is None:
             raise RuntimeError("CONFLICT: chat runtime agent is not ready")
-        await SteerMiddleware.require(self._agent).steer(text)
+        await SteerMiddleware.require(self._agent).steer(text, artifact_comments)
 
     async def cancel_steer(self) -> None:
         """Release pending steer waiters when SteerMiddleware is present."""

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/utils/plan.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/utils/plan.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+"""Project between the runtime SOP plan shape and the console Plan schema.
+
+The console client edits plans as ``{"tasks": [...]}`` (subject/state/
+blocked_by); the runtime plans in SOP shape (name/description/
+expected_outcome/deps). Chats persist SOP dumps, optionally annotated
+with per-node ``state`` from the live graph.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+_NODE_STATE_TO_TASK = {
+    "todo": "pending",
+    "in_progress": "in_progress",
+    "done": "completed",
+    "failed": "in_progress",
+    "abandoned": "completed",
+}
+
+
+def sop_plan_to_schema(plan: dict[str, Any] | None) -> dict[str, Any] | None:
+    """SOP dump (nodes may carry ``state``) → console Plan dict, or None."""
+    if not plan:
+        return None
+    nodes = plan.get("nodes") or []
+    if not nodes:
+        return None
+    tasks: list[dict[str, Any]] = []
+    blocks: dict[str, list[str]] = {}
+    for node in nodes:
+        for dep in node.get("deps") or []:
+            blocks.setdefault(dep, []).append(node.get("node_id") or "")
+    for index, node in enumerate(nodes):
+        node_id = node.get("node_id") or f"node_{index:03d}"
+        metadata: dict[str, Any] = {}
+        if node.get("expected_outcome"):
+            metadata["expected_outcome"] = node["expected_outcome"]
+        tasks.append(
+            {
+                "id": node_id,
+                "subject": node.get("name") or node_id,
+                "description": node.get("description") or "",
+                "metadata": metadata,
+                "state": _NODE_STATE_TO_TASK.get(
+                    node.get("state") or "todo", "pending"
+                ),
+                "owner": None,
+                "blocks": blocks.get(node_id, []),
+                "blocked_by": list(node.get("deps") or []),
+            }
+        )
+    return {"tasks": tasks}
+
+
+def plan_schema_to_sop(
+    plan: dict[str, Any] | None,
+    *,
+    previous: dict[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    """Console Plan dict → SOP dict; graph meta carried over from ``previous``."""
+    if plan is None:
+        return None
+    prior = previous or {}
+    nodes = [
+        {
+            "node_id": task["id"],
+            "name": task.get("subject") or task["id"],
+            "description": task.get("description") or "",
+            "expected_outcome": (
+                (task.get("metadata") or {}).get("expected_outcome")
+                or task.get("description")
+                or task.get("subject")
+                or task["id"]
+            ),
+            "deps": list(task.get("blocked_by") or []),
+        }
+        for task in plan.get("tasks") or []
+    ]
+    return {
+        "name": prior.get("name") or "用户编辑的计划",
+        "description": prior.get("description") or "由控制台计划编辑生成",
+        "expected_outcome": prior.get("expected_outcome") or "按编辑后的计划完成任务",
+        "nodes": nodes,
+    }

--- a/packages/qwenpaw-data-host-core/tests/test_plan_edit.py
+++ b/packages/qwenpaw-data-host-core/tests/test_plan_edit.py
@@ -1,0 +1,281 @@
+# -*- coding: utf-8 -*-
+"""Plan projection, plan-edit routes, and steer comment composition."""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from qwenpaw_data.host.core.agent.middleware import SteerMiddleware
+from qwenpaw_data.host.core.utils.plan import (
+    plan_schema_to_sop,
+    sop_plan_to_schema,
+)
+
+SOP_PLAN = {
+    "name": "月度分析",
+    "description": "拆解销售异动",
+    "expected_outcome": "定位根因",
+    "nodes": [
+        {
+            "node_id": "n1",
+            "name": "取数",
+            "description": "拉取订单明细",
+            "expected_outcome": "明细表",
+            "deps": [],
+            "state": "done",
+        },
+        {
+            "node_id": "n2",
+            "name": "归因",
+            "description": "按区域拆解",
+            "expected_outcome": "归因结论",
+            "deps": ["n1"],
+            "state": "in_progress",
+        },
+    ],
+}
+
+
+# ---------------------------------------------------------------------------
+# Projection
+
+
+def test_sop_plan_to_schema_projects_tasks() -> None:
+    plan = sop_plan_to_schema(SOP_PLAN)
+    assert plan is not None
+    tasks = plan["tasks"]
+    assert [t["id"] for t in tasks] == ["n1", "n2"]
+    assert tasks[0]["subject"] == "取数"
+    assert tasks[0]["state"] == "completed"
+    assert tasks[0]["blocks"] == ["n2"]
+    assert tasks[1]["state"] == "in_progress"
+    assert tasks[1]["blocked_by"] == ["n1"]
+    assert tasks[1]["metadata"]["expected_outcome"] == "归因结论"
+
+
+def test_sop_plan_to_schema_empty_is_none() -> None:
+    assert sop_plan_to_schema(None) is None
+    assert sop_plan_to_schema({}) is None
+    assert sop_plan_to_schema({"name": "x", "nodes": []}) is None
+    # Unannotated nodes default to pending.
+    plan = sop_plan_to_schema(
+        {"nodes": [{"node_id": "a", "name": "任务A", "deps": []}]}
+    )
+    assert plan["tasks"][0]["state"] == "pending"
+
+
+def test_plan_schema_to_sop_carries_meta_and_deps() -> None:
+    schema = sop_plan_to_schema(SOP_PLAN)
+    sop = plan_schema_to_sop(schema, previous=SOP_PLAN)
+    assert sop["name"] == "月度分析"
+    assert [n["node_id"] for n in sop["nodes"]] == ["n1", "n2"]
+    assert sop["nodes"][1]["deps"] == ["n1"]
+    assert sop["nodes"][1]["expected_outcome"] == "归因结论"
+    # No previous plan → generated meta, description falls back.
+    bare = plan_schema_to_sop(
+        {"tasks": [{"id": "t1", "subject": "只有标题"}]}
+    )
+    assert bare["name"]
+    assert bare["nodes"][0]["expected_outcome"] == "只有标题"
+    assert plan_schema_to_sop(None) is None
+
+
+# ---------------------------------------------------------------------------
+# Steer middleware composes comments into the injected hint
+
+
+class FakeState:
+    def __init__(self) -> None:
+        self.reply_id = "reply-1"
+        self.context: list[Any] = []
+
+
+class FakeAgent:
+    def __init__(self, middleware: SteerMiddleware) -> None:
+        self.name = "qwenpaw-data"
+        self.state = FakeState()
+        self._reasoning_middlewares = [middleware]
+
+
+async def test_middleware_composes_comments_into_hint() -> None:
+    middleware = SteerMiddleware()
+    agent = FakeAgent(middleware)
+    comments = [
+        {"path": "out/a.md", "line_start": 2, "line_end": 3, "comment": "补充"}
+    ]
+
+    steer_task = asyncio.create_task(middleware.steer("改一下", comments))
+    await asyncio.sleep(0)
+
+    async def next_handler(**_kwargs: Any):
+        yield "sentinel"
+
+    events = [
+        event
+        async for event in middleware.on_reasoning(agent, {}, next_handler)
+    ]
+    await steer_task
+
+    hint_event = events[0]
+    # The stream event keeps the raw text; comments ride in metadata.
+    assert hint_event.hint == "改一下"
+    assert hint_event.metadata["artifact_comments"] == comments
+    # The model context receives the composed input.
+    composed = agent.state.context[0].content[0].hint
+    assert "out/a.md" in composed and composed.endswith("改一下")
+
+
+# ---------------------------------------------------------------------------
+# Plan edit routes
+
+pytest.importorskip("fastapi")
+import httpx  # noqa: E402
+
+from qwenpaw_data.host.core.api.app import create_app  # noqa: E402
+from qwenpaw_data.host.core.domain.identity import Identity  # noqa: E402
+from qwenpaw_data.host.core.domain.session import Session  # noqa: E402
+from qwenpaw_data.host.core.runtime.registry import (  # noqa: E402
+    get_runtime_registry,
+)
+
+
+class FakePlanRuntime:
+    def __init__(self) -> None:
+        self.replacements: list[tuple[dict[str, Any], str | None]] = []
+
+    async def replace_plan(
+        self,
+        plan: dict[str, Any],
+        *,
+        reason: str | None = None,
+    ) -> dict[str, Any]:
+        self.replacements.append((plan, reason))
+        return plan
+
+
+@asynccontextmanager
+async def plan_client(tmp_path: Path, monkeypatch):
+    monkeypatch.delenv("QWENPAW_DATA_API_TOKEN", raising=False)
+    monkeypatch.delenv("QWENPAW_DATA_DB_URL", raising=False)
+    monkeypatch.delenv("QWENPAW_DATA_STORE", raising=False)
+    app = create_app(home=tmp_path, model=object())
+    async with app.router.lifespan_context(app):
+        transport = httpx.ASGITransport(app=app, client=("127.0.0.1", 1234))
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://testserver",
+        ) as http:
+            yield http, app
+
+
+async def _seed_chat(app, *, plan: dict | None = None) -> tuple[str, str]:
+    state = app.state.service
+    session = Session.create(identity=Identity.anonymous())
+    await state.sessions.add(session)
+    chat = session.open_chat(text="hi", datasource_id=None, has_active_chat=False)
+    if plan is not None:
+        chat.plan = plan
+    await state.sessions.save(session)
+    await state.chats.add(chat)
+    return session.id, chat.id
+
+
+EDIT_BODY = {
+    "reason": "去掉冗余步骤",
+    "plan": {
+        "tasks": [
+            {"id": "n1", "subject": "取数", "description": "拉取订单明细"},
+            {
+                "id": "n2",
+                "subject": "归因",
+                "description": "按区域拆解",
+                "blocked_by": ["n1"],
+            },
+        ]
+    },
+}
+
+
+async def test_plan_edit_idle_chat_persists(tmp_path, monkeypatch) -> None:
+    async with plan_client(tmp_path, monkeypatch) as (http, app):
+        sid, cid = await _seed_chat(app, plan=SOP_PLAN)
+        chat = await app.state.service.chats.get(cid)
+        chat.mark_status("completed")
+        await app.state.service.chats.save(chat)
+
+        response = await http.post(
+            f"/api/v1/sessions/{sid}/chats/{cid}/plan/edit", json=EDIT_BODY
+        )
+        assert response.status_code == 200, response.text
+        tasks = response.json()["plan"]["tasks"]
+        assert [t["id"] for t in tasks] == ["n1", "n2"]
+        assert tasks[1]["blocked_by"] == ["n1"]
+
+        stored = await app.state.service.chats.get(cid)
+        assert stored.plan["name"] == "月度分析"  # meta carried over
+        assert [n["node_id"] for n in stored.plan["nodes"]] == ["n1", "n2"]
+
+        # Clearing the plan on an idle chat is allowed.
+        cleared = await http.post(
+            f"/api/v1/sessions/{sid}/chats/{cid}/plan/edit",
+            json={"plan": None},
+        )
+        assert cleared.status_code == 200
+        assert cleared.json()["plan"] is None
+        assert (await app.state.service.chats.get(cid)).plan is None
+
+
+async def test_plan_edit_live_chat_routes_to_runtime(
+    tmp_path, monkeypatch
+) -> None:
+    async with plan_client(tmp_path, monkeypatch) as (http, app):
+        sid, cid = await _seed_chat(app)
+
+        # Running chat without a live runtime → 409.
+        orphan = await http.post(
+            f"/api/v1/sessions/{sid}/chats/{cid}/plan/edit", json=EDIT_BODY
+        )
+        assert orphan.status_code == 409
+
+        runtime = FakePlanRuntime()
+        get_runtime_registry().register(cid, runtime)  # type: ignore[arg-type]
+        try:
+            ok = await http.post(
+                f"/api/v1/sessions/{sid}/chats/{cid}/plan/edit", json=EDIT_BODY
+            )
+            assert ok.status_code == 200, ok.text
+            sop, reason = runtime.replacements[0]
+            assert reason == "去掉冗余步骤"
+            assert [n["node_id"] for n in sop["nodes"]] == ["n1", "n2"]
+
+            # A running chat cannot have its plan cleared.
+            cleared = await http.post(
+                f"/api/v1/sessions/{sid}/chats/{cid}/plan/edit",
+                json={"plan": None},
+            )
+            assert cleared.status_code == 400
+        finally:
+            get_runtime_registry().unregister(cid)
+
+
+async def test_plan_edit_missing_chat(tmp_path, monkeypatch) -> None:
+    async with plan_client(tmp_path, monkeypatch) as (http, _app):
+        response = await http.post(
+            "/api/v1/sessions/s/chats/c/plan/edit", json={"plan": None}
+        )
+        assert response.status_code == 404
+
+
+async def test_chat_schema_projects_plan(tmp_path, monkeypatch) -> None:
+    async with plan_client(tmp_path, monkeypatch) as (http, app):
+        sid, cid = await _seed_chat(app, plan=SOP_PLAN)
+        listed = await http.get(f"/api/v1/sessions/{sid}/chats")
+        assert listed.status_code == 200
+        chat = listed.json()["items"][0]
+        assert chat["plan"]["tasks"][0]["subject"] == "取数"
+        assert chat["plan"]["tasks"][0]["state"] == "completed"

--- a/packages/qwenpaw-data-host-core/tests/test_steer_clarification_api.py
+++ b/packages/qwenpaw-data-host-core/tests/test_steer_clarification_api.py
@@ -23,11 +23,15 @@ from qwenpaw_data.host.core.runtime.registry import (  # noqa: E402
 
 class FakeRuntime:
     def __init__(self) -> None:
-        self.steers: list[str] = []
+        self.steers: list[tuple[str, list[dict[str, Any]]]] = []
         self.answers: list[tuple[str, dict[str, Any]]] = []
 
-    async def steer(self, text: str) -> None:
-        self.steers.append(text)
+    async def steer(
+        self,
+        text: str,
+        artifact_comments: list[dict[str, Any]] | None = None,
+    ) -> None:
+        self.steers.append((text, list(artifact_comments or [])))
 
     def answer(self, *, clarification_id: str, result: dict[str, Any]) -> None:
         if clarification_id == "clar_conflict":
@@ -101,7 +105,26 @@ async def test_steer_paths(tmp_path, monkeypatch) -> None:
                 json={"text": "聚焦华东"},
             )
             assert ok.status_code == 204
-            assert runtime.steers == ["聚焦华东"]
+            assert runtime.steers == [("聚焦华东", [])]
+
+            commented = await http.post(
+                f"/api/v1/sessions/{sid}/chats/{cid}/steer",
+                json={
+                    "text": "改一下图",
+                    "artifact_comments": [
+                        {
+                            "path": "out/chart.png",
+                            "line_start": 1,
+                            "line_end": 1,
+                            "comment": "换成柱状图",
+                        }
+                    ],
+                },
+            )
+            assert commented.status_code == 204
+            text, comments = runtime.steers[-1]
+            assert text == "改一下图"
+            assert comments[0]["comment"] == "换成柱状图"
         finally:
             get_runtime_registry().unregister(cid)
 


### PR DESCRIPTION
## Summary
- Steer requests carry artifact row comments end-to-end: composed into the injected hint for the model, raw text + comments preserved in the stream event metadata for rendering.
- New `POST /sessions/{sid}/chats/{cid}/plan/edit`: live chats reload the runtime task graph via new `QwenPawDataAgent.replace_plan()` (node states reset to todo; the agent re-marks progress) and stream the fresh snapshot; idle chats persist directly.
- `utils/plan.py` projects between the console's task-list plan shape and the runtime SOP shape at the API boundary; plan snapshots now annotate per-node states so task progress renders during a run.

Stacked on #58.

## Test plan
- [x] Full suite green; new tests cover projection round-trips, steer comment composition (middleware-level), live/idle/missing plan-edit paths, chat-schema plan projection
- [x] Live-verified: execution plan panel showed per-node states updating mid-run in the embedded console