### PR TITLE
feat(host-core): chat trace views and feedback reactions

### DIFF
--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/app.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/app.py
@@ -34,11 +34,13 @@ from qwenpaw_data.host.core.api.routers import console as console_router
 from qwenpaw_data.host.core.api.routers import cron as cron_router
 from qwenpaw_data.host.core.api.routers import datasources as datasources_router
 from qwenpaw_data.host.core.api.routers import events as events_router
+from qwenpaw_data.host.core.api.routers import feedback as feedback_router
 from qwenpaw_data.host.core.api.routers import plan as plan_router
 from qwenpaw_data.host.core.api.routers import preferences as preferences_router
 from qwenpaw_data.host.core.api.routers import sessions as sessions_router
 from qwenpaw_data.host.core.api.routers import settlement as settlement_router
 from qwenpaw_data.host.core.api.routers import steer as steer_router
+from qwenpaw_data.host.core.api.routers import trace as trace_router
 from qwenpaw_data.host.core.cron import CronManager
 from qwenpaw_data.host.core.domain.identity import Identity
 from qwenpaw_data.host.core.model import build_model_from_env
@@ -54,6 +56,7 @@ from qwenpaw_data.host.core.store.json_store import (
     JSONChatEventStore,
     JSONChatStore,
     JSONCronStore,
+    JSONFeedbackStore,
     JSONPreferencesStore,
     JSONSessionStore,
     JSONSettlementStore,
@@ -115,6 +118,7 @@ def create_app(
             channel_config_store: Any = JSONChannelConfigStore(store_root)
             channel_binding_store: Any = JSONChannelBindingStore(store_root)
             attachment_store: Any = JSONAttachmentStore(store_root)
+            feedback_store: Any = JSONFeedbackStore(store_root)
         else:
             from qwenpaw_data.host.core.db.engine import (
                 create_engine_and_factory,
@@ -128,6 +132,7 @@ def create_app(
                 SQLChatEventStore,
                 SQLChatStore,
                 SQLCronStore,
+                SQLFeedbackStore,
                 SQLPreferencesStore,
                 SQLSessionStore,
                 SQLSettlementStore,
@@ -146,6 +151,7 @@ def create_app(
             channel_config_store = SQLChannelConfigStore(factory)
             channel_binding_store = SQLChannelBindingStore(factory)
             attachment_store = SQLAttachmentStore(factory)
+            feedback_store = SQLFeedbackStore(factory)
 
         async def resolve_model() -> Any:
             """Prefer the local user's configured default model over env."""
@@ -178,6 +184,7 @@ def create_app(
             channel_configs=channel_config_store,
             channel_bindings=channel_binding_store,
             attachments=attachment_store,
+            feedback=feedback_store,
             hosts=QwenPawDataHostRegistry(
                 home=resolved_home,
                 model=model,
@@ -261,6 +268,8 @@ def create_app(
     app.include_router(console_router.router, prefix="/api/v1")
     app.include_router(events_router.router, prefix="/api/v1")
     app.include_router(plan_router.router, prefix="/api/v1")
+    app.include_router(trace_router.router, prefix="/api/v1")
+    app.include_router(feedback_router.router, prefix="/api/v1")
     app.include_router(steer_router.router, prefix="/api/v1")
     app.include_router(clarification_router.router, prefix="/api/v1")
     app.include_router(preferences_router.router, prefix="/api/v1")

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/deps.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/deps.py
@@ -16,6 +16,7 @@ from qwenpaw_data.host.core.store.protocols import (
     ChatEventStore,
     ChatStore,
     CronStore,
+    FeedbackStore,
     PreferencesStore,
     SessionStore,
     SettlementStore,
@@ -33,6 +34,7 @@ class ServiceState:
     channel_configs: ChannelConfigStore
     channel_bindings: ChannelBindingStore
     attachments: AttachmentStore
+    feedback: FeedbackStore
     hosts: QwenPawDataHostRegistry
     cron_manager: Any = None
     channel_manager: Any = None

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/models/artifact.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/models/artifact.py
@@ -16,6 +16,14 @@ class ArtifactSchema(ApiModel):
     updated_at: datetime
 
 
+class ArtifactLineRefSchema(ApiModel):
+    artifact_id: str
+    content_hash: str
+    line_start: int
+    line_end: int
+    quote: str
+
+
 class ArtifactCommentSchema(ApiModel):
     path: str
     line_start: int

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/models/chat.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/models/chat.py
@@ -4,13 +4,27 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Literal
 
-from qwenpaw_data.host.core.api.models.artifact import ArtifactCommentSchema
+from qwenpaw_data.host.core.api.models.artifact import (
+    ArtifactCommentSchema,
+    ArtifactLineRefSchema,
+)
 from qwenpaw_data.host.core.api.models.common import ApiModel, AttachmentRefSchema
 
 
 class ChatErrorSchema(ApiModel):
     code: str
     message: str
+
+
+class FeedbackSchema(ApiModel):
+    id: str
+    session_id: str
+    chat_id: str
+    kind: Literal["like", "dislike", "copy", "artifact_comment"]
+    reason: str | None = None
+    detail: str | None = None
+    artifact_ref: ArtifactLineRefSchema | None = None
+    created_at: datetime
 
 
 class AskUserQuestionAnswerSchema(ApiModel):

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/models/requests.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/models/requests.py
@@ -1,7 +1,12 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-from qwenpaw_data.host.core.api.models.artifact import ArtifactCommentSchema
+from typing import Literal
+
+from qwenpaw_data.host.core.api.models.artifact import (
+    ArtifactCommentSchema,
+    ArtifactLineRefSchema,
+)
 from qwenpaw_data.host.core.api.models.chat import (
     AskUserQuestionAnsweredResultSchema,
     AskUserQuestionTimeoutResultSchema,
@@ -42,6 +47,13 @@ class SteerRequest(ApiModel):
 class PlanEditRequest(ApiModel):
     reason: str | None = None
     plan: PlanSchema | None
+
+
+class FeedbackRequest(ApiModel):
+    kind: Literal["like", "dislike", "copy", "artifact_comment"]
+    reason: str | None = None
+    detail: str | None = None
+    artifact_ref: ArtifactLineRefSchema | None = None
 
 
 class ClarificationAnswerRequest(ApiModel):

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/routers/feedback.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/routers/feedback.py
@@ -1,0 +1,106 @@
+# -*- coding: utf-8 -*-
+"""Like/dislike reactions and appended feedback on a chat."""
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, Response
+
+from qwenpaw_data.host.core.api.deps import ServiceState, get_identity, get_state
+from qwenpaw_data.host.core.api.errors import map_domain_error
+from qwenpaw_data.host.core.api.models.chat import FeedbackSchema
+from qwenpaw_data.host.core.api.models.requests import FeedbackRequest
+from qwenpaw_data.host.core.domain.identity import Identity
+from qwenpaw_data.host.core.utils.time import utcnow
+
+router = APIRouter(prefix="/sessions/{session_id}/chats/{chat_id}", tags=["feedback"])
+
+
+def _to_schema(data: dict[str, Any]) -> dict[str, Any]:
+    return FeedbackSchema.model_validate(data).model_dump(mode="json")
+
+
+async def _touch_chat(state: ServiceState, chat) -> None:
+    chat.updated_at = utcnow()
+    await state.chats.save(chat)
+
+
+@router.post("/feedback")
+async def feedback(
+    session_id: str,
+    chat_id: str,
+    body: FeedbackRequest,
+    identity: Identity = Depends(get_identity),
+    state: ServiceState = Depends(get_state),
+) -> dict[str, Any]:
+    try:
+        chat = await state.chats.get(chat_id, session_id=session_id)
+        if body.kind in {"like", "dislike"}:
+            fb = await state.feedback.set_reaction(
+                user_id=identity.user_id,
+                session_id=session_id,
+                chat_id=chat_id,
+                kind=body.kind,
+                reason=body.reason,
+                detail=body.detail,
+            )
+        else:
+            fb = await state.feedback.add(
+                user_id=identity.user_id,
+                session_id=session_id,
+                chat_id=chat_id,
+                kind=body.kind,
+                reason=body.reason,
+                detail=body.detail,
+                artifact_ref=(
+                    body.artifact_ref.model_dump(mode="json")
+                    if body.artifact_ref
+                    else None
+                ),
+            )
+        await _touch_chat(state, chat)
+    except Exception as exc:
+        http = map_domain_error(exc)
+        if http:
+            raise http from exc
+        raise
+    return {"feedback": _to_schema(fb)}
+
+
+@router.get("/feedback/reaction")
+async def get_feedback_reaction(
+    session_id: str,
+    chat_id: str,
+    identity: Identity = Depends(get_identity),
+    state: ServiceState = Depends(get_state),
+) -> dict[str, Any]:
+    try:
+        await state.chats.get(chat_id, session_id=session_id)
+        reaction = await state.feedback.get_reaction(
+            identity.user_id, session_id, chat_id
+        )
+    except Exception as exc:
+        http = map_domain_error(exc)
+        if http:
+            raise http from exc
+        raise
+    return {"feedback": _to_schema(reaction) if reaction else None}
+
+
+@router.delete("/feedback/reaction", status_code=204)
+async def delete_feedback_reaction(
+    session_id: str,
+    chat_id: str,
+    identity: Identity = Depends(get_identity),
+    state: ServiceState = Depends(get_state),
+) -> Response:
+    try:
+        chat = await state.chats.get(chat_id, session_id=session_id)
+        await state.feedback.clear_reaction(identity.user_id, session_id, chat_id)
+        await _touch_chat(state, chat)
+    except Exception as exc:
+        http = map_domain_error(exc)
+        if http:
+            raise http from exc
+        raise
+    return Response(status_code=204)

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/routers/trace.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/routers/trace.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+"""Raw message and business-event trace for a chat."""
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, Query
+
+from qwenpaw_data.host.core.api.deps import ServiceState, get_identity, get_state
+from qwenpaw_data.host.core.api.errors import map_domain_error, raise_api
+from qwenpaw_data.host.core.api.models.stream_objects import dump_stream_object
+from qwenpaw_data.host.core.domain.identity import Identity
+
+router = APIRouter(prefix="/sessions/{session_id}/chats/{chat_id}", tags=["trace"])
+
+
+@router.get("/trace")
+async def trace(
+    session_id: str,
+    chat_id: str,
+    identity: Identity = Depends(get_identity),
+    state: ServiceState = Depends(get_state),
+    view: str = Query("raw"),
+) -> dict[str, Any]:
+    _ = identity
+    if view not in ("raw", "business", "both"):
+        raise_api("VALIDATION", "invalid view", status=400)
+    try:
+        await state.chats.get(chat_id, session_id=session_id)
+        events = await state.events.read_after(chat_id, -1)
+    except Exception as exc:
+        http = map_domain_error(exc)
+        if http:
+            raise http from exc
+        raise
+    messages: list[dict[str, Any]] = []
+    if view in ("raw", "both"):
+        for obj in events:
+            if obj.object != "message":
+                continue
+            payload = dump_stream_object(obj)
+            payload.pop("sequence_number", None)
+            payload.pop("session_id", None)
+            messages.append(payload)
+    biz_events: list[dict[str, Any]] = []
+    if view in ("business", "both"):
+        biz_events = [
+            obj.biz_event.model_dump(mode="json")
+            for obj in events
+            if obj.object == "biz_event" and obj.biz_event.channel == "main"
+        ]
+    return {"messages": messages, "biz_events": biz_events}

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/db/tables.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/db/tables.py
@@ -94,6 +94,21 @@ class AttachmentRow(UserIdColumn, Base):
     )
 
 
+class FeedbackRow(UserIdColumn, Base):
+    __tablename__ = "feedbacks"
+
+    id: Mapped[str] = mapped_column(String, primary_key=True)
+    session_id: Mapped[str] = mapped_column(String, nullable=False)
+    chat_id: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    kind: Mapped[str] = mapped_column(String, nullable=False)
+    reason: Mapped[str | None] = mapped_column(String, nullable=True)
+    detail: Mapped[str | None] = mapped_column(Text, nullable=True)
+    artifact_ref_json: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=utcnow
+    )
+
+
 class ChatEventRow(UserIdColumn, Base):
     __tablename__ = "chat_events"
 

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/store/json_store.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/store/json_store.py
@@ -34,6 +34,7 @@ from qwenpaw_data.host.core.store._prefs_logic import (
     clean_model_upsert,
     merge_provider_patch,
 )
+from qwenpaw_data.host.core.utils.ids import create_id
 from qwenpaw_data.host.core.utils.secrets import decrypt_api_key
 from qwenpaw_data.host.core.utils.time import utcnow
 
@@ -1122,3 +1123,152 @@ class JSONAttachmentStore:
     async def delete(self, user_id: str, attachment_id: str) -> None:
         await self.get(user_id, attachment_id)
         await asyncio.to_thread(self._path(attachment_id).unlink)
+
+
+class JSONFeedbackStore:
+    """Layout: ``<root>/feedback/<chat_id>.json`` (list of feedback docs)."""
+
+    def __init__(self, root: Path) -> None:
+        self._feedback_root = Path(root).expanduser().resolve() / "feedback"
+
+    def _path(self, chat_id: str) -> Path:
+        return self._feedback_root / f"{chat_id}.json"
+
+    def _read(self, chat_id: str) -> list[dict[str, Any]]:
+        path = self._path(chat_id)
+        with file_lock(path):
+            if not path.exists():
+                return []
+            return json.loads(path.read_text(encoding="utf-8"))
+
+    def _write(self, chat_id: str, docs: list[dict[str, Any]]) -> None:
+        path = self._path(chat_id)
+        with file_lock(path):
+            write_atomic(path, docs)
+
+    @staticmethod
+    def _new_doc(
+        *,
+        user_id: str,
+        session_id: str,
+        chat_id: str,
+        kind: str,
+        reason: str | None,
+        detail: str | None,
+        artifact_ref: dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        return {
+            "id": create_id("fbk"),
+            "user_id": user_id,
+            "session_id": session_id,
+            "chat_id": chat_id,
+            "kind": kind,
+            "reason": reason,
+            "detail": detail,
+            "artifact_ref": artifact_ref,
+            "created_at": _dt_to_json(utcnow()),
+        }
+
+    @staticmethod
+    def _public(doc: dict[str, Any]) -> dict[str, Any]:
+        item = dict(doc)
+        item.pop("user_id", None)
+        item["created_at"] = _dt_from_json(doc["created_at"])
+        return item
+
+    async def add(
+        self,
+        *,
+        user_id: str,
+        session_id: str,
+        chat_id: str,
+        kind: str,
+        reason: str | None = None,
+        detail: str | None = None,
+        artifact_ref: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        doc = self._new_doc(
+            user_id=user_id,
+            session_id=session_id,
+            chat_id=chat_id,
+            kind=kind,
+            reason=reason,
+            detail=detail,
+            artifact_ref=artifact_ref,
+        )
+
+        def _append() -> None:
+            docs = self._read(chat_id)
+            docs.append(doc)
+            self._write(chat_id, docs)
+
+        await asyncio.to_thread(_append)
+        return self._public(doc)
+
+    def _reactions(self, docs: list[dict[str, Any]], user_id: str) -> list[dict]:
+        return [
+            d
+            for d in docs
+            if d["kind"] in ("like", "dislike") and d["user_id"] == user_id
+        ]
+
+    async def set_reaction(
+        self,
+        *,
+        user_id: str,
+        session_id: str,
+        chat_id: str,
+        kind: str,
+        reason: str | None = None,
+        detail: str | None = None,
+    ) -> dict[str, Any]:
+        if kind not in ("like", "dislike"):
+            raise ValueError("reaction kind must be like or dislike")
+        doc = self._new_doc(
+            user_id=user_id,
+            session_id=session_id,
+            chat_id=chat_id,
+            kind=kind,
+            reason=reason,
+            detail=detail,
+            artifact_ref=None,
+        )
+
+        def _replace() -> None:
+            docs = self._read(chat_id)
+            docs = [d for d in docs if d not in self._reactions(docs, user_id)]
+            docs.append(doc)
+            self._write(chat_id, docs)
+
+        await asyncio.to_thread(_replace)
+        return self._public(doc)
+
+    async def get_reaction(
+        self,
+        user_id: str,
+        session_id: str,
+        chat_id: str,
+    ) -> dict[str, Any] | None:
+        _ = session_id
+        docs = await asyncio.to_thread(self._read, chat_id)
+        reactions = self._reactions(docs, user_id)
+        if not reactions:
+            return None
+        reactions.sort(key=lambda d: (d["created_at"], d["id"]))
+        return self._public(reactions[-1])
+
+    async def clear_reaction(
+        self,
+        user_id: str,
+        session_id: str,
+        chat_id: str,
+    ) -> None:
+        _ = session_id
+
+        def _clear() -> None:
+            docs = self._read(chat_id)
+            keep = [d for d in docs if d not in self._reactions(docs, user_id)]
+            if len(keep) != len(docs):
+                self._write(chat_id, keep)
+
+        await asyncio.to_thread(_clear)

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/store/protocols.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/store/protocols.py
@@ -172,6 +172,47 @@ class AttachmentStore(Protocol):
     async def delete(self, user_id: str, attachment_id: str) -> None: ...
 
 
+class FeedbackStore(Protocol):
+    """Chat feedback: one mutable like/dislike reaction plus append-only rest."""
+
+    async def add(
+        self,
+        *,
+        user_id: str,
+        session_id: str,
+        chat_id: str,
+        kind: str,
+        reason: str | None = None,
+        detail: str | None = None,
+        artifact_ref: dict[str, Any] | None = None,
+    ) -> dict[str, Any]: ...
+
+    async def set_reaction(
+        self,
+        *,
+        user_id: str,
+        session_id: str,
+        chat_id: str,
+        kind: str,
+        reason: str | None = None,
+        detail: str | None = None,
+    ) -> dict[str, Any]: ...
+
+    async def get_reaction(
+        self,
+        user_id: str,
+        session_id: str,
+        chat_id: str,
+    ) -> dict[str, Any] | None: ...
+
+    async def clear_reaction(
+        self,
+        user_id: str,
+        session_id: str,
+        chat_id: str,
+    ) -> None: ...
+
+
 class ChatEventStore(Protocol):
     async def append(
         self,

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/store/sql_store.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/store/sql_store.py
@@ -30,6 +30,7 @@ from qwenpaw_data.host.core.db.tables import (
     ChatEventRow,
     ChatRow,
     CronJobRow,
+    FeedbackRow,
     SessionRow,
     SettlementCardRow,
     UserActiveModelRow,
@@ -1123,4 +1124,134 @@ class SQLAttachmentStore:
             if row is None or row.user_id != user_id:
                 raise LookupError("attachment not found")
             await db.delete(row)
+            await db.commit()
+
+
+class SQLFeedbackStore:
+    def __init__(self, session_factory: async_sessionmaker[AsyncSession]) -> None:
+        self._sessions = session_factory
+
+    @staticmethod
+    def _to_dict(row: FeedbackRow) -> dict[str, Any]:
+        return {
+            "id": row.id,
+            "session_id": row.session_id,
+            "chat_id": row.chat_id,
+            "kind": row.kind,
+            "reason": row.reason,
+            "detail": row.detail,
+            "artifact_ref": row.artifact_ref_json,
+            "created_at": row.created_at,
+        }
+
+    async def _reaction_rows(
+        self,
+        db: AsyncSession,
+        user_id: str,
+        chat_id: str,
+    ) -> list[FeedbackRow]:
+        return list(
+            (
+                await db.scalars(
+                    select(FeedbackRow)
+                    .where(
+                        FeedbackRow.user_id == user_id,
+                        FeedbackRow.chat_id == chat_id,
+                        FeedbackRow.kind.in_(("like", "dislike")),
+                    )
+                    .order_by(
+                        FeedbackRow.created_at.desc(), FeedbackRow.id.desc()
+                    )
+                )
+            ).all()
+        )
+
+    async def add(
+        self,
+        *,
+        user_id: str,
+        session_id: str,
+        chat_id: str,
+        kind: str,
+        reason: str | None = None,
+        detail: str | None = None,
+        artifact_ref: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        async with self._sessions() as db:
+            row = FeedbackRow(
+                id=create_id("fbk"),
+                user_id=user_id,
+                session_id=session_id,
+                chat_id=chat_id,
+                kind=kind,
+                reason=reason,
+                detail=detail,
+                artifact_ref_json=artifact_ref,
+                created_at=utcnow(),
+            )
+            db.add(row)
+            await db.commit()
+            return self._to_dict(row)
+
+    async def set_reaction(
+        self,
+        *,
+        user_id: str,
+        session_id: str,
+        chat_id: str,
+        kind: str,
+        reason: str | None = None,
+        detail: str | None = None,
+    ) -> dict[str, Any]:
+        if kind not in ("like", "dislike"):
+            raise ValueError("reaction kind must be like or dislike")
+        async with self._sessions() as db:
+            now = utcnow()
+            rows = await self._reaction_rows(db, user_id, chat_id)
+            if rows:
+                row = rows[0]
+                row.kind = kind
+                row.reason = reason
+                row.detail = detail
+                row.artifact_ref_json = None
+                row.created_at = now
+                for stale in rows[1:]:
+                    await db.delete(stale)
+            else:
+                row = FeedbackRow(
+                    id=create_id("fbk"),
+                    user_id=user_id,
+                    session_id=session_id,
+                    chat_id=chat_id,
+                    kind=kind,
+                    reason=reason,
+                    detail=detail,
+                    artifact_ref_json=None,
+                    created_at=now,
+                )
+                db.add(row)
+            await db.commit()
+            return self._to_dict(row)
+
+    async def get_reaction(
+        self,
+        user_id: str,
+        session_id: str,
+        chat_id: str,
+    ) -> dict[str, Any] | None:
+        _ = session_id
+        async with self._sessions() as db:
+            rows = await self._reaction_rows(db, user_id, chat_id)
+            return self._to_dict(rows[0]) if rows else None
+
+    async def clear_reaction(
+        self,
+        user_id: str,
+        session_id: str,
+        chat_id: str,
+    ) -> None:
+        _ = session_id
+        async with self._sessions() as db:
+            for row in await self._reaction_rows(db, user_id, chat_id):
+                await db.delete(row)
             await db.commit()

--- a/packages/qwenpaw-data-host-core/tests/test_trace_feedback.py
+++ b/packages/qwenpaw-data-host-core/tests/test_trace_feedback.py
@@ -1,0 +1,260 @@
+# -*- coding: utf-8 -*-
+"""Trace view assembly and feedback store/routes."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import pytest
+
+from qwenpaw_data.host.core.store.json_store import JSONFeedbackStore
+
+sqlalchemy = pytest.importorskip("sqlalchemy")
+
+from qwenpaw_data.host.core.db.engine import (  # noqa: E402
+    create_engine_and_factory,
+    init_db,
+)
+from qwenpaw_data.host.core.store.sql_store import SQLFeedbackStore  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# FeedbackStore conformance
+
+
+@pytest.fixture(params=["json", "sql"])
+async def feedback_store(request, tmp_path: Path):
+    if request.param == "json":
+        yield JSONFeedbackStore(tmp_path)
+        return
+    engine, factory = create_engine_and_factory(
+        f"sqlite+aiosqlite:///{tmp_path / 'host.db'}",
+    )
+    await init_db(engine)
+    yield SQLFeedbackStore(factory)
+    await engine.dispose()
+
+
+IDS = {"user_id": "local", "session_id": "ses1", "chat_id": "chat1"}
+
+
+async def test_reaction_set_replace_get_clear(feedback_store) -> None:
+    assert await feedback_store.get_reaction("local", "ses1", "chat1") is None
+
+    liked = await feedback_store.set_reaction(**IDS, kind="like")
+    assert liked["kind"] == "like"
+    assert liked["chat_id"] == "chat1"
+
+    switched = await feedback_store.set_reaction(
+        **IDS, kind="dislike", reason="错误结论", detail="口径没对齐"
+    )
+    assert switched["kind"] == "dislike"
+
+    current = await feedback_store.get_reaction("local", "ses1", "chat1")
+    assert current is not None
+    assert current["kind"] == "dislike"
+    assert current["reason"] == "错误结论"
+
+    # Reactions are per user.
+    assert await feedback_store.get_reaction("other", "ses1", "chat1") is None
+
+    await feedback_store.clear_reaction("local", "ses1", "chat1")
+    assert await feedback_store.get_reaction("local", "ses1", "chat1") is None
+
+
+async def test_reaction_rejects_other_kinds(feedback_store) -> None:
+    with pytest.raises(ValueError, match="like or dislike"):
+        await feedback_store.set_reaction(**IDS, kind="copy")
+
+
+async def test_add_keeps_history_and_reaction_apart(feedback_store) -> None:
+    copied = await feedback_store.add(**IDS, kind="copy")
+    assert copied["kind"] == "copy"
+    commented = await feedback_store.add(
+        **IDS,
+        kind="artifact_comment",
+        detail="换个配色",
+        artifact_ref={
+            "artifact_id": "art_1",
+            "content_hash": "h",
+            "line_start": 1,
+            "line_end": 2,
+            "quote": "q",
+        },
+    )
+    assert commented["artifact_ref"]["artifact_id"] == "art_1"
+    # Appended feedback never surfaces as the reaction.
+    assert await feedback_store.get_reaction("local", "ses1", "chat1") is None
+    await feedback_store.clear_reaction("local", "ses1", "chat1")
+
+
+# ---------------------------------------------------------------------------
+# Routes
+
+pytest.importorskip("fastapi")
+import httpx  # noqa: E402
+
+from qwenpaw_data.host.core.api.app import create_app  # noqa: E402
+from qwenpaw_data.host.core.domain.identity import Identity  # noqa: E402
+from qwenpaw_data.host.core.domain.session import Session  # noqa: E402
+
+
+@asynccontextmanager
+async def service_client(tmp_path: Path, monkeypatch):
+    monkeypatch.delenv("QWENPAW_DATA_API_TOKEN", raising=False)
+    monkeypatch.delenv("QWENPAW_DATA_DB_URL", raising=False)
+    monkeypatch.delenv("QWENPAW_DATA_STORE", raising=False)
+    app = create_app(home=tmp_path, model=object())
+    async with app.router.lifespan_context(app):
+        transport = httpx.ASGITransport(app=app, client=("127.0.0.1", 1234))
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://testserver",
+        ) as http:
+            yield http, app
+
+
+async def _seed_chat(app) -> tuple[str, str]:
+    state = app.state.service
+    session = Session.create(identity=Identity.anonymous())
+    await state.sessions.add(session)
+    chat = session.open_chat(text="hi", datasource_id=None, has_active_chat=False)
+    await state.sessions.save(session)
+    await state.chats.add(chat)
+    return session.id, chat.id
+
+
+def _message_payload(msg_id: str, text: str) -> dict:
+    return {
+        "object": "message",
+        "id": msg_id,
+        "sequence": 0,
+        "type": "text",
+        "role": "assistant",
+        "status": "completed",
+        "content": [
+            {"object": "content", "type": "text", "index": 0, "text": text}
+        ],
+    }
+
+
+def _biz_event_payload(event_id: str, channel: str) -> dict:
+    return {
+        "object": "biz_event",
+        "biz_event": {
+            "event_id": event_id,
+            "seq": 1,
+            "channel": channel,
+            "status": "done",
+            "started_at": 1.0,
+            "presentation": {
+                "card_type": "text",
+                "caption": "取数",
+                "body": "拉取订单明细",
+            },
+        },
+    }
+
+
+async def test_trace_views(tmp_path, monkeypatch) -> None:
+    async with service_client(tmp_path, monkeypatch) as (http, app):
+        sid, cid = await _seed_chat(app)
+        events = app.state.service.events
+        await events.append(
+            session_id=sid, chat_id=cid, payload=_message_payload("msg_1", "你好")
+        )
+        await events.append(
+            session_id=sid, chat_id=cid, payload=_biz_event_payload("be_1", "main")
+        )
+        await events.append(
+            session_id=sid,
+            chat_id=cid,
+            payload=_biz_event_payload("be_2", "subagent"),
+        )
+
+        raw = await http.get(f"/api/v1/sessions/{sid}/chats/{cid}/trace")
+        assert raw.status_code == 200, raw.text
+        body = raw.json()
+        assert [m["id"] for m in body["messages"]] == ["msg_1"]
+        assert "sequence_number" not in body["messages"][0]
+        assert body["biz_events"] == []
+
+        business = await http.get(
+            f"/api/v1/sessions/{sid}/chats/{cid}/trace", params={"view": "business"}
+        )
+        events_body = business.json()
+        assert events_body["messages"] == []
+        # Subagent-channel events are filtered out.
+        assert [e["event_id"] for e in events_body["biz_events"]] == ["be_1"]
+
+        both = await http.get(
+            f"/api/v1/sessions/{sid}/chats/{cid}/trace", params={"view": "both"}
+        )
+        assert both.json()["messages"] and both.json()["biz_events"]
+
+        invalid = await http.get(
+            f"/api/v1/sessions/{sid}/chats/{cid}/trace", params={"view": "nope"}
+        )
+        assert invalid.status_code == 400
+
+        missing = await http.get("/api/v1/sessions/s/chats/c/trace")
+        assert missing.status_code == 404
+
+
+async def test_feedback_routes(tmp_path, monkeypatch) -> None:
+    async with service_client(tmp_path, monkeypatch) as (http, app):
+        sid, cid = await _seed_chat(app)
+        base = f"/api/v1/sessions/{sid}/chats/{cid}/feedback"
+
+        # No reaction yet.
+        empty = await http.get(f"{base}/reaction")
+        assert empty.status_code == 200
+        assert empty.json()["feedback"] is None
+
+        liked = await http.post(base, json={"kind": "like"})
+        assert liked.status_code == 200, liked.text
+        assert liked.json()["feedback"]["kind"] == "like"
+
+        # Switching replaces instead of stacking.
+        switched = await http.post(
+            base, json={"kind": "dislike", "reason": "结论不对"}
+        )
+        assert switched.json()["feedback"]["kind"] == "dislike"
+        reaction = await http.get(f"{base}/reaction")
+        assert reaction.json()["feedback"]["kind"] == "dislike"
+
+        # Copy feedback is appended and does not disturb the reaction.
+        copied = await http.post(base, json={"kind": "copy"})
+        assert copied.status_code == 200
+        assert (await http.get(f"{base}/reaction")).json()["feedback"][
+            "kind"
+        ] == "dislike"
+
+        commented = await http.post(
+            base,
+            json={
+                "kind": "artifact_comment",
+                "detail": "调整图例",
+                "artifact_ref": {
+                    "artifact_id": "art_1",
+                    "content_hash": "h",
+                    "line_start": 1,
+                    "line_end": 1,
+                    "quote": "q",
+                },
+            },
+        )
+        assert commented.status_code == 200
+        assert (
+            commented.json()["feedback"]["artifact_ref"]["artifact_id"] == "art_1"
+        )
+
+        deleted = await http.delete(f"{base}/reaction")
+        assert deleted.status_code == 204
+        assert (await http.get(f"{base}/reaction")).json()["feedback"] is None
+
+        missing = await http.post(
+            "/api/v1/sessions/s/chats/c/feedback", json={"kind": "like"}
+        )
+        assert missing.status_code == 404


### PR DESCRIPTION
## Summary
- `GET /sessions/{sid}/chats/{cid}/trace?view=raw|business|both` assembles the raw message transcript and main-channel business events from the persisted event stream — no separate trace store.
- Feedback routes keep one mutable like/dislike reaction per user and chat (switching replaces, never stacks); copy and artifact-comment feedback append as history. `FeedbackStore` ships JSON and SQL backends under the shared conformance suite.

Stacked on the plan-edit PR.

## Test plan
- [x] Full suite green; new tests cover reaction set/replace/get/clear + user scoping (both backends), trace view assembly incl. subagent-channel filtering, feedback route flows
- [x] Live-verified: Traces tab rendered the real run trace; like feedback persisted and rendered active in the embedded console