### PR TITLE
feat(host-core): session fork/snapshot, signed share links, console bootstrap

### DIFF
--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/app.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/app.py
@@ -287,6 +287,11 @@ def create_app(
     async def health() -> dict[str, str]:
         return {"status": "ok"}
 
+    @app.get("/api/v1/auth/status")
+    async def auth_status() -> dict[str, Any]:
+        """Console-compat probe; bearer auth lives in the middleware."""
+        return {"enabled": False, "sso_enabled": False, "sso_login_path": ""}
+
     # Auth first (inner), CORS last (outermost).
     install_api_token_auth(app)
     app.add_middleware(

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/app.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/app.py
@@ -35,6 +35,7 @@ from qwenpaw_data.host.core.api.routers import cron as cron_router
 from qwenpaw_data.host.core.api.routers import datasources as datasources_router
 from qwenpaw_data.host.core.api.routers import events as events_router
 from qwenpaw_data.host.core.api.routers import feedback as feedback_router
+from qwenpaw_data.host.core.api.routers import files as files_router
 from qwenpaw_data.host.core.api.routers import plan as plan_router
 from qwenpaw_data.host.core.api.routers import preferences as preferences_router
 from qwenpaw_data.host.core.api.routers import sessions as sessions_router
@@ -278,6 +279,8 @@ def create_app(
     app.include_router(settlement_router.router, prefix="/api/v1")
     app.include_router(channels_router.router, prefix="/api/v1")
     app.include_router(artifacts_router.router, prefix="/api/v1")
+    app.include_router(files_router.router, prefix="/api/v1")
+    app.include_router(files_router.shared_router, prefix="/api/v1")
     app.include_router(channels_router.config_router, prefix="/api/v1")
 
     @app.get("/health")

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/app.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/app.py
@@ -277,6 +277,7 @@ def create_app(
     app.include_router(datasources_router.router, prefix="/api/v1")
     app.include_router(cron_router.router, prefix="/api/v1")
     app.include_router(settlement_router.router, prefix="/api/v1")
+    app.include_router(settlement_router.drafts_router, prefix="/api/v1")
     app.include_router(channels_router.router, prefix="/api/v1")
     app.include_router(artifacts_router.router, prefix="/api/v1")
     app.include_router(files_router.router, prefix="/api/v1")

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/auth.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/auth.py
@@ -21,6 +21,8 @@ from fastapi.responses import JSONResponse
 
 API_TOKEN_ENV = "QWENPAW_DATA_API_TOKEN"
 AUTH_EXEMPT_PATHS = frozenset({"/health"})
+# Share links carry their own HMAC credential; recipients have no token.
+AUTH_EXEMPT_PREFIXES = ("/api/v1/files/shared/",)
 
 
 def get_configured_api_token() -> str:
@@ -58,6 +60,8 @@ def install_api_token_auth(app: FastAPI) -> None:
     @app.middleware("http")
     async def api_token_auth_middleware(request: Request, call_next):
         if request.url.path in AUTH_EXEMPT_PATHS or request.method == "OPTIONS":
+            return await call_next(request)
+        if request.url.path.startswith(AUTH_EXEMPT_PREFIXES):
             return await call_next(request)
 
         expected = get_configured_api_token()

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/mappers.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/mappers.py
@@ -116,7 +116,11 @@ def session_to_schema(
     ).model_dump(mode="json")
 
 
-def chat_to_schema(chat: Chat) -> dict[str, Any]:
+def chat_to_schema(
+    chat: Chat,
+    extras: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    bundle = extras or {}
     return ChatSchema(
         id=chat.id,
         session_id=chat.session_id,
@@ -131,6 +135,10 @@ def chat_to_schema(chat: Chat) -> dict[str, Any]:
         active_duration_ms=chat.active_duration_ms,
         error=ChatErrorSchema(**chat.error) if chat.error else None,
         plan=sop_plan_to_schema(chat.plan),
+        segments=bundle.get("segments") or [],
+        biz_events=bundle.get("biz_events") or [],
+        artifacts=bundle.get("artifacts") or [],
+        followup=bundle.get("followup"),
         artifact_comments=chat.artifact_comments,  # type: ignore[arg-type]
         attachments=chat.attachments,  # type: ignore[arg-type]
     ).model_dump(mode="json")

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/models/artifact.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/models/artifact.py
@@ -29,3 +29,13 @@ class ArtifactCommentSchema(ApiModel):
     line_start: int
     line_end: int
     comment: str
+
+
+class ShareFileRequest(ApiModel):
+    path: str
+
+
+class ShareFileResponse(ApiModel):
+    url: str
+    expires_at: datetime
+    name: str

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/models/chat.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/models/chat.py
@@ -7,8 +7,10 @@ from typing import Any, Literal
 from qwenpaw_data.host.core.api.models.artifact import (
     ArtifactCommentSchema,
     ArtifactLineRefSchema,
+    ArtifactSchema,
 )
 from qwenpaw_data.host.core.api.models.common import ApiModel, AttachmentRefSchema
+from qwenpaw_data.host.core.api.models.trace import BizEventSchema, SegmentSchema
 
 
 class ChatErrorSchema(ApiModel):
@@ -76,5 +78,9 @@ class ChatSchema(ApiModel):
     active_duration_ms: int = 0
     error: ChatErrorSchema | None = None
     plan: dict[str, Any] | None = None
+    segments: list[SegmentSchema] = []
+    biz_events: list[BizEventSchema] = []
+    artifacts: list[ArtifactSchema] = []
+    followup: FollowUpSchema | None = None
     artifact_comments: list[ArtifactCommentSchema] = []
     attachments: list[AttachmentRefSchema] = []

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/models/preferences.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/models/preferences.py
@@ -53,3 +53,15 @@ class SetActiveModelsRequest(ApiModel):
     default_model_id: str
     light_provider_id: str | None = None
     light_model_id: str | None = None
+
+
+class RuntimeSettingsSchema(ApiModel):
+    react_max_iters: int
+    llm_retry_enabled: bool
+    llm_max_retries: int
+
+
+class SetRuntimeSettingsRequest(ApiModel):
+    react_max_iters: int | None = None
+    llm_retry_enabled: bool | None = None
+    llm_max_retries: int | None = None

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/models/requests.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/models/requests.py
@@ -25,6 +25,10 @@ class PatchSessionRequest(ApiModel):
     title: str | None = None
 
 
+class ForkSessionRequest(ApiModel):
+    chat_id: str
+
+
 class CreateChatRequest(ApiModel):
     text: str
     datasource_id: str | None = None

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/routers/files.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/routers/files.py
@@ -1,0 +1,194 @@
+# -*- coding: utf-8 -*-
+"""Session workspace file access and HMAC-signed share links.
+
+Share links substitute for the enterprise object-store URLs: the token
+encodes ``session_id|path|expiry`` signed with ``QWENPAW_DATA_SHARE_SECRET``
+(else the API token), so the resolver route works without bearer auth —
+the signature is the credential.
+"""
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import hmac
+import mimetypes
+import os
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Literal
+
+from fastapi import APIRouter, Depends, Query
+from fastapi.responses import FileResponse
+
+from qwenpaw_data.host.core.api.auth import get_configured_api_token
+from qwenpaw_data.host.core.api.deps import ServiceState, get_identity, get_state
+from qwenpaw_data.host.core.api.errors import map_domain_error, raise_api
+from qwenpaw_data.host.core.api.models.artifact import (
+    ShareFileRequest,
+    ShareFileResponse,
+)
+from qwenpaw_data.host.core.domain.identity import Identity
+
+router = APIRouter(prefix="/sessions/{session_id}/files", tags=["files"])
+shared_router = APIRouter(prefix="/files", tags=["files"])
+
+SHARE_SECRET_ENV = "QWENPAW_DATA_SHARE_SECRET"
+SHARE_TTL_ENV = "QWENPAW_DATA_SHARE_TTL_SECONDS"
+_DEFAULT_TTL_SECONDS = 3600
+
+
+def _artifact_dir(state: ServiceState, session_id: str) -> Path:
+    return Path(state.hosts.get(session_id=session_id).paths.artifact_dir)
+
+
+def resolve_session_file(artifact_root: Path, relative_path: str) -> Path:
+    """Containment-checked lookup under the session artifact directory."""
+    if (
+        not relative_path
+        or relative_path.startswith(("/", "~"))
+        or "\\" in relative_path
+        or "\x00" in relative_path
+        or any(
+            segment in {"", ".", ".."} for segment in relative_path.split("/")
+        )
+    ):
+        raise_api("NOT_FOUND", "workspace file not found", status=404)
+    root = artifact_root.resolve()
+    # Normpath+prefix barrier; only the guarded branch may return, with a
+    # symlink-safe resolve containment check on top.
+    normalized = os.path.normpath(os.path.join(str(root), relative_path))
+    if normalized.startswith(str(root) + os.sep):
+        candidate = Path(normalized).resolve()
+        if candidate != root and root in candidate.parents and candidate.is_file():
+            return candidate
+    raise_api("NOT_FOUND", "workspace file not found", status=404)
+
+
+def _share_secret() -> str:
+    secret = (os.environ.get(SHARE_SECRET_ENV) or "").strip()
+    if secret:
+        return secret
+    return get_configured_api_token()
+
+
+def _share_ttl() -> int:
+    raw = (os.environ.get(SHARE_TTL_ENV) or "").strip()
+    try:
+        return max(60, int(raw)) if raw else _DEFAULT_TTL_SECONDS
+    except ValueError:
+        return _DEFAULT_TTL_SECONDS
+
+
+def _sign(session_id: str, path: str, expires: int, secret: str) -> str:
+    message = f"{session_id}|{path}|{expires}".encode()
+    return hmac.new(secret.encode(), message, hashlib.sha256).hexdigest()
+
+
+def _encode_token(session_id: str, path: str, expires: int) -> str:
+    raw = f"{session_id}|{path}|{expires}".encode()
+    return base64.urlsafe_b64encode(raw).decode().rstrip("=")
+
+
+def _decode_token(token: str) -> tuple[str, str, int]:
+    padded = token + "=" * (-len(token) % 4)
+    try:
+        raw = base64.urlsafe_b64decode(padded.encode()).decode()
+        session_id, path, expires = raw.rsplit("|", 2)
+        return session_id, path, int(expires)
+    except (ValueError, UnicodeDecodeError, binascii.Error) as exc:
+        raise LookupError("share link is invalid") from exc
+
+
+@router.get("/access", response_class=FileResponse)
+async def access_workspace_file(
+    session_id: str,
+    path: str = Query(..., min_length=1),
+    purpose: Literal["preview", "download"] = Query("preview"),
+    identity: Identity = Depends(get_identity),
+    state: ServiceState = Depends(get_state),
+) -> FileResponse:
+    _ = identity
+    try:
+        await state.sessions.get(session_id)
+    except Exception as exc:
+        http = map_domain_error(exc)
+        if http:
+            raise http from exc
+        raise
+    file_path = resolve_session_file(_artifact_dir(state, session_id), path)
+    media_type, _guess = mimetypes.guess_type(file_path.name)
+    return FileResponse(
+        path=file_path,
+        filename=file_path.name,
+        media_type=media_type or "application/octet-stream",
+        content_disposition_type=(
+            "inline" if purpose == "preview" else "attachment"
+        ),
+    )
+
+
+@router.post("/share")
+async def share_workspace_file(
+    session_id: str,
+    body: ShareFileRequest,
+    identity: Identity = Depends(get_identity),
+    state: ServiceState = Depends(get_state),
+) -> dict[str, Any]:
+    _ = identity
+    try:
+        await state.sessions.get(session_id)
+        secret = _share_secret()
+        if not secret:
+            raise ValueError(
+                "sharing requires QWENPAW_DATA_SHARE_SECRET or an API token"
+            )
+    except Exception as exc:
+        http = map_domain_error(exc)
+        if http:
+            raise http from exc
+        raise
+    file_path = resolve_session_file(_artifact_dir(state, session_id), body.path)
+    expires = int(time.time()) + _share_ttl()
+    token = _encode_token(session_id, body.path, expires)
+    signature = _sign(session_id, body.path, expires, secret)
+    return ShareFileResponse(
+        url=f"/api/v1/files/shared/{token}?sig={signature}",
+        expires_at=datetime.fromtimestamp(expires, tz=timezone.utc),
+        name=file_path.name,
+    ).model_dump(mode="json")
+
+
+@shared_router.get("/shared/{token}", response_class=FileResponse)
+async def resolve_shared_file(
+    token: str,
+    sig: str = Query(..., min_length=1),
+    state: ServiceState = Depends(get_state),
+) -> FileResponse:
+    try:
+        session_id, path, expires = _decode_token(token)
+    except LookupError:
+        raise_api("NOT_FOUND", "share link is invalid", status=404)
+    secret = _share_secret()
+    if not secret or not hmac.compare_digest(
+        sig, _sign(session_id, path, expires, secret)
+    ):
+        raise_api("NOT_FOUND", "share link is invalid", status=404)
+    if time.time() > expires:
+        raise_api("NOT_FOUND", "share link has expired", status=404)
+    try:
+        await state.sessions.get(session_id)
+    except Exception as exc:
+        http = map_domain_error(exc)
+        if http:
+            raise http from exc
+        raise
+    file_path = resolve_session_file(_artifact_dir(state, session_id), path)
+    media_type, _guess = mimetypes.guess_type(file_path.name)
+    return FileResponse(
+        path=file_path,
+        filename=file_path.name,
+        media_type=media_type or "application/octet-stream",
+        content_disposition_type="attachment",
+    )

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/routers/preferences.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/routers/preferences.py
@@ -10,7 +10,9 @@ from qwenpaw_data.host.core.api.errors import map_domain_error
 from qwenpaw_data.host.core.api.mappers import models_to_schema, providers_to_schema
 from qwenpaw_data.host.core.api.models.preferences import (
     ActiveModelsSchema,
+    RuntimeSettingsSchema,
     SetActiveModelsRequest,
+    SetRuntimeSettingsRequest,
     UpsertProviderModelRequest,
     UpsertProviderRequest,
 )
@@ -157,3 +159,31 @@ async def set_active_models(
     except Exception as exc:
         _raise(exc)
     return {"active_models": ActiveModelsSchema.model_validate(item)}
+
+
+@router.get("/runtime-settings")
+async def get_runtime_settings(
+    identity: Identity = Depends(get_identity),
+    state: ServiceState = Depends(get_state),
+) -> dict[str, Any]:
+    try:
+        item = await state.prefs.get_runtime_settings(identity.user_id)
+    except Exception as exc:
+        _raise(exc)
+    return {"runtime_settings": RuntimeSettingsSchema.model_validate(item)}
+
+
+@router.put("/runtime-settings")
+async def set_runtime_settings(
+    body: SetRuntimeSettingsRequest,
+    identity: Identity = Depends(get_identity),
+    state: ServiceState = Depends(get_state),
+) -> dict[str, Any]:
+    try:
+        item = await state.prefs.set_runtime_settings(
+            identity.user_id,
+            body.model_dump(exclude_unset=True),
+        )
+    except Exception as exc:
+        _raise(exc)
+    return {"runtime_settings": RuntimeSettingsSchema.model_validate(item)}

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/routers/sessions.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/routers/sessions.py
@@ -7,13 +7,16 @@ from fastapi import APIRouter, Depends, Query
 
 from qwenpaw_data.host.core.api.deps import ServiceState, get_identity, get_state
 from qwenpaw_data.host.core.api.errors import map_domain_error
-from qwenpaw_data.host.core.api.mappers import session_to_schema
+from qwenpaw_data.host.core.api.mappers import chat_to_schema, session_to_schema
 from qwenpaw_data.host.core.api.models.requests import (
     CreateSessionRequest,
+    ForkSessionRequest,
     PatchSessionRequest,
 )
 from qwenpaw_data.host.core.domain.identity import Identity
 from qwenpaw_data.host.core.domain.session import Session
+from qwenpaw_data.host.core.fork import fork_session
+from qwenpaw_data.host.core.store.protocols import ChatEventStore
 
 router = APIRouter(prefix="/sessions", tags=["sessions"])
 
@@ -137,3 +140,81 @@ async def delete_session(
         if http:
             raise http from exc
         raise
+
+
+@router.post("/{session_id}/fork")
+async def fork(
+    session_id: str,
+    body: ForkSessionRequest,
+    identity: Identity = Depends(get_identity),
+    state: ServiceState = Depends(get_state),
+) -> dict[str, Any]:
+    _ = identity
+    try:
+        session = await fork_session(
+            sessions=state.sessions,
+            chats=state.chats,
+            events=state.events,
+            attachments=state.attachments,
+            home=state.hosts.home,
+            session_id=session_id,
+            chat_id=body.chat_id,
+        )
+    except Exception as exc:
+        http = map_domain_error(exc)
+        if http:
+            raise http from exc
+        raise
+    return {"session": session_to_schema(session, has_active_chat=False)}
+
+
+async def bundle_extras(
+    events: ChatEventStore,
+    chat_id: str,
+) -> dict[str, Any]:
+    """Segments, main-channel biz events, artifacts, last followup."""
+    segments: list[dict[str, Any]] = []
+    biz_events: list[dict[str, Any]] = []
+    artifacts: list[dict[str, Any]] = []
+    followup: dict[str, Any] | None = None
+    for obj in await events.read_after(chat_id, -1):
+        if obj.object == "segment":
+            segments.append(obj.segment.model_dump(mode="json"))
+        elif obj.object == "biz_event" and obj.biz_event.channel == "main":
+            biz_events.append(obj.biz_event.model_dump(mode="json"))
+        elif obj.object == "artifact.registered":
+            artifacts.append(obj.artifact.model_dump(mode="json"))
+        elif obj.object == "followup.generated":
+            followup = obj.followup.model_dump(mode="json")
+    return {
+        "segments": segments,
+        "biz_events": biz_events,
+        "artifacts": artifacts,
+        "followup": followup,
+    }
+
+
+@router.get("/{session_id}/snapshot")
+async def snapshot(
+    session_id: str,
+    identity: Identity = Depends(get_identity),
+    state: ServiceState = Depends(get_state),
+) -> dict[str, Any]:
+    _ = identity
+    try:
+        session = await state.sessions.get(session_id)
+        active = await state.sessions.has_active_chat(session_id)
+        chats = await state.chats.list_for_session(session_id)
+        bundles = [
+            chat_to_schema(chat, await bundle_extras(state.events, chat.id))
+            for chat in chats
+        ]
+    except Exception as exc:
+        http = map_domain_error(exc)
+        if http:
+            raise http from exc
+        raise
+    return {
+        "session": session_to_schema(session, has_active_chat=active),
+        "chats": bundles,
+    }

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/routers/settlement.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/api/routers/settlement.py
@@ -106,3 +106,45 @@ async def dismiss_settlement_card(
             raise http from exc
         raise
     return {"ok": True, "card": card}
+
+
+# Skill evolution stays in the enterprise edition; the console's workspace
+# probes these on every session open, so answer with empty collections.
+@router.get("/skill-proposals")
+async def list_skill_proposals(
+    session_id: str,
+    status: str | None = Query(default=None),
+    identity: Identity = Depends(get_identity),
+    state: ServiceState = Depends(get_state),
+) -> dict[str, Any]:
+    _ = (status, identity)
+    try:
+        await state.sessions.get(session_id)
+    except Exception as exc:
+        http = map_domain_error(exc)
+        if http:
+            raise http from exc
+        raise
+    return {"skill_proposals": [], "count": 0}
+
+
+drafts_router = APIRouter(
+    prefix="/sessions/{session_id}/skill-drafts", tags=["settlement"]
+)
+
+
+@drafts_router.get("")
+async def list_skill_drafts(
+    session_id: str,
+    identity: Identity = Depends(get_identity),
+    state: ServiceState = Depends(get_state),
+) -> dict[str, Any]:
+    _ = identity
+    try:
+        await state.sessions.get(session_id)
+    except Exception as exc:
+        http = map_domain_error(exc)
+        if http:
+            raise http from exc
+        raise
+    return {"skill_drafts": [], "count": 0}

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/db/engine.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/db/engine.py
@@ -11,8 +11,8 @@ import os
 from collections.abc import Mapping
 from pathlib import Path
 
-from sqlalchemy import event
-from sqlalchemy.engine import make_url
+from sqlalchemy import event, inspect, text
+from sqlalchemy.engine import Connection, make_url
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
     AsyncSession,
@@ -66,3 +66,25 @@ async def init_db(engine: AsyncEngine) -> None:
     async with engine.begin() as conn:
         for table in Base.metadata.sorted_tables:
             await conn.execute(CreateTable(table, if_not_exists=True))
+        await conn.run_sync(_add_missing_columns)
+
+
+def _add_missing_columns(conn: Connection) -> None:
+    """Additive migration: columns introduced after a table already exists.
+
+    Added as nullable regardless of the model (SQLite cannot ADD COLUMN
+    NOT NULL without a default); readers treat NULL as the empty value.
+    """
+    inspector = inspect(conn)
+    for table in Base.metadata.sorted_tables:
+        existing = {column["name"] for column in inspector.get_columns(table.name)}
+        for column in table.columns:
+            if column.name in existing:
+                continue
+            column_type = column.type.compile(conn.dialect)
+            conn.execute(
+                text(
+                    f'ALTER TABLE "{table.name}" '
+                    f'ADD COLUMN "{column.name}" {column_type}'
+                )
+            )

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/db/tables.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/db/tables.py
@@ -189,6 +189,18 @@ class UserProviderModelRow(Base):
     )
 
 
+class UserRuntimeSettingsRow(Base):
+    __tablename__ = "user_runtime_settings"
+
+    user_id: Mapped[str] = mapped_column(String, primary_key=True)
+    react_max_iters: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    llm_retry_enabled: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    llm_max_retries: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=utcnow
+    )
+
+
 class UserActiveModelRow(Base):
     __tablename__ = "user_active_models"
 

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/domain/session.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/domain/session.py
@@ -96,6 +96,29 @@ class Session:
         self.updated_at = utcnow()
         return self.chat_count
 
+    def fork(self, *, at_chat: Chat, has_active_chat: bool) -> Session:
+        if has_active_chat:
+            raise RuntimeError("CONFLICT: session has active chat")
+        if at_chat.session_id != self.id:
+            raise LookupError("chat not found")
+        if at_chat.status != "completed":
+            raise RuntimeError("CONFLICT: chat is not completed")
+        now = utcnow()
+        title = self.title.strip()
+        return Session(
+            id=create_id("ses"),
+            identity=self.identity,
+            agent_id=self.agent_id,
+            title=f"{title} (fork)" if title else "fork",
+            datasource_id=self.datasource_id,
+            chat_count=at_chat.sequence,
+            channel="console",
+            created_at=now,
+            updated_at=now,
+            parent_session_id=self.id,
+            forked_from_chat_id=at_chat.id,
+        )
+
     def soft_delete(self, *, has_active_chat: bool) -> None:
         if self.deleted_at is not None:
             return

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/domain/session_fork.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/domain/session_fork.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+"""Pure fork bookkeeping: id remapping and payload rewriting."""
+from __future__ import annotations
+
+from typing import Any
+
+from qwenpaw_data.host.core.domain.attachment import (
+    Attachment,
+    uploads_relative_path,
+)
+from qwenpaw_data.host.core.domain.chat import Chat
+from qwenpaw_data.host.core.domain.session import Session
+from qwenpaw_data.host.core.utils.ids import create_id
+
+
+class SessionFork:
+    def __init__(
+        self,
+        source: Session,
+        at_chat: Chat,
+        *,
+        has_active_chat: bool,
+    ) -> None:
+        self.source = source
+        self.at_chat = at_chat
+        self.target = source.fork(at_chat=at_chat, has_active_chat=has_active_chat)
+        self._ids = {source.id: self.target.id}
+
+    def remap(self, old_id: str, prefix: str) -> str:
+        if old_id not in self._ids:
+            self._ids[old_id] = create_id(prefix)
+        return self._ids[old_id]
+
+    def mapped(self, old_id: str) -> str:
+        return self._ids[old_id]
+
+    def rewrite(self, value: Any) -> Any:
+        if isinstance(value, str):
+            for old, new in self._ids.items():
+                value = value.replace(old, new)
+            return value
+        if isinstance(value, list):
+            return [self.rewrite(item) for item in value]
+        if isinstance(value, dict):
+            return {key: self.rewrite(item) for key, item in value.items()}
+        return value
+
+    def copy_chat(self, chat: Chat) -> Chat:
+        return Chat(
+            id=self.mapped(chat.id),
+            session_id=self.target.id,
+            identity=self.target.identity,
+            sequence=chat.sequence,
+            user_input=self.rewrite(chat.user_input),
+            datasource_id=chat.datasource_id,
+            kind=chat.kind,
+            status=chat.status,
+            last_sequence_number=chat.last_sequence_number,
+            started_at=chat.started_at,
+            completed_at=chat.completed_at,
+            active_duration_ms=chat.active_duration_ms,
+            error=self.rewrite(chat.error),
+            plan=self.rewrite(chat.plan),
+            created_at=chat.created_at,
+            updated_at=chat.updated_at,
+            artifact_comments=self.rewrite(chat.artifact_comments),
+            attachments=self.rewrite(chat.attachments),
+        )
+
+    def copy_attachment(self, attachment: Attachment) -> Attachment:
+        return Attachment(
+            id=self.mapped(attachment.id),
+            session_id=self.target.id,
+            identity=self.target.identity,
+            filename=attachment.filename,
+            storage_path=uploads_relative_path(
+                self.target.id, attachment.filename
+            ),
+            created_at=attachment.created_at,
+        )

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/fork.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/fork.py
@@ -1,0 +1,148 @@
+# -*- coding: utf-8 -*-
+"""Fork a session: copy records, events, uploads, artifacts, agent state."""
+from __future__ import annotations
+
+import asyncio
+import json
+import shutil
+from pathlib import Path
+from typing import Any
+
+from qwenpaw_data.host.core.api.models.stream_objects import dump_stream_object
+from qwenpaw_data.host.core.domain.attachment import Attachment
+from qwenpaw_data.host.core.domain.session import Session
+from qwenpaw_data.host.core.domain.session_fork import SessionFork
+from qwenpaw_data.host.core.paths import Paths
+from qwenpaw_data.host.core.store.protocols import (
+    AttachmentStore,
+    ChatEventStore,
+    ChatStore,
+    SessionStore,
+)
+
+_BASE_FIELDS = ("sequence_number", "session_id", "chat_id")
+
+
+async def fork_session(
+    *,
+    sessions: SessionStore,
+    chats: ChatStore,
+    events: ChatEventStore,
+    attachments: AttachmentStore,
+    home: Path,
+    session_id: str,
+    chat_id: str,
+) -> Session:
+    source = await sessions.get(session_id)
+    at_chat = await chats.get(chat_id, session_id=session_id)
+    fork = SessionFork(
+        source,
+        at_chat,
+        has_active_chat=await sessions.has_active_chat(session_id),
+    )
+    selected = [
+        chat
+        for chat in await chats.list_for_session(session_id)
+        if chat.sequence <= at_chat.sequence
+    ]
+    if not selected:
+        raise LookupError("chat not found")
+    for chat in selected:
+        fork.remap(chat.id, "chat")
+
+    user_id = source.identity.user_id
+    loaded: dict[str, Attachment] = {}
+    for chat in selected:
+        for item in chat.attachments:
+            attachment_id = item["attachment_id"]
+            if attachment_id in loaded:
+                continue
+            attachment = await attachments.get(user_id, attachment_id)
+            if attachment.session_id != source.id:
+                raise LookupError("attachment not found")
+            fork.remap(attachment.id, "att")
+            loaded[attachment.id] = attachment
+
+    created_paths = await asyncio.to_thread(
+        _copy_files, fork, home, list(loaded.values())
+    )
+    try:
+        await sessions.add(fork.target)
+        for chat in selected:
+            await chats.add(fork.copy_chat(chat))
+        for chat in selected:
+            target_chat_id = fork.mapped(chat.id)
+            for obj in await events.read_after(chat.id, -1):
+                payload = dump_stream_object(obj)
+                for field in _BASE_FIELDS:
+                    payload.pop(field, None)
+                await events.append(
+                    session_id=fork.target.id,
+                    chat_id=target_chat_id,
+                    payload=fork.rewrite(payload),
+                )
+        for attachment in loaded.values():
+            await attachments.add(fork.copy_attachment(attachment))
+    except Exception:
+        await asyncio.to_thread(_cleanup, created_paths)
+        raise
+    return fork.target
+
+
+def _copy_files(
+    fork: SessionFork,
+    home: Path,
+    attachments: list[Attachment],
+) -> list[Path]:
+    source_paths = Paths(home, session_id=fork.source.id)
+    target_paths = Paths(home, session_id=fork.target.id)
+    created: list[Path] = []
+
+    if attachments:
+        uploads_dir = target_paths.workspace / "uploads" / fork.target.id
+        uploads_dir.mkdir(parents=True, exist_ok=True)
+        created.append(uploads_dir)
+        for attachment in attachments:
+            src = source_paths.workspace / attachment.storage_path
+            if src.is_file():
+                shutil.copy2(src, uploads_dir / attachment.filename)
+
+    if source_paths.artifact_dir.is_dir():
+        shutil.copytree(
+            source_paths.artifact_dir,
+            target_paths.artifact_dir,
+            dirs_exist_ok=True,
+        )
+        created.append(target_paths.artifact_dir)
+
+    # Agent conversational state and DAG snapshots: `{user}_{sid}.json`.
+    for state_root in (source_paths.console_root, source_paths.dag_root):
+        if not state_root.is_dir():
+            continue
+        for src in state_root.glob(f"*_{fork.source.id}.json"):
+            dst = src.with_name(
+                src.name.replace(fork.source.id, fork.target.id)
+            )
+            dst.write_text(
+                _rewrite_text(src.read_text(encoding="utf-8"), fork),
+                encoding="utf-8",
+            )
+            created.append(dst)
+    return created
+
+
+def _rewrite_text(text: str, fork: SessionFork) -> str:
+    # Validate JSON before and after so a broken rewrite fails loudly.
+    json.loads(text)
+    rewritten: Any = text
+    rewritten = fork.rewrite(rewritten)
+    json.loads(rewritten)
+    return rewritten
+
+
+def _cleanup(paths: list[Path]) -> None:
+    for path in reversed(paths):
+        if path.is_dir():
+            shutil.rmtree(path, ignore_errors=True)
+        elif path.is_file():
+            path.unlink(missing_ok=True)

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/runtime/chat_runtime.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/runtime/chat_runtime.py
@@ -442,6 +442,10 @@ class ChatRuntime:
             snapshot = self._agent.get_plan().model_dump(mode="json")
         except RuntimeError:
             return None
+        if not snapshot.get("nodes"):
+            # finish_plan archives the graph; keep the last real plan
+            # visible instead of clobbering it with an empty snapshot.
+            return None
         states = self._agent.get_plan_states()
         for node in snapshot.get("nodes") or []:
             state = states.get(node.get("node_id"))

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/store/_prefs_logic.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/store/_prefs_logic.py
@@ -55,3 +55,55 @@ def clean_model_upsert(
 def validate_active_selection(prefs: Any) -> None:
     """Raise when the requested active models cannot resolve."""
     prefs.validate_selection()
+
+
+RUNTIME_SETTING_KEYS = (
+    "react_max_iters",
+    "llm_retry_enabled",
+    "llm_max_retries",
+)
+
+
+def runtime_defaults() -> dict[str, Any]:
+    """Instance-wide runtime defaults, overridable via environment."""
+    import os
+
+    def _int(name: str, fallback: int) -> int:
+        raw = (os.environ.get(name) or "").strip()
+        try:
+            return int(raw) if raw else fallback
+        except ValueError:
+            return fallback
+
+    raw_retry = (
+        os.environ.get("QWENPAW_DATA_LLM_RETRY_ENABLED") or ""
+    ).strip().lower()
+    return {
+        "react_max_iters": _int("QWENPAW_DATA_REACT_MAX_ITERS", 10000),
+        "llm_retry_enabled": raw_retry not in {"0", "false", "off"},
+        "llm_max_retries": _int("QWENPAW_DATA_LLM_MAX_RETRIES", 3),
+    }
+
+
+def resolve_runtime_settings(
+    overrides: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Per-user overrides on top of the instance defaults."""
+    resolved = runtime_defaults()
+    for key in RUNTIME_SETTING_KEYS:
+        value = None if overrides is None else overrides.get(key)
+        if value is not None:
+            resolved[key] = value
+    return resolved
+
+
+def merge_runtime_patch(
+    current: dict[str, Any] | None,
+    patch: dict[str, Any],
+) -> dict[str, Any]:
+    """Apply only known keys; ``None`` values clear back to the default."""
+    merged = dict(current or {})
+    for key in RUNTIME_SETTING_KEYS:
+        if key in patch:
+            merged[key] = patch[key]
+    return merged

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/store/json_store.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/store/json_store.py
@@ -33,6 +33,8 @@ from qwenpaw_data.host.core.session._locking import file_lock, write_atomic
 from qwenpaw_data.host.core.store._prefs_logic import (
     clean_model_upsert,
     merge_provider_patch,
+    merge_runtime_patch,
+    resolve_runtime_settings,
 )
 from qwenpaw_data.host.core.utils.ids import create_id
 from qwenpaw_data.host.core.utils.secrets import decrypt_api_key
@@ -191,6 +193,20 @@ class JSONPreferencesStore:
         }
         await asyncio.to_thread(self._write, user_id, doc)
         return await self.get_active_models(user_id)
+
+    async def get_runtime_settings(self, user_id: str) -> dict[str, Any]:
+        doc = await asyncio.to_thread(self._read, user_id)
+        return resolve_runtime_settings(doc.get("runtime"))
+
+    async def set_runtime_settings(
+        self,
+        user_id: str,
+        patch: dict[str, Any],
+    ) -> dict[str, Any]:
+        doc = await asyncio.to_thread(self._read, user_id)
+        doc["runtime"] = merge_runtime_patch(doc.get("runtime"), patch)
+        await asyncio.to_thread(self._write, user_id, doc)
+        return resolve_runtime_settings(doc["runtime"])
 
 
 def _session_to_dict(session: Session) -> dict[str, Any]:

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/store/protocols.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/store/protocols.py
@@ -98,6 +98,14 @@ class PreferencesStore(Protocol):
         light_model_id: str | None = None,
     ) -> dict[str, Any]: ...
 
+    async def get_runtime_settings(self, user_id: str) -> dict[str, Any]: ...
+
+    async def set_runtime_settings(
+        self,
+        user_id: str,
+        patch: dict[str, Any],
+    ) -> dict[str, Any]: ...
+
 
 class SessionStore(Protocol):
     async def add(self, session: Session) -> None: ...

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/store/sql_store.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/store/sql_store.py
@@ -36,6 +36,7 @@ from qwenpaw_data.host.core.db.tables import (
     UserActiveModelRow,
     UserProviderModelRow,
     UserProviderRow,
+    UserRuntimeSettingsRow,
 )
 from qwenpaw_data.host.core.domain.attachment import Attachment
 from qwenpaw_data.host.core.domain.chat import ACTIVE, Chat
@@ -49,6 +50,8 @@ from qwenpaw_data.host.core.domain.session import Session
 from qwenpaw_data.host.core.store._prefs_logic import (
     clean_model_upsert,
     merge_provider_patch,
+    merge_runtime_patch,
+    resolve_runtime_settings,
 )
 from qwenpaw_data.host.core.utils.ids import create_id
 from qwenpaw_data.host.core.utils.secrets import decrypt_api_key
@@ -263,6 +266,42 @@ class SQLPreferencesStore:
                 row.updated_at = now
             await db.commit()
         return await self.get_active_models(user_id)
+
+    async def get_runtime_settings(self, user_id: str) -> dict[str, Any]:
+        async with self._sessions() as db:
+            row = await db.get(UserRuntimeSettingsRow, user_id)
+            return resolve_runtime_settings(self._runtime_overrides(row))
+
+    async def set_runtime_settings(
+        self,
+        user_id: str,
+        patch: dict[str, Any],
+    ) -> dict[str, Any]:
+        async with self._sessions() as db:
+            row = await db.get(UserRuntimeSettingsRow, user_id)
+            merged = merge_runtime_patch(self._runtime_overrides(row), patch)
+            now = utcnow()
+            if row is None:
+                row = UserRuntimeSettingsRow(user_id=user_id, updated_at=now)
+                db.add(row)
+            row.react_max_iters = merged.get("react_max_iters")
+            row.llm_retry_enabled = merged.get("llm_retry_enabled")
+            row.llm_max_retries = merged.get("llm_max_retries")
+            row.updated_at = now
+            await db.commit()
+            return resolve_runtime_settings(merged)
+
+    @staticmethod
+    def _runtime_overrides(
+        row: UserRuntimeSettingsRow | None,
+    ) -> dict[str, Any] | None:
+        if row is None:
+            return None
+        return {
+            "react_max_iters": row.react_max_iters,
+            "llm_retry_enabled": row.llm_retry_enabled,
+            "llm_max_retries": row.llm_max_retries,
+        }
 
 
 def _session_from_row(row: SessionRow) -> Session:

--- a/packages/qwenpaw-data-host-core/tests/test_fork_share.py
+++ b/packages/qwenpaw-data-host-core/tests/test_fork_share.py
@@ -276,3 +276,46 @@ async def test_shared_route_bypasses_bearer_auth(tmp_path, monkeypatch) -> None:
         resolved = await http.get(shared.json()["url"])
         assert resolved.status_code == 200
         assert resolved.text == "shared"
+
+
+async def test_init_db_adds_missing_columns(tmp_path) -> None:
+    """Old databases gain newly introduced columns without data loss."""
+    import aiosqlite  # noqa: F401  (ensures the driver is present)
+    from sqlalchemy import text
+
+    from qwenpaw_data.host.core.db.engine import (
+        create_engine_and_factory,
+        init_db,
+    )
+    from qwenpaw_data.host.core.store.sql_store import SQLChatStore
+
+    db_path = tmp_path / "host.db"
+    engine, factory = create_engine_and_factory(
+        f"sqlite+aiosqlite:///{db_path}",
+    )
+    await init_db(engine)
+    # Simulate an old install: drop a column that a later release added.
+    async with engine.begin() as conn:
+        await conn.execute(
+            text('ALTER TABLE "chats" DROP COLUMN "artifact_comments_json"')
+        )
+        await conn.execute(
+            text('ALTER TABLE "chats" DROP COLUMN "attachments_json"')
+        )
+    await init_db(engine)
+
+    from qwenpaw_data.host.core.domain.chat import Chat
+    from qwenpaw_data.host.core.domain.identity import Identity
+
+    store = SQLChatStore(factory)
+    chat = Chat.start(
+        session_id="s",
+        identity=Identity.anonymous(),
+        sequence=1,
+        datasource_id=None,
+        text="hi",
+    )
+    await store.add(chat)
+    loaded = await store.get(chat.id)
+    assert loaded.attachments == []
+    await engine.dispose()

--- a/packages/qwenpaw-data-host-core/tests/test_fork_share.py
+++ b/packages/qwenpaw-data-host-core/tests/test_fork_share.py
@@ -1,0 +1,278 @@
+# -*- coding: utf-8 -*-
+"""Session fork, snapshot bundles, and file access/share links."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+import httpx  # noqa: E402
+
+from qwenpaw_data.host.core.api.app import create_app  # noqa: E402
+
+
+@asynccontextmanager
+async def service_client(tmp_path: Path, monkeypatch, **env: str):
+    monkeypatch.delenv("QWENPAW_DATA_API_TOKEN", raising=False)
+    monkeypatch.delenv("QWENPAW_DATA_DB_URL", raising=False)
+    monkeypatch.delenv("QWENPAW_DATA_STORE", raising=False)
+    monkeypatch.delenv("QWENPAW_DATA_SHARE_SECRET", raising=False)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    app = create_app(home=tmp_path, model=object())
+    async with app.router.lifespan_context(app):
+        transport = httpx.ASGITransport(app=app, client=("127.0.0.1", 1234))
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://testserver",
+        ) as http:
+            yield http, app
+
+
+def _biz_event_payload(event_id: str) -> dict:
+    return {
+        "object": "biz_event",
+        "biz_event": {
+            "event_id": event_id,
+            "seq": 1,
+            "channel": "main",
+            "status": "done",
+            "started_at": 1.0,
+        },
+    }
+
+
+async def _seed_forkable_session(http, app) -> tuple[str, str, str]:
+    """Session with an uploaded attachment and one completed chat."""
+    created = await http.post("/api/v1/sessions", json={"title": "月报"})
+    session_id = created.json()["session"]["id"]
+    uploaded = await http.post(
+        "/api/v1/console/upload",
+        data={"session_id": session_id},
+        files={"file": ("data.csv", b"a,b\n1,2\n", "text/csv")},
+    )
+    attachment_id = uploaded.json()["attachment"]["attachment_id"]
+    chat = await http.post(
+        "/api/v1/console/chat",
+        json={
+            "session_id": session_id,
+            "text": "分析这个文件",
+            "attachment_ids": [attachment_id],
+        },
+    )
+    chat_id = chat.json()["chat"]["id"]
+
+    state = app.state.service
+    events = state.events
+    await events.append(
+        session_id=session_id,
+        chat_id=chat_id,
+        payload=_biz_event_payload("be_1"),
+    )
+    await events.append(
+        session_id=session_id,
+        chat_id=chat_id,
+        payload={
+            "object": "followup.generated",
+            "followup": {"chat_id": chat_id, "questions": ["按区域拆一下？"]},
+        },
+    )
+    # Force the background run (which fails without a real model) terminal.
+    record = await state.chats.get(chat_id)
+    if record.status not in ("completed",):
+        record.mark_status("completed")
+        await state.chats.save(record)
+    # Seed an artifact and agent state on disk.
+    artifact_dir = Path(state.hosts.get(session_id=session_id).paths.artifact_dir)
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    (artifact_dir / "report.md").write_text("# 结论", encoding="utf-8")
+    console_root = state.hosts.get(session_id=session_id).paths.console_root
+    console_root.mkdir(parents=True, exist_ok=True)
+    (console_root / f"local_{session_id}.json").write_text(
+        f'{{"session_id": "{session_id}"}}', encoding="utf-8"
+    )
+    return session_id, chat_id, attachment_id
+
+
+async def test_fork_copies_session_state(tmp_path, monkeypatch) -> None:
+    async with service_client(tmp_path, monkeypatch) as (http, app):
+        sid, cid, att_id = await _seed_forkable_session(http, app)
+
+        forked = await http.post(
+            f"/api/v1/sessions/{sid}/fork", json={"chat_id": cid}
+        )
+        assert forked.status_code == 200, forked.text
+        target = forked.json()["session"]
+        new_sid = target["id"]
+        assert new_sid != sid
+        assert target["title"] == "月报 (fork)"
+        assert target["parent_session_id"] == sid
+        assert target["forked_from_chat_id"] == cid
+        assert target["chat_count"] == 1
+
+        # Chats copied with remapped ids and rewritten attachment refs.
+        chats = (await http.get(f"/api/v1/sessions/{new_sid}/chats")).json()
+        assert len(chats["items"]) == 1
+        copied = chats["items"][0]
+        assert copied["id"] != cid
+        assert copied["session_id"] == new_sid
+        new_att_id = copied["attachments"][0]["attachment_id"]
+        assert new_att_id != att_id
+
+        # Events copied and rewritten (runtime response frames ride along).
+        state = app.state.service
+        events = await state.events.read_after(copied["id"], -1)
+        objects = [e.object for e in events]
+        assert "biz_event" in objects and "followup.generated" in objects
+        followup = next(e for e in events if e.object == "followup.generated")
+        assert followup.followup.chat_id == copied["id"]
+        assert all(e.chat_id == copied["id"] for e in events)
+
+        # Files copied: uploads, artifacts, console agent state.
+        paths = state.hosts.get(session_id=new_sid).paths
+        assert (paths.workspace / "uploads" / new_sid / "data.csv").is_file()
+        assert (paths.artifact_dir / "report.md").is_file()
+        state_file = paths.console_root / f"local_{new_sid}.json"
+        assert state_file.is_file()
+        assert new_sid in state_file.read_text(encoding="utf-8")
+
+        # The copied attachment is usable in the forked session.
+        chat2 = await http.post(
+            "/api/v1/console/chat",
+            json={
+                "session_id": new_sid,
+                "text": "继续",
+                "attachment_ids": [new_att_id],
+            },
+        )
+        assert chat2.status_code == 200, chat2.text
+
+
+async def test_fork_guards(tmp_path, monkeypatch) -> None:
+    async with service_client(tmp_path, monkeypatch) as (http, app):
+        sid, cid, _ = await _seed_forkable_session(http, app)
+
+        missing = await http.post(
+            f"/api/v1/sessions/{sid}/fork", json={"chat_id": "chat_missing"}
+        )
+        assert missing.status_code == 404
+
+        # A non-completed chat cannot be the fork point.
+        record = await app.state.service.chats.get(cid)
+        record.mark_status("failed")
+        await app.state.service.chats.save(record)
+        conflict = await http.post(
+            f"/api/v1/sessions/{sid}/fork", json={"chat_id": cid}
+        )
+        assert conflict.status_code == 409
+
+
+async def test_snapshot_bundles(tmp_path, monkeypatch) -> None:
+    async with service_client(tmp_path, monkeypatch) as (http, app):
+        sid, cid, _ = await _seed_forkable_session(http, app)
+
+        snapshot = await http.get(f"/api/v1/sessions/{sid}/snapshot")
+        assert snapshot.status_code == 200, snapshot.text
+        body = snapshot.json()
+        assert body["session"]["id"] == sid
+        assert len(body["chats"]) == 1
+        bundle = body["chats"][0]
+        assert bundle["id"] == cid
+        assert [e["event_id"] for e in bundle["biz_events"]] == ["be_1"]
+        assert bundle["followup"]["questions"] == ["按区域拆一下？"]
+        assert bundle["attachments"][0]["filename"] == "data.csv"
+
+        missing = await http.get("/api/v1/sessions/ses_missing/snapshot")
+        assert missing.status_code == 404
+
+
+async def test_files_access(tmp_path, monkeypatch) -> None:
+    async with service_client(tmp_path, monkeypatch) as (http, app):
+        sid, _, _ = await _seed_forkable_session(http, app)
+
+        preview = await http.get(
+            f"/api/v1/sessions/{sid}/files/access",
+            params={"path": "report.md"},
+        )
+        assert preview.status_code == 200
+        assert "inline" in preview.headers["content-disposition"]
+
+        download = await http.get(
+            f"/api/v1/sessions/{sid}/files/access",
+            params={"path": "report.md", "purpose": "download"},
+        )
+        assert "attachment" in download.headers["content-disposition"]
+
+        for bad in ("../secret", "/etc/hosts", "a/../../b", "./x", ""):
+            response = await http.get(
+                f"/api/v1/sessions/{sid}/files/access", params={"path": bad}
+            )
+            assert response.status_code in (404, 422), bad
+
+
+async def test_share_link_roundtrip(tmp_path, monkeypatch) -> None:
+    async with service_client(
+        tmp_path, monkeypatch, QWENPAW_DATA_SHARE_SECRET="test-secret"
+    ) as (http, app):
+        sid, _, _ = await _seed_forkable_session(http, app)
+
+        shared = await http.post(
+            f"/api/v1/sessions/{sid}/files/share", json={"path": "report.md"}
+        )
+        assert shared.status_code == 200, shared.text
+        body = shared.json()
+        assert body["name"] == "report.md"
+        url = body["url"]
+        assert url.startswith("/api/v1/files/shared/")
+
+        resolved = await http.get(url)
+        assert resolved.status_code == 200
+        assert resolved.text == "# 结论"
+
+        # Tampered signature and truncated token both fail closed.
+        tampered = await http.get(url[:-1] + ("0" if url[-1] != "0" else "1"))
+        assert tampered.status_code == 404
+        broken = await http.get(
+            "/api/v1/files/shared/not-a-token", params={"sig": "x"}
+        )
+        assert broken.status_code == 404
+
+
+async def test_share_requires_secret(tmp_path, monkeypatch) -> None:
+    async with service_client(tmp_path, monkeypatch) as (http, app):
+        sid, _, _ = await _seed_forkable_session(http, app)
+        response = await http.post(
+            f"/api/v1/sessions/{sid}/files/share", json={"path": "report.md"}
+        )
+        assert response.status_code in (400, 422)
+
+
+async def test_shared_route_bypasses_bearer_auth(tmp_path, monkeypatch) -> None:
+    async with service_client(
+        tmp_path,
+        monkeypatch,
+        QWENPAW_DATA_API_TOKEN="api-token",
+    ) as (http, app):
+        headers = {"Authorization": "Bearer api-token"}
+        created = await http.post(
+            "/api/v1/sessions", json={"title": "s"}, headers=headers
+        )
+        sid = created.json()["session"]["id"]
+        state = app.state.service
+        artifact_dir = Path(state.hosts.get(session_id=sid).paths.artifact_dir)
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+        (artifact_dir / "out.txt").write_text("shared", encoding="utf-8")
+
+        shared = await http.post(
+            f"/api/v1/sessions/{sid}/files/share",
+            json={"path": "out.txt"},
+            headers=headers,
+        )
+        assert shared.status_code == 200, shared.text
+        # No Authorization header on the resolver: the signature is enough.
+        resolved = await http.get(shared.json()["url"])
+        assert resolved.status_code == 200
+        assert resolved.text == "shared"

--- a/packages/qwenpaw-data-host-core/tests/test_runtime_settings.py
+++ b/packages/qwenpaw-data-host-core/tests/test_runtime_settings.py
@@ -1,0 +1,128 @@
+# -*- coding: utf-8 -*-
+"""Per-user runtime settings: store conformance and routes."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import pytest
+
+from qwenpaw_data.host.core.store.json_store import JSONPreferencesStore
+
+sqlalchemy = pytest.importorskip("sqlalchemy")
+
+from qwenpaw_data.host.core.db.engine import (  # noqa: E402
+    create_engine_and_factory,
+    init_db,
+)
+from qwenpaw_data.host.core.store.sql_store import SQLPreferencesStore  # noqa: E402
+
+
+@pytest.fixture(params=["json", "sql"])
+async def prefs(request, tmp_path: Path):
+    if request.param == "json":
+        yield JSONPreferencesStore(tmp_path)
+        return
+    engine, factory = create_engine_and_factory(
+        f"sqlite+aiosqlite:///{tmp_path / 'host.db'}",
+    )
+    await init_db(engine)
+    yield SQLPreferencesStore(factory)
+    await engine.dispose()
+
+
+async def test_defaults_and_overrides(prefs, monkeypatch) -> None:
+    monkeypatch.delenv("QWENPAW_DATA_REACT_MAX_ITERS", raising=False)
+    monkeypatch.delenv("QWENPAW_DATA_LLM_RETRY_ENABLED", raising=False)
+    monkeypatch.delenv("QWENPAW_DATA_LLM_MAX_RETRIES", raising=False)
+
+    initial = await prefs.get_runtime_settings("local")
+    assert initial == {
+        "react_max_iters": 10000,
+        "llm_retry_enabled": True,
+        "llm_max_retries": 3,
+    }
+
+    updated = await prefs.set_runtime_settings(
+        "local", {"react_max_iters": 500, "llm_retry_enabled": False}
+    )
+    assert updated["react_max_iters"] == 500
+    assert updated["llm_retry_enabled"] is False
+    assert updated["llm_max_retries"] == 3  # untouched → default
+
+    # Partial update keeps prior overrides; None clears back to defaults.
+    again = await prefs.set_runtime_settings("local", {"llm_max_retries": 5})
+    assert again["react_max_iters"] == 500
+    assert again["llm_max_retries"] == 5
+    cleared = await prefs.set_runtime_settings("local", {"react_max_iters": None})
+    assert cleared["react_max_iters"] == 10000
+
+    # Per-user isolation.
+    other = await prefs.get_runtime_settings("someone-else")
+    assert other["react_max_iters"] == 10000
+
+
+async def test_env_defaults(prefs, monkeypatch) -> None:
+    monkeypatch.setenv("QWENPAW_DATA_REACT_MAX_ITERS", "42")
+    monkeypatch.setenv("QWENPAW_DATA_LLM_RETRY_ENABLED", "off")
+    assert await prefs.get_runtime_settings("local") == {
+        "react_max_iters": 42,
+        "llm_retry_enabled": False,
+        "llm_max_retries": 3,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Routes
+
+pytest.importorskip("fastapi")
+import httpx  # noqa: E402
+
+from qwenpaw_data.host.core.api.app import create_app  # noqa: E402
+
+
+@asynccontextmanager
+async def service_client(tmp_path: Path, monkeypatch):
+    for env in (
+        "QWENPAW_DATA_API_TOKEN",
+        "QWENPAW_DATA_DB_URL",
+        "QWENPAW_DATA_STORE",
+        "QWENPAW_DATA_REACT_MAX_ITERS",
+        "QWENPAW_DATA_LLM_RETRY_ENABLED",
+        "QWENPAW_DATA_LLM_MAX_RETRIES",
+    ):
+        monkeypatch.delenv(env, raising=False)
+    app = create_app(home=tmp_path, model=object())
+    async with app.router.lifespan_context(app):
+        transport = httpx.ASGITransport(app=app, client=("127.0.0.1", 1234))
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://testserver",
+        ) as http:
+            yield http
+
+
+async def test_runtime_settings_routes(tmp_path, monkeypatch) -> None:
+    async with service_client(tmp_path, monkeypatch) as http:
+        fetched = await http.get("/api/v1/preferences/runtime-settings")
+        assert fetched.status_code == 200, fetched.text
+        assert fetched.json()["runtime_settings"]["react_max_iters"] == 10000
+
+        saved = await http.put(
+            "/api/v1/preferences/runtime-settings",
+            json={"react_max_iters": 250, "llm_max_retries": 1},
+        )
+        assert saved.status_code == 200, saved.text
+        body = saved.json()["runtime_settings"]
+        assert body["react_max_iters"] == 250
+        assert body["llm_max_retries"] == 1
+
+        again = await http.get("/api/v1/preferences/runtime-settings")
+        assert again.json()["runtime_settings"]["react_max_iters"] == 250
+
+        invalid = await http.put(
+            "/api/v1/preferences/runtime-settings",
+            json={"react_max_iters": "not-a-number"},
+        )
+        assert invalid.status_code == 422


### PR DESCRIPTION
## Summary
- `POST /sessions/{sid}/fork` copies a session up to a completed chat — records, events, uploads, artifacts, and on-disk agent/DAG state — with every id remapped and rewritten through the copied payloads. `GET /snapshot` bundles each chat with segments, main-channel biz events, artifacts, and last followup (the console's session-restore shape).
- Files routes: containment-checked `GET /files/access` (preview/download) and `POST /files/share` returning HMAC-SHA256-signed expiring URLs resolved by an auth-exempt route — the signature is the credential.
- Console bootstrap compat: `GET /api/v1/auth/status` (`enabled:false`) and empty skill-proposal/skill-draft stubs (those features stay in the enterprise edition).
- `init_db` now adds newly introduced columns to existing databases (old installs crashed on the new chat columns), and `finish_plan` no longer clobbers the last real plan snapshot.

Last of the stack; with this, the enterprise console frontend runs unmodified against the OSS engine.

## Test plan
- [x] Full suite green (940 passed); new tests cover fork copy/rewrite/guards, snapshot bundles, file access traversal rejection, share sign/tamper/expiry/auth-bypass, and the additive DB migration
- [x] Live-verified end-to-end: fork created a linked session; share URL resolved unauthenticated via the gateway; snapshot restored a 14-artifact session in the embedded console