### PR TITLE
feat(context): datasource type registry, MySQL-compatible engines, DuckDB/SQLite

### DIFF
--- a/packages/qwenpaw-data-context/frontend/src/i18n/locales/en.json
+++ b/packages/qwenpaw-data-context/frontend/src/i18n/locales/en.json
@@ -391,7 +391,9 @@
       "createFailed": "Failed to create. Please try again.",
       "testFailed": "Connection test failed. Please try again.",
       "notFound": "Data source not found"
-    }
+    },
+    "filePathRequired": "Please enter the database file path",
+    "filePathPlaceholder": "Absolute path on the server, e.g. /data/analytics.duckdb"
   },
   "kgDocs": {
     "title": "KG Docs Management",

--- a/packages/qwenpaw-data-context/frontend/src/i18n/locales/zh.json
+++ b/packages/qwenpaw-data-context/frontend/src/i18n/locales/zh.json
@@ -391,7 +391,9 @@
       "createFailed": "创建失败，请稍后重试",
       "testFailed": "连接测试失败，请稍后重试",
       "notFound": "数据源不存在"
-    }
+    },
+    "filePathRequired": "请输入数据库文件路径",
+    "filePathPlaceholder": "服务器上的绝对路径，如 /data/analytics.duckdb"
   },
   "kgDocs": {
     "title": "KG 文档管理",

--- a/packages/qwenpaw-data-context/frontend/src/pages/DataSourceManagement/index.tsx
+++ b/packages/qwenpaw-data-context/frontend/src/pages/DataSourceManagement/index.tsx
@@ -1,11 +1,13 @@
 import {
   createDataSource,
   deleteDataSource,
+  fetchDataSourceTypes,
   queryDataSourceList,
   testDataSourceConnection,
   testSavedDataSourceConnection,
   updateDataSource,
 } from '@/services/dataSource';
+import type { DataSourceTypeInfo } from '@/services/dataSource';
 import type { DataSourceConfig, DataSourceItem, DataSourceQueryParams, DataSourceType } from '@/types/dataSource';
 import { deleteExtraDelete, isFormValidationError, toOptionalString } from '@/utils';
 import { normalizeListResponse, extractTotal } from '@/utils/listResponse';
@@ -13,15 +15,13 @@ import { PlusOutlined } from '@/design';
 import { Button, Drawer, Form, Input, Modal, Select, Space, message } from '@/design';
 import { ProColumns, ProTable } from '@/design';
 import type { ActionType } from '@/design';
-import React, { useMemo, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDataSourceOptionsStore } from '@/store';
 
-type NormalizedDataSourceType = 'mysql' | 'postgresql' | 'odps';
-
 interface DataSourceFormValues {
   datasource_name: string;
-  datasource_type: NormalizedDataSourceType;
+  datasource_type: string;
   host?: string;
   port?: number | string;
   user?: string;
@@ -33,23 +33,73 @@ interface DataSourceFormValues {
   access_key_id?: string;
   access_key_secret?: string;
   sts_token?: string;
+  path?: string;
 }
 
-const DATA_SOURCE_TYPE_OPTIONS = [
-  { label: 'MySQL', value: 'mysql' },
-  { label: 'PostgreSQL', value: 'postgresql' },
-  { label: 'ODPS', value: 'odps' },
+/** Offline/old-backend fallback: mirrors the backend defaults before the
+ * `/datasource/types` endpoint existed. */
+const FALLBACK_TYPE_INFOS: DataSourceTypeInfo[] = [
+  {
+    type: 'mysql',
+    label: 'MySQL',
+    fields: [
+      { name: 'host', type: 'string', required: true },
+      { name: 'port', type: 'integer', required: false, default: 3306 },
+      { name: 'database', type: 'string', required: true },
+      { name: 'user', type: 'string', required: true },
+      { name: 'password', type: 'string', required: true, secret: true },
+    ],
+  },
+  {
+    type: 'postgresql',
+    label: 'PostgreSQL',
+    fields: [
+      { name: 'host', type: 'string', required: true },
+      { name: 'port', type: 'integer', required: false, default: 5432 },
+      { name: 'dbname', type: 'string', required: true },
+      { name: 'user', type: 'string', required: true },
+      { name: 'password', type: 'string', required: true, secret: true },
+    ],
+  },
+  {
+    type: 'odps',
+    label: 'ODPS',
+    fields: [
+      { name: 'access_key_id', type: 'string', required: true },
+      { name: 'access_key_secret', type: 'string', required: true, secret: true },
+      { name: 'project', type: 'string', required: true },
+      { name: 'endpoint', type: 'string', required: true },
+      { name: 'sts_token', type: 'string', required: false },
+    ],
+  },
 ];
 
-function normalizeType(type?: DataSourceType | string | null): NormalizedDataSourceType {
+function findTypeInfo(
+  typeInfos: DataSourceTypeInfo[],
+  type?: DataSourceType | string | null,
+): DataSourceTypeInfo {
   const value = String(type || '').toLowerCase();
-  if (value === 'postgresql' || value === 'odps') return value;
-  return 'mysql';
+  return (
+    typeInfos.find((item) => item.type === value)
+    ?? typeInfos.find((item) => item.type === 'mysql')
+    ?? typeInfos[0]
+  );
 }
 
-function typeLabel(type?: DataSourceType | string | null) {
-  const normalized = normalizeType(type);
-  return DATA_SOURCE_TYPE_OPTIONS.find((item) => item.value === normalized)?.label ?? String(type || '-');
+/** Derive the form shape from the backend field spec. */
+function formShape(info: DataSourceTypeInfo): 'file' | 'odps' | 'server' {
+  const names = new Set(info.fields.map((field) => field.name));
+  if (names.has('path')) return 'file';
+  if (names.has('endpoint')) return 'odps';
+  return 'server';
+}
+
+function fieldDefault(info: DataSourceTypeInfo, name: string): unknown {
+  return info.fields.find((field) => field.name === name)?.default;
+}
+
+function dbFieldKey(info: DataSourceTypeInfo): 'dbname' | 'database' {
+  return info.fields.some((field) => field.name === 'dbname') ? 'dbname' : 'database';
 }
 
 function optionalNumber(value: number | string | undefined): number | undefined {
@@ -62,7 +112,7 @@ function configToFormValues(record: DataSourceItem): Partial<DataSourceFormValue
   const config = (record.config || {}) as Record<string, unknown>;
   return {
     datasource_name: record.datasource_name,
-    datasource_type: normalizeType(record.datasource_type),
+    datasource_type: String(record.datasource_type || 'mysql').toLowerCase(),
     host: config.host as string | undefined,
     port: config.port as number | undefined,
     user: config.user as string | undefined,
@@ -74,43 +124,37 @@ function configToFormValues(record: DataSourceItem): Partial<DataSourceFormValue
     access_key_id: config.access_key_id as string | undefined,
     access_key_secret: config.access_key_secret as string | undefined,
     sts_token: config.sts_token as string | undefined,
+    path: config.path as string | undefined,
   };
 }
 
-function valuesToPayload(values: DataSourceFormValues): Partial<DataSourceItem> {
-  const datasource_type = normalizeType(values.datasource_type);
-  let config: DataSourceConfig;
+function valuesToPayload(
+  values: DataSourceFormValues,
+  typeInfos: DataSourceTypeInfo[],
+): Partial<DataSourceItem> {
+  const info = findTypeInfo(typeInfos, values.datasource_type);
+  const raw = values as unknown as Record<string, unknown>;
+  const config: Record<string, unknown> = {};
 
-  if (datasource_type === 'odps') {
-    config = {
-      endpoint: values.endpoint?.trim() || '',
-      project: values.project?.trim() || '',
-      access_key_id: values.access_key_id?.trim() || '',
-      access_key_secret: values.access_key_secret || '',
-      sts_token: values.sts_token?.trim() || null,
-    };
-  } else if (datasource_type === 'postgresql') {
-    config = {
-      host: values.host?.trim() || '',
-      port: optionalNumber(values.port) ?? 5432,
-      dbname: values.dbname?.trim() || '',
-      user: values.user?.trim() || '',
-      password: values.password || '',
-    };
-  } else {
-    config = {
-      host: values.host?.trim() || '',
-      port: optionalNumber(values.port) ?? 3306,
-      database: values.database?.trim() || '',
-      user: values.user?.trim() || '',
-      password: values.password || '',
-    };
+  for (const field of info.fields) {
+    const value = raw[field.name];
+    if (field.type === 'integer') {
+      config[field.name] = optionalNumber(value as number | string | undefined)
+        ?? (field.default as number | undefined);
+    } else if (field.secret) {
+      // Secrets are submitted verbatim (no trim) so pastes survive intact.
+      config[field.name] = (value as string | undefined) || '';
+    } else if (field.required) {
+      config[field.name] = String(value ?? '').trim();
+    } else {
+      config[field.name] = String(value ?? '').trim() || null;
+    }
   }
 
   return {
     datasource_name: values.datasource_name.trim(),
-    datasource_type,
-    config,
+    datasource_type: info.type,
+    config: config as DataSourceConfig,
   };
 }
 
@@ -124,11 +168,37 @@ const DataSourceManagement: React.FC = () => {
   const [testing, setTesting] = useState(false);
   const selectedType = Form.useWatch('datasource_type', form);
   const isEdit = Boolean(editingRecord);
+  const [typeInfos, setTypeInfos] = useState<DataSourceTypeInfo[]>(FALLBACK_TYPE_INFOS);
 
-  const selectedNormalizedType = useMemo(
-    () => normalizeType(selectedType),
-    [selectedType],
+  useEffect(() => {
+    let cancelled = false;
+    fetchDataSourceTypes()
+      .then((response) => {
+        const items = (response as { items?: DataSourceTypeInfo[] })?.items;
+        if (!cancelled && Array.isArray(items) && items.length > 0) {
+          setTypeInfos(items);
+        }
+      })
+      .catch(() => {
+        /* old backend without the endpoint: keep the fallback list */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const typeOptions = useMemo(
+    () => typeInfos.map((item) => ({ label: item.label, value: item.type })),
+    [typeInfos],
   );
+  const selectedInfo = useMemo(
+    () => findTypeInfo(typeInfos, selectedType),
+    [typeInfos, selectedType],
+  );
+  const selectedShape = formShape(selectedInfo);
+  const typeLabel = (type?: DataSourceType | string | null) =>
+    typeInfos.find((item) => item.type === String(type || '').toLowerCase())?.label
+    ?? String(type || '-');
 
   const resetDataSourceOptionCache = () => {
     useDataSourceOptionsStore.getState().reset();
@@ -142,9 +212,10 @@ const DataSourceManagement: React.FC = () => {
   const handleOpenAddDrawer = () => {
     setEditingRecord(null);
     form.resetFields();
+    const initial = findTypeInfo(typeInfos, 'mysql');
     form.setFieldsValue({
-      datasource_type: 'mysql',
-      port: 3306,
+      datasource_type: initial.type,
+      port: fieldDefault(initial, 'port') as number | undefined,
     });
     setDrawerVisible(true);
   };
@@ -162,10 +233,11 @@ const DataSourceManagement: React.FC = () => {
     form.resetFields();
   };
 
-  const handleTypeChange = (type: NormalizedDataSourceType) => {
+  const handleTypeChange = (type: string) => {
+    const info = findTypeInfo(typeInfos, type);
     form.setFieldsValue({
       host: undefined,
-      port: type === 'mysql' ? 3306 : type === 'postgresql' ? 5432 : undefined,
+      port: fieldDefault(info, 'port') as number | undefined,
       user: undefined,
       password: undefined,
       dbname: undefined,
@@ -175,13 +247,14 @@ const DataSourceManagement: React.FC = () => {
       access_key_id: undefined,
       access_key_secret: undefined,
       sts_token: undefined,
+      path: undefined,
     });
   };
 
   const handleTestFormConnection = async () => {
     try {
       const values = await form.validateFields();
-      const payload = valuesToPayload(values);
+      const payload = valuesToPayload(values, typeInfos);
       setTesting(true);
       const result = await testDataSourceConnection({
         datasource_type: payload.datasource_type,
@@ -226,7 +299,7 @@ const DataSourceManagement: React.FC = () => {
   const handleDrawerOk = async () => {
     try {
       const values = await form.validateFields();
-      const payload = valuesToPayload(values);
+      const payload = valuesToPayload(values, typeInfos);
       setConfirmLoading(true);
       if (editingRecord) {
         await updateDataSource(editingRecord.datasource_id, payload);
@@ -268,7 +341,7 @@ const DataSourceManagement: React.FC = () => {
       valueType: 'select',
       width: 160,
       fieldProps: {
-        options: DATA_SOURCE_TYPE_OPTIONS,
+        options: typeOptions,
       },
       render: (_, record) => typeLabel(record.datasource_type),
     },
@@ -375,12 +448,20 @@ const DataSourceManagement: React.FC = () => {
           >
             <Select
               placeholder={t('validation.selectDataSourceType')}
-              options={DATA_SOURCE_TYPE_OPTIONS}
+              options={typeOptions}
               onChange={handleTypeChange}
             />
           </Form.Item>
 
-          {selectedNormalizedType === 'odps' ? (
+          {selectedShape === 'file' ? (
+            <Form.Item
+              name="path"
+              label={t('dataConnection.filePath')}
+              rules={[{ required: true, message: t('dataConnection.filePathRequired') }]}
+            >
+              <Input placeholder={t('dataConnection.filePathPlaceholder')} allowClear />
+            </Form.Item>
+          ) : selectedShape === 'odps' ? (
             <>
               <Form.Item
                 name="endpoint"
@@ -449,7 +530,7 @@ const DataSourceManagement: React.FC = () => {
                 />
               </Form.Item>
               <Form.Item
-                name={selectedNormalizedType === 'postgresql' ? 'dbname' : 'database'}
+                name={dbFieldKey(selectedInfo)}
                 label={t('dataConnection.db')}
                 rules={[{ required: true, message: t('dataConnection.dbRequired') }]}
               >

--- a/packages/qwenpaw-data-context/frontend/src/services/dataSource.ts
+++ b/packages/qwenpaw-data-context/frontend/src/services/dataSource.ts
@@ -7,6 +7,25 @@ export const queryDataSourceList = (params?: DataSourceQueryParams) => {
   return request.get(semanticConfigApi('/datasource'), { params });
 };
 
+export interface DataSourceFieldSpec {
+  name: string;
+  type: string;
+  required: boolean;
+  default?: unknown;
+  secret?: boolean;
+}
+
+export interface DataSourceTypeInfo {
+  type: string;
+  label: string;
+  fields: DataSourceFieldSpec[];
+}
+
+// 支持的数据源类型与连接表单字段（后端 pydantic 模型单点导出）
+export const fetchDataSourceTypes = (): Promise<{ items: DataSourceTypeInfo[] }> => {
+  return request.get(semanticConfigApi('/datasource/types'));
+};
+
 // Credential-free datasource identities for ordinary query pages/dropdowns.
 export const queryDataSourceMetadata = (params?: DataSourceQueryParams) => {
   return request.get('/api/v1/cm/datasources', { params });

--- a/packages/qwenpaw-data-context/frontend/src/types/dataSource.ts
+++ b/packages/qwenpaw-data-context/frontend/src/types/dataSource.ts
@@ -1,4 +1,4 @@
-export type DataSourceType = 'ODPS' | 'MYSQL' | 'POSTGRESQL' | 'odps' | 'mysql' | 'postgresql';
+export type DataSourceType = string;
 
 export type DataSourceConfig =
   | {

--- a/packages/qwenpaw-data-context/pyproject.toml
+++ b/packages/qwenpaw-data-context/pyproject.toml
@@ -64,6 +64,7 @@ dependencies = [
 
 [project.optional-dependencies]
 bigquery = ["google-cloud-bigquery>=3.25,<4.0"]
+duckdb = ["duckdb>=1.0,<2.0", "duckdb-engine>=0.13,<1.0"]
 
 [project.urls]
 Homepage = "https://github.com/agentscope-ai/QwenPaw-Data"

--- a/packages/qwenpaw-data-context/src/context_manager/api/authorization.py
+++ b/packages/qwenpaw-data-context/src/context_manager/api/authorization.py
@@ -251,6 +251,7 @@ _register(
     ("PUT", "/api/system/model-config/embedding"),
     ("POST", "/api/system/model-config/embedding/test"),
     ("GET", "/api/semantic-config/datasource"),
+    ("GET", "/api/semantic-config/datasource/types"),
     ("POST", "/api/semantic-config/datasource"),
     ("POST", "/api/semantic-config/datasource/test-connection"),
     ("GET", "/api/semantic-config/datasource/{datasource_id}"),

--- a/packages/qwenpaw-data-context/src/context_manager/api/executor.py
+++ b/packages/qwenpaw-data-context/src/context_manager/api/executor.py
@@ -212,10 +212,15 @@ def _resolve_sql_exec_backend() -> str:
             ds_type = cfg.get("_datasource_type", "")
             if ds_type in ("postgresql", "postgres", "hologres"):
                 return "direct"
-            if ds_type == "mysql":
+            if ds_type in ("mysql", "starrocks", "doris", "tidb"):
+                # MySQL 线协议兼容引擎全部走 PyMySQL 直连。
                 return "pymysql_direct"
             if ds_type == "odps":
                 return "odps_akless"
+            if ds_type == "duckdb":
+                return "duckdb_direct"
+            if ds_type == "sqlite":
+                return "sqlite_direct"
     return "unknown"
 
 
@@ -237,10 +242,15 @@ def _resolve_backend_for_datasource(datasource_id: str) -> str:
             ds_type = cfg.get("_datasource_type", "")
             if ds_type in ("postgresql", "postgres", "hologres"):
                 return "direct"
-            if ds_type == "mysql":
+            if ds_type in ("mysql", "starrocks", "doris", "tidb"):
+                # MySQL 线协议兼容引擎全部走 PyMySQL 直连。
                 return "pymysql_direct"
             if ds_type == "odps":
                 return "odps_akless"
+            if ds_type == "duckdb":
+                return "duckdb_direct"
+            if ds_type == "sqlite":
+                return "sqlite_direct"
         return "unknown"
     return _resolve_sql_exec_backend()
 
@@ -333,6 +343,94 @@ def _execute_sql_via_pymysql(
                 )
         finally:
             conn.close()
+    except Exception as exc:
+        return ExecResult(
+            sql=sql, error=str(exc),
+            elapsed_ms=(time.time() - t0) * 1000,
+        )
+
+
+def _file_db_path(datasource_id: str, expected_type: str) -> "Path":
+    """从 semantic_config.db 取单文件数据源的本地路径并校验存在。"""
+    from pathlib import Path
+
+    from .datasource_active_api import load_datasource_config
+
+    cfg = load_datasource_config(datasource_id)
+    if cfg is None:
+        raise RuntimeError(
+            f"datasource_id={datasource_id!r} 在 semantic_config.db 中无 config"
+        )
+    ds_type = cfg.get("_datasource_type", "")
+    if ds_type != expected_type:
+        raise RuntimeError(
+            f"datasource_id={datasource_id!r} 类型 {ds_type!r} 不是 {expected_type}"
+        )
+    path = Path(str(cfg.get("path") or "")).expanduser()
+    if not path.is_file():
+        raise RuntimeError(f"{expected_type} 数据库文件不存在: {path}")
+    return path
+
+
+def _execute_sql_via_duckdb(
+    sql: str,
+    *,
+    max_rows: int = 200,
+    datasource_id: str = "",
+) -> ExecResult:
+    """Execute read-only SQL against a local DuckDB file (read_only=True)."""
+    t0 = time.time()
+    try:
+        path = _file_db_path(datasource_id, "duckdb")
+        import duckdb
+
+        conn = duckdb.connect(str(path), read_only=True)
+        try:
+            cur = conn.execute(sql)
+            cols = [d[0] for d in (cur.description or [])]
+            rows = cur.fetchmany(max_rows + 1)
+            truncated = len(rows) > max_rows
+            rows = rows[:max_rows]
+        finally:
+            conn.close()
+        return ExecResult(
+            sql=sql, columns=cols, rows=[list(r) for r in rows],
+            row_count=len(rows), truncated=truncated,
+            elapsed_ms=(time.time() - t0) * 1000,
+        )
+    except Exception as exc:
+        return ExecResult(
+            sql=sql, error=str(exc),
+            elapsed_ms=(time.time() - t0) * 1000,
+        )
+
+
+def _execute_sql_via_sqlite(
+    sql: str,
+    *,
+    max_rows: int = 200,
+    datasource_id: str = "",
+) -> ExecResult:
+    """Execute read-only SQL against a local SQLite file (mode=ro URI)."""
+    t0 = time.time()
+    try:
+        path = _file_db_path(datasource_id, "sqlite")
+        import sqlite3
+
+        conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True, timeout=5)
+        try:
+            cur = conn.execute(sql)
+            cols = [d[0] for d in (cur.description or [])]
+            rows = cur.fetchmany(max_rows + 1)
+            truncated = len(rows) > max_rows
+            rows = rows[:max_rows]
+        finally:
+            conn.close()
+        return ExecResult(
+            sql=sql, columns=cols, rows=[list(r) for r in rows],
+            row_count=len(rows), truncated=truncated,
+            elapsed_ms=(time.time() - t0) * 1000,
+        )
     except Exception as exc:
         return ExecResult(
             sql=sql, error=str(exc),
@@ -468,6 +566,10 @@ def execute_sql(
             return _execute_sql_via_odps_akless(s, max_rows=max_rows, datasource_id=active_ds)
         if backend == "pymysql_direct":
             return _execute_sql_via_pymysql(s, max_rows=max_rows, datasource_id=active_ds)
+        if backend == "duckdb_direct":
+            return _execute_sql_via_duckdb(s, max_rows=max_rows, datasource_id=active_ds)
+        if backend == "sqlite_direct":
+            return _execute_sql_via_sqlite(s, max_rows=max_rows, datasource_id=active_ds)
         if backend == "direct":
             return _execute_sql_via_psycopg(
                 s, max_rows=max_rows, datasource_id=active_ds,

--- a/packages/qwenpaw-data-context/src/context_manager/api/executor.py
+++ b/packages/qwenpaw-data-context/src/context_manager/api/executor.py
@@ -31,6 +31,7 @@ import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Optional, Tuple
 
 import psycopg
@@ -350,10 +351,8 @@ def _execute_sql_via_pymysql(
         )
 
 
-def _file_db_path(datasource_id: str, expected_type: str) -> "Path":
+def _file_db_path(datasource_id: str, expected_type: str) -> Path:
     """从 semantic_config.db 取单文件数据源的本地路径并校验存在。"""
-    from pathlib import Path
-
     from .datasource_active_api import load_datasource_config
 
     cfg = load_datasource_config(datasource_id)

--- a/packages/qwenpaw-data-context/src/context_manager/graph/adapters/duckdb_adapter.py
+++ b/packages/qwenpaw-data-context/src/context_manager/graph/adapters/duckdb_adapter.py
@@ -1,0 +1,53 @@
+"""DuckDB adapter — minimal overrides on UniversalConnector (single local
+file, schema == ``main``; reflection via duckdb-engine)."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional, Sequence
+
+from pydantic import BaseModel
+
+from ...secrets.schemas import DuckdbConnection
+from ...utils import get_logger
+from .base import ConnectorError
+from .universal import UniversalConnector
+
+log = get_logger("graph.adapters.duckdb")
+
+#: DuckDB 默认 schema 名（写进图节点 ``schema`` 字段）。
+_DUCKDB_SCHEMA = "main"
+
+
+class DuckDBConnector(UniversalConnector):
+    """Single-file analytical source: no host / credentials; construction
+    validates the file exists because duckdb silently creates missing
+    databases."""
+
+    connection_model = DuckdbConnection
+
+    def __init__(self, conn: DuckdbConnection, *, db_id: str):
+        path = Path(conn.path).expanduser()
+        if not path.is_file():
+            raise ConnectorError(f"DuckDB 数据库文件不存在: {path}")
+        super().__init__(conn, db_id=db_id)
+
+    def _engine_url(self, conn: BaseModel):
+        from sqlalchemy import URL
+
+        return URL.create(
+            "duckdb",
+            database=str(Path(conn.path).expanduser()),
+        )
+
+    def _connect_args(self) -> dict:
+        read_only = getattr(self._conn, "read_only", True)
+        return {"read_only": bool(read_only)}
+
+    def _resolve_schema(self, schemas: Sequence[str]) -> Optional[str]:
+        return None  # 单文件库走 inspector 默认 schema（main）
+
+    def _schema_label(self, resolved: Optional[str]) -> str:
+        return _DUCKDB_SCHEMA
+
+
+__all__ = ["DuckDBConnector"]

--- a/packages/qwenpaw-data-context/src/context_manager/graph/adapters/registry.py
+++ b/packages/qwenpaw-data-context/src/context_manager/graph/adapters/registry.py
@@ -40,15 +40,21 @@ def _register_builtins() -> None:
     from .csv_adapter import CSVAdapter
     from .odps_adapter import OdpsAdapter
     from .sqlite_adapter import SQLiteConnector
+    from .duckdb_adapter import DuckDBConnector
     from .bigquery_adapter import BigQueryConnector
 
     register_adapter("postgres", PostgresAdapter.from_config)
     register_adapter("hologres", PostgresAdapter.from_config)
     register_adapter("mysql", MySQLAdapter.from_config)
+    # MySQL 线协议兼容引擎：information_schema 反射与 MySQL 相同。
+    register_adapter("starrocks", MySQLAdapter.from_config)
+    register_adapter("doris", MySQLAdapter.from_config)
+    register_adapter("tidb", MySQLAdapter.from_config)
     register_adapter("odps", OdpsAdapter.from_config)
     register_adapter("ddl", DDLAdapter.from_config)
     register_adapter("csv", CSVAdapter.from_config)
     register_adapter("sqlite", SQLiteConnector.from_config)
+    register_adapter("duckdb", DuckDBConnector.from_config)
     register_adapter("bigquery", BigQueryConnector.from_config)
 
 

--- a/packages/qwenpaw-data-context/src/context_manager/secrets/schemas.py
+++ b/packages/qwenpaw-data-context/src/context_manager/secrets/schemas.py
@@ -20,7 +20,8 @@ class PostgresConnection(BaseModel):
 
 
 class MySQLConnection(BaseModel):
-    type: Literal["mysql"]
+    # MySQL 线协议兼容引擎（StarRocks/Doris/TiDB）共用同一连接形态。
+    type: Literal["mysql", "starrocks", "doris", "tidb"]
     host: str
     port: int = 3306
     database: str
@@ -90,6 +91,14 @@ class SqliteConnection(BaseModel):
     )
 
 
+class DuckdbConnection(BaseModel):
+    type: Literal["duckdb"]
+    path: str
+    read_only: bool = Field(
+        default=True, description="只读模式打开（防止误写）"
+    )
+
+
 TypedConnection = Annotated[
     Union[
         PostgresConnection,
@@ -101,6 +110,7 @@ TypedConnection = Annotated[
         DDLConnection,
         CSVConnection,
         SqliteConnection,
+        DuckdbConnection,
     ],
     Field(discriminator="type"),
 ]

--- a/packages/qwenpaw-data-context/src/semantic_config/models/datasource_config.py
+++ b/packages/qwenpaw-data-context/src/semantic_config/models/datasource_config.py
@@ -20,6 +20,29 @@ class DatasourceType(str, Enum):
     POSTGRESQL = "postgresql"
     MYSQL = "mysql"
     ODPS = "odps"
+    # MySQL 线协议兼容引擎：注册/校验/连测/执行全部复用 MySQL 通道。
+    STARROCKS = "starrocks"
+    DORIS = "doris"
+    TIDB = "tidb"
+    # 单文件分析库：无 host/凭证，只需本地路径。
+    DUCKDB = "duckdb"
+    SQLITE = "sqlite"
+
+
+#: MySQL 线协议兼容类型（PyMySQL 直连 + information_schema 反射均可用）。
+MYSQL_COMPATIBLE_TYPES: frozenset[DatasourceType] = frozenset(
+    {
+        DatasourceType.MYSQL,
+        DatasourceType.STARROCKS,
+        DatasourceType.DORIS,
+        DatasourceType.TIDB,
+    }
+)
+
+#: 单文件类型（连接配置只有 ``path``）。
+FILE_DATABASE_TYPES: frozenset[DatasourceType] = frozenset(
+    {DatasourceType.DUCKDB, DatasourceType.SQLITE}
+)
 
 
 class PostgresConfig(BaseModel):
@@ -58,10 +81,44 @@ class OdpsConfig(BaseModel):
     sts_token: str | None = None
 
 
+class DuckdbConfig(BaseModel):
+    """DuckDB 单文件连接（duckdb 原生驱动，只读打开）。"""
+
+    model_config = ConfigDict(extra="forbid")
+
+    path: str
+
+
+class SqliteConfig(BaseModel):
+    """SQLite 单文件连接（sqlite3，``mode=ro`` 只读 URI 打开）。"""
+
+    model_config = ConfigDict(extra="forbid")
+
+    path: str
+
+
 CONFIG_MODEL_BY_TYPE: dict[DatasourceType, type[BaseModel]] = {
     DatasourceType.POSTGRESQL: PostgresConfig,
     DatasourceType.MYSQL: MysqlConfig,
     DatasourceType.ODPS: OdpsConfig,
+    # MySQL 兼容引擎共用同一份连接模型。
+    DatasourceType.STARROCKS: MysqlConfig,
+    DatasourceType.DORIS: MysqlConfig,
+    DatasourceType.TIDB: MysqlConfig,
+    DatasourceType.DUCKDB: DuckdbConfig,
+    DatasourceType.SQLITE: SqliteConfig,
+}
+
+#: 展示名（``/datasource/types`` 端点使用；前端下拉据此渲染）。
+TYPE_LABELS: dict[DatasourceType, str] = {
+    DatasourceType.MYSQL: "MySQL",
+    DatasourceType.POSTGRESQL: "PostgreSQL",
+    DatasourceType.ODPS: "ODPS",
+    DatasourceType.STARROCKS: "StarRocks",
+    DatasourceType.DORIS: "Apache Doris",
+    DatasourceType.TIDB: "TiDB",
+    DatasourceType.DUCKDB: "DuckDB",
+    DatasourceType.SQLITE: "SQLite",
 }
 
 
@@ -100,10 +157,15 @@ def validate_config(datasource_type: str | None, config: dict | None) -> dict:
 
 __all__ = [
     "DatasourceType",
+    "MYSQL_COMPATIBLE_TYPES",
+    "FILE_DATABASE_TYPES",
     "PostgresConfig",
     "MysqlConfig",
     "OdpsConfig",
+    "DuckdbConfig",
+    "SqliteConfig",
     "CONFIG_MODEL_BY_TYPE",
+    "TYPE_LABELS",
     "resolve_type",
     "validate_config",
 ]

--- a/packages/qwenpaw-data-context/src/semantic_config/routers/datasource_router.py
+++ b/packages/qwenpaw-data-context/src/semantic_config/routers/datasource_router.py
@@ -34,6 +34,52 @@ async def list_datasource_metadata(
     )
 
 
+_SECRET_FIELDS = {"password", "access_key_secret", "sts_token"}
+
+
+@router.get("/types")
+async def list_datasource_types() -> dict:
+    """支持的数据源类型及其连接表单字段（由 pydantic 配置模型单点导出）。
+
+    前端 Add Data Source 表单据此渲染类型下拉与逐字段输入；新增类型只改
+    ``datasource_config.py``，不再改前端硬编码列表。
+    """
+    from semantic_config.models.datasource_config import (
+        CONFIG_MODEL_BY_TYPE,
+        TYPE_LABELS,
+    )
+
+    items = []
+    for ds_type, model in CONFIG_MODEL_BY_TYPE.items():
+        schema = model.model_json_schema()
+        required = set(schema.get("required", []))
+        fields = []
+        for name, spec in (schema.get("properties") or {}).items():
+            json_type = spec.get("type")
+            if json_type is None and "anyOf" in spec:
+                json_type = next(
+                    (opt.get("type") for opt in spec["anyOf"] if opt.get("type") not in (None, "null")),
+                    "string",
+                )
+            fields.append(
+                {
+                    "name": name,
+                    "type": json_type or "string",
+                    "required": name in required,
+                    "default": spec.get("default"),
+                    "secret": name in _SECRET_FIELDS,
+                }
+            )
+        items.append(
+            {
+                "type": ds_type.value,
+                "label": TYPE_LABELS.get(ds_type, ds_type.value),
+                "fields": fields,
+            }
+        )
+    return {"items": items}
+
+
 @router.post("", response_model=DatasourceResponse)
 async def create_datasource(payload: DatasourceCreate, db: aiosqlite.Connection = Depends(get_db)):
     return await service.create(db, payload)

--- a/packages/qwenpaw-data-context/src/semantic_config/services/connection_tester.py
+++ b/packages/qwenpaw-data-context/src/semantic_config/services/connection_tester.py
@@ -118,10 +118,53 @@ def _try_count(cur, sql: str, params: tuple = ()) -> int | None:
         return None
 
 
+def _test_duckdb(cfg: dict) -> tuple[str, int | None]:
+    from pathlib import Path
+
+    import duckdb
+
+    path = Path(cfg["path"]).expanduser()
+    if not path.is_file():
+        raise RuntimeError(f"DuckDB 数据库文件不存在: {path}")
+    conn = duckdb.connect(str(path), read_only=True)
+    try:
+        row = conn.execute(
+            "SELECT count(*) FROM information_schema.tables "
+            "WHERE table_schema = 'main'"
+        ).fetchone()
+        tables = int(row[0]) if row and row[0] is not None else None
+    finally:
+        conn.close()
+    return f"connected to {path}", tables
+
+
+def _test_sqlite(cfg: dict) -> tuple[str, int | None]:
+    import sqlite3
+    from pathlib import Path
+
+    path = Path(cfg["path"]).expanduser()
+    if not path.is_file():
+        raise RuntimeError(f"SQLite 数据库文件不存在: {path}")
+    conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True, timeout=CONNECT_TIMEOUT)
+    try:
+        cur = conn.execute("SELECT count(*) FROM sqlite_master WHERE type = 'table'")
+        row = cur.fetchone()
+        tables = int(row[0]) if row and row[0] is not None else None
+    finally:
+        conn.close()
+    return f"connected to {path}", tables
+
+
 _TESTER_BY_TYPE = {
     DatasourceType.POSTGRESQL: _test_postgres,
     DatasourceType.MYSQL: _test_mysql,
     DatasourceType.ODPS: _test_odps,
+    # MySQL 线协议兼容引擎：探测通道与 MySQL 相同。
+    DatasourceType.STARROCKS: _test_mysql,
+    DatasourceType.DORIS: _test_mysql,
+    DatasourceType.TIDB: _test_mysql,
+    DatasourceType.DUCKDB: _test_duckdb,
+    DatasourceType.SQLITE: _test_sqlite,
 }
 
 

--- a/packages/qwenpaw-data-context/src/semantic_config/services/datasource_service.py
+++ b/packages/qwenpaw-data-context/src/semantic_config/services/datasource_service.py
@@ -22,7 +22,9 @@ from semantic_config.services import connection_tester
 
 log = logging.getLogger("semantic_config.datasource_service")
 
-_ALLOWED_TYPES = {"mysql", "postgresql", "odps"}
+from semantic_config.models.datasource_config import DatasourceType as _DatasourceType
+
+_ALLOWED_TYPES = {t.value for t in _DatasourceType}
 _SENSITIVE_CONFIG_KEYS = frozenset({"password", "access_key_secret", "sts_token"})
 
 

--- a/packages/qwenpaw-data-context/tests/test_datasource_types.py
+++ b/packages/qwenpaw-data-context/tests/test_datasource_types.py
@@ -117,6 +117,7 @@ def duckdb_db(tmp_path):
 
 
 def test_duckdb_adapter_metadata_and_sql(duckdb_db) -> None:
+    pytest.importorskip("duckdb_engine")
     from context_manager.graph.adapters.duckdb_adapter import DuckDBConnector
     from context_manager.secrets.schemas import DuckdbConnection
 

--- a/packages/qwenpaw-data-context/tests/test_datasource_types.py
+++ b/packages/qwenpaw-data-context/tests/test_datasource_types.py
@@ -1,0 +1,208 @@
+"""新数据源类型：MySQL 兼容别名、单文件库（DuckDB/SQLite）、类型枚举端点。"""
+from __future__ import annotations
+
+import sqlite3
+
+import duckdb
+import pytest
+
+from semantic_config.errors import BadRequestError
+from semantic_config.models.datasource_config import (
+    CONFIG_MODEL_BY_TYPE,
+    DatasourceType,
+    MYSQL_COMPATIBLE_TYPES,
+    MysqlConfig,
+    TYPE_LABELS,
+    validate_config,
+)
+from semantic_config.services.connection_tester import (
+    test_connection as run_connection_test,
+)
+
+
+def test_mysql_compatible_types_share_config_model() -> None:
+    for ds_type in ("starrocks", "doris", "tidb"):
+        member = DatasourceType(ds_type)
+        assert member in MYSQL_COMPATIBLE_TYPES
+        assert CONFIG_MODEL_BY_TYPE[member] is MysqlConfig
+        normalized = validate_config(
+            ds_type,
+            {
+                "host": "db.internal",
+                "port": 9030,
+                "database": "dw",
+                "user": "reader",
+                "password": "secret",
+            },
+        )
+        assert normalized["port"] == 9030
+
+
+def test_every_type_has_label_and_model() -> None:
+    for member in DatasourceType:
+        assert member in CONFIG_MODEL_BY_TYPE, member
+        assert member in TYPE_LABELS, member
+
+
+def test_file_types_validate_path_only() -> None:
+    assert validate_config("duckdb", {"path": "/tmp/a.duckdb"}) == {
+        "path": "/tmp/a.duckdb"
+    }
+    assert validate_config("sqlite", {"path": "/tmp/a.db"}) == {"path": "/tmp/a.db"}
+    with pytest.raises(BadRequestError):
+        validate_config("duckdb", {"path": "/tmp/a.duckdb", "host": "nope"})
+
+
+async def test_duckdb_connection_test(tmp_path) -> None:
+    db_path = tmp_path / "analytics.duckdb"
+    conn = duckdb.connect(str(db_path))
+    conn.execute("CREATE TABLE sales (id INTEGER, amount DOUBLE)")
+    conn.close()
+
+    result = await run_connection_test("duckdb", {"path": str(db_path)})
+    assert result.success, result.message
+    assert "analytics.duckdb" in result.message
+
+    missing = await run_connection_test("duckdb", {"path": str(tmp_path / "nope.db")})
+    assert not missing.success
+
+
+async def test_sqlite_connection_test(tmp_path) -> None:
+    db_path = tmp_path / "app.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute("CREATE TABLE users (id INTEGER PRIMARY KEY)")
+    conn.commit()
+    conn.close()
+
+    result = await run_connection_test("sqlite", {"path": str(db_path)})
+    assert result.success, result.message
+
+
+async def test_types_endpoint() -> None:
+    from semantic_config.routers.datasource_router import list_datasource_types
+
+    body = await list_datasource_types()
+    items = {item["type"]: item for item in body["items"]}
+    assert set(items) == {t.value for t in DatasourceType}
+
+    mysql = items["mysql"]
+    assert mysql["label"] == "MySQL"
+    field_by_name = {f["name"]: f for f in mysql["fields"]}
+    assert field_by_name["port"]["default"] == 3306
+    assert field_by_name["port"]["type"] == "integer"
+    assert field_by_name["password"]["secret"] is True
+    assert field_by_name["host"]["required"] is True
+
+    duckdb_info = items["duckdb"]
+    assert [f["name"] for f in duckdb_info["fields"]] == ["path"]
+
+    starrocks = items["starrocks"]
+    assert starrocks["label"] == "StarRocks"
+    assert {f["name"] for f in starrocks["fields"]} == set(field_by_name)
+
+
+# ---------------------------------------------------------------------------
+# DuckDB adapter + registry aliases
+
+
+@pytest.fixture
+def duckdb_db(tmp_path):
+    path = tmp_path / "shop.duckdb"
+    conn = duckdb.connect(str(path))
+    conn.execute("CREATE TABLE orders (id INTEGER, customer_id INTEGER, gmv DOUBLE)")
+    conn.execute("CREATE TABLE customers (id INTEGER, name VARCHAR)")
+    conn.execute("INSERT INTO orders VALUES (1, 1, 250.5), (2, 2, 80.0)")
+    conn.close()
+    return path
+
+
+def test_duckdb_adapter_metadata_and_sql(duckdb_db) -> None:
+    from context_manager.graph.adapters.duckdb_adapter import DuckDBConnector
+    from context_manager.secrets.schemas import DuckdbConnection
+
+    connector = DuckDBConnector(
+        DuckdbConnection(type="duckdb", path=str(duckdb_db)), db_id="shop"
+    )
+    try:
+        result = connector.test_connection()
+        assert result.success
+        assert result.tables_found == 2
+
+        manifest = connector.extract_metadata([])
+        assert manifest.schema == "main"
+        assert {t.name for t in manifest.tables} == {"orders", "customers"}
+
+        rows = connector.execute_sql("SELECT count(*) FROM orders")
+        assert rows.rows[0][0] == 2
+    finally:
+        connector.close()
+
+
+def test_duckdb_adapter_missing_file() -> None:
+    from context_manager.graph.adapters.base import ConnectorError
+    from context_manager.graph.adapters.duckdb_adapter import DuckDBConnector
+    from context_manager.secrets.schemas import DuckdbConnection
+
+    with pytest.raises(ConnectorError, match="不存在"):
+        DuckDBConnector(
+            DuckdbConnection(type="duckdb", path="/nonexistent/nope.duckdb"),
+            db_id="shop",
+        )
+
+
+def test_registry_aliases_mysql_compatible_types() -> None:
+    from context_manager.graph.adapters.registry import _FACTORIES, _register_builtins
+
+    _register_builtins()
+    for alias in ("starrocks", "doris", "tidb", "duckdb"):
+        assert alias in _FACTORIES, alias
+
+
+def test_executor_backend_resolution(monkeypatch, tmp_path) -> None:
+    from context_manager.api import executor
+
+    def fake_config(ds_type: str, path: str = ""):
+        def loader(_ds_id: str):
+            cfg = {"_datasource_type": ds_type}
+            if path:
+                cfg["path"] = path
+            return cfg
+
+        return loader
+
+    from context_manager.api import datasource_active_api
+
+    for ds_type, expected in (
+        ("starrocks", "pymysql_direct"),
+        ("doris", "pymysql_direct"),
+        ("tidb", "pymysql_direct"),
+        ("duckdb", "duckdb_direct"),
+        ("sqlite", "sqlite_direct"),
+        ("mysql", "pymysql_direct"),
+        ("postgresql", "direct"),
+    ):
+        monkeypatch.setattr(
+            datasource_active_api, "load_datasource_config", fake_config(ds_type)
+        )
+        assert executor._resolve_backend_for_datasource("ds1") == expected, ds_type
+
+
+def test_executor_duckdb_reads_rows(monkeypatch, duckdb_db) -> None:
+    from context_manager.api import datasource_active_api, executor
+
+    monkeypatch.setattr(
+        datasource_active_api,
+        "load_datasource_config",
+        lambda _ds: {"_datasource_type": "duckdb", "path": str(duckdb_db)},
+    )
+    result = executor._execute_sql_via_duckdb(
+        "SELECT id FROM orders ORDER BY id", datasource_id="ds1"
+    )
+    assert result.error is None
+    assert [r[0] for r in result.rows] == [1, 2]
+
+    # 只读打开：写入必须失败。
+    write = executor._execute_sql_via_duckdb(
+        "INSERT INTO orders VALUES (3, 3, 1.0)", datasource_id="ds1"
+    )
+    assert write.error is not None

--- a/uv.lock
+++ b/uv.lock
@@ -981,6 +981,20 @@ wheels = [
 ]
 
 [[package]]
+name = "duckdb-engine"
+version = "0.17.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "duckdb" },
+    { name = "packaging" },
+    { name = "sqlalchemy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/89/d5/c0d8d0a4ca3ffea92266f33d92a375e2794820ad89f9be97cf0c9a9697d0/duckdb_engine-0.17.0.tar.gz", hash = "sha256:396b23869754e536aa80881a92622b8b488015cf711c5a40032d05d2cf08f3cf", size = 48054, upload-time = "2025-03-29T09:49:17.663Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/a2/e90242f53f7ae41554419b1695b4820b364df87c8350aa420b60b20cab92/duckdb_engine-0.17.0-py3-none-any.whl", hash = "sha256:3aa72085e536b43faab635f487baf77ddc5750069c16a2f8d9c6c3cb6083e979", size = 49676, upload-time = "2025-03-29T09:49:15.564Z" },
+]
+
+[[package]]
 name = "et-xmlfile"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3420,6 +3434,10 @@ dependencies = [
 bigquery = [
     { name = "google-cloud-bigquery" },
 ]
+duckdb = [
+    { name = "duckdb" },
+    { name = "duckdb-engine" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -3430,6 +3448,8 @@ requires-dist = [
     { name = "dbt-core", specifier = ">=1.11,<2.0" },
     { name = "dbt-duckdb", specifier = ">=1.10,<2.0" },
     { name = "duckdb", specifier = ">=1.5,<2.0" },
+    { name = "duckdb", marker = "extra == 'duckdb'", specifier = ">=1.0,<2.0" },
+    { name = "duckdb-engine", marker = "extra == 'duckdb'", specifier = ">=0.13,<1.0" },
     { name = "fastapi", specifier = ">=0.141.1,<1.0" },
     { name = "func-timeout", specifier = ">=4.3,<5.0" },
     { name = "google-cloud-bigquery", marker = "extra == 'bigquery'", specifier = ">=3.25,<4.0" },
@@ -3457,7 +3477,7 @@ requires-dist = [
     { name = "tqdm", specifier = ">=4.68,<5.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.52.1,<1.0" },
 ]
-provides-extras = ["bigquery"]
+provides-extras = ["bigquery", "duckdb"]
 
 [[package]]
 name = "qwenpaw-data-host-core"


### PR DESCRIPTION
## Summary
- New `GET /api/semantic-config/datasource/types` exports each type's connection-form field spec straight from the pydantic config models; the console's Add Data Source form now renders the type list and per-type fields from it (with an offline fallback), so adding a datasource type no longer touches the frontend.
- **StarRocks, Apache Doris, TiDB**: first-class types riding the MySQL wire protocol end to end — validation, connection test, PyMySQL governed-query backend, and `information_schema` reflection via the existing MySQL adapter.
- **DuckDB + SQLite**: single-file sources registerable from the form (path-only config), with read-only governed-query executor backends; DuckDB gains a `UniversalConnector` adapter (`duckdb-engine`) behind a new `[duckdb]` extra.

Independent of the #58–#61 host-core stack (context package only).

## Test plan
- [x] Full suite green (901 passed) incl. 11 new tests: type/label/model completeness, MySQL-compatible validation, DuckDB/SQLite connection testers, types endpoint field specs, adapter metadata+SQL+read-only, executor backend resolution, DuckDB executor row reads + write rejection
- [x] Live-verified in the console: dropdown lists all 8 types, DuckDB form renders path-only, test-connection succeeds against a real .duckdb file
- [x] L3 security review: 0 findings