### PR TITLE
fix(host-core): emit follow-ups before completion

### DIFF
--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/algo/followup/__init__.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/algo/followup/__init__.py
@@ -10,10 +10,7 @@ from qwenpaw_data.host.core.algo.followup.models import (
     SourceChannel,
 )
 from qwenpaw_data.host.core.algo.followup.ranking import select
-from qwenpaw_data.host.core.algo.followup.recommend import (
-    FollowUpCallback,
-    FollowUpRecommend,
-)
+from qwenpaw_data.host.core.algo.followup.recommend import FollowUpRecommend
 from qwenpaw_data.host.core.algo.followup.relevance import (
     EntityEvidence,
     RankedEntities,
@@ -30,7 +27,6 @@ __all__ = [
     "EntityEvidence",
     "EntityRecord",
     "FollowUp",
-    "FollowUpCallback",
     "FollowUpRecommend",
     "FollowUpService",
     "IntentCategory",

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/algo/followup/recommend.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/algo/followup/recommend.py
@@ -10,12 +10,11 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any
 
 from qwenpaw_data.host.core.algo.followup.collector import SignalCollector
 from qwenpaw_data.host.core.algo.followup.llm import FollowUpLLM, for_structured_calls
-from qwenpaw_data.host.core.algo.followup.models import Candidate, FollowUp, SignalSnapshot
+from qwenpaw_data.host.core.algo.followup.models import FollowUp, SignalSnapshot
 from qwenpaw_data.host.core.algo.followup.service import FollowUpService
 from qwenpaw_data.host.core.algo.followup.settings import (
     MAX_DIMENSIONS,
@@ -34,16 +33,13 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-FollowUpCallback = Callable[[list[str]], Awaitable[None]]
-
 
 class FollowUpRecommend:
     """Recommend the next questions for one Chat, out of the reply's way.
 
     The host drives ``start`` once, ``append`` per event, and ``join`` on the
-    completed path only. None of the three may block the reply: collection runs
-    on its own task, and ``join`` gives up on its own budget rather than holding
-    the turn open.
+    completed path only. Collection runs concurrently with the reply. At join,
+    the service bounds the model call and falls back to rules before returning.
 
     Every knob is a plain argument with the validated default: the host owns the
     configuration (``settings.followup``) and passes it in, so nothing here
@@ -54,9 +50,7 @@ class FollowUpRecommend:
         run_context: The Chat being answered, and the models it may run on.
         previous_followups: Questions recommended earlier in this Session, so
             the same one is not offered twice.
-        deliver: Optional sink for a result that misses the budget. Without it a
-            late result is dropped, since the turn has already closed.
-        timeout_sec: What the closing moment of the Chat will wait for.
+        timeout_sec: Maximum time allowed for the model channel.
         max_questions: Upper bound on the delivered questions.
         max_metrics: Cap on metrics entering the prompt.
         max_dimensions: Cap on dimensions entering the prompt.
@@ -68,7 +62,6 @@ class FollowUpRecommend:
         *,
         run_context: RunContext,
         previous_followups: tuple[str, ...] = (),
-        deliver: FollowUpCallback | None = None,
         timeout_sec: float = TIMEOUT_SEC,
         max_questions: int = MAX_QUESTIONS,
         max_metrics: int = MAX_METRICS,
@@ -79,7 +72,6 @@ class FollowUpRecommend:
         self.chat_id = run_context.chat_id
         self.session_id = run_context.session_id
         self.previous_followups = previous_followups
-        self.deliver = deliver
         self.timeout_sec = timeout_sec
         self.max_questions = max_questions
         self.max_metrics = max_metrics
@@ -87,8 +79,6 @@ class FollowUpRecommend:
         self.min_relevance = min_relevance
         self._collector: SignalCollector | None = None
         self._snapshot: asyncio.Task[SignalSnapshot] | None = None
-        self._pipeline: asyncio.Task[list[Candidate]] | None = None
-        self._late: asyncio.Task[None] | None = None
         self._questions: list[str] | None = None
 
     async def start(self) -> None:
@@ -130,7 +120,7 @@ class FollowUpRecommend:
     async def join(self) -> list[str]:
         """Return the questions to recommend, or nothing if none can be made."""
         if self._questions is None:
-            self._questions = await self._within_budget()
+            self._questions = await self._recommend()
         return self._questions
 
     def _begin_freeze(self) -> None:
@@ -152,49 +142,23 @@ class FollowUpRecommend:
             )
             return SignalSnapshot()
 
-    def _begin_pipeline(self) -> asyncio.Task[list[Candidate]] | None:
-        if self._pipeline is None:
-            self._begin_freeze()
-            if self._snapshot is None:
-                return None
-            self._pipeline = asyncio.create_task(self._run_pipeline(self._snapshot))
-        return self._pipeline
-
-    async def _within_budget(self) -> list[str]:
-        pipeline = self._begin_pipeline()
-        if pipeline is None:
+    async def _recommend(self) -> list[str]:
+        self._begin_freeze()
+        if self._snapshot is None:
             return []
-        try:
-            # Shielded: the questions are worth persisting even once the turn
-            # has stopped waiting for them.
-            candidates = await asyncio.wait_for(
-                asyncio.shield(pipeline), timeout=self.timeout_sec
-            )
-        except TimeoutError:
-            logger.warning(
-                "Follow-up recommendation missed its %ss budget for chat %s",
-                self.timeout_sec,
-                self.chat_id,
-            )
-            self._begin_late_delivery(pipeline)
-            return []
-        return FollowUp.of(self.chat_id, candidates).questions
-
-    async def _run_pipeline(
-        self, snapshot: asyncio.Task[SignalSnapshot]
-    ) -> list[Candidate]:
         service = FollowUpService(
             timeout_sec=self.timeout_sec,
             max_questions=self.max_questions,
             llm=self._build_llm(),
         )
         try:
-            return await service.recommend(await snapshot)
+            candidates = await service.recommend(await self._snapshot)
         except Exception:
             logger.exception(
                 "Follow-up recommendation failed for chat %s", self.chat_id
             )
             return []
+        return FollowUp.of(self.chat_id, candidates).questions
 
     def _build_llm(self) -> FollowUpLLM | None:
         """The model channel's model, or None to fall back to rules only.
@@ -224,24 +188,5 @@ class FollowUpRecommend:
             return None
         return FollowUpLLM(model, timeout=self.timeout_sec)
 
-    def _begin_late_delivery(self, pipeline: asyncio.Task[list[Candidate]]) -> None:
-        if self.deliver is not None and self._late is None:
-            self._late = asyncio.create_task(self._deliver_late(pipeline))
 
-    async def _deliver_late(self, pipeline: asyncio.Task[list[Candidate]]) -> None:
-        """Persist a result the turn outran, for the next snapshot to carry."""
-        deliver = self.deliver
-        if deliver is None:
-            return
-        try:
-            questions = FollowUp.of(self.chat_id, await pipeline).questions
-            if questions:
-                await deliver(questions)
-        except Exception:
-            logger.exception(
-                "Follow-up recommendation failed to deliver late for chat %s",
-                self.chat_id,
-            )
-
-
-__all__ = ["FollowUpCallback", "FollowUpRecommend"]
+__all__ = ["FollowUpRecommend"]

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/runtime/chat_runtime.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/runtime/chat_runtime.py
@@ -249,7 +249,6 @@ class ChatRuntime:
             followup = FollowUpRecommend(
                 run_context=self._run_context,
                 previous_followups=await self._load_previous_followups(chat),
-                deliver=envelope.send_followup,
             )
             await followup.start()
             await followup.append(

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/runtime/envelope.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/runtime/envelope.py
@@ -118,7 +118,9 @@ class Envelope:
             )
 
     async def send_followup(self, questions: list[str]) -> None:
-        """Persist and broadcast follow-up questions (FollowUpCallback shape)."""
+        """Persist and broadcast follow-up questions before completion."""
+        if self._terminal:
+            return
         try:
             await self.stream.followup_generated(questions=questions)
         except Exception:

--- a/packages/qwenpaw-data-host-core/tests/test_envelope.py
+++ b/packages/qwenpaw-data-host-core/tests/test_envelope.py
@@ -96,6 +96,23 @@ async def test_envelope_uses_host_ids_and_agentscope_source_ids() -> None:
     assert stream.calls[-1][0] == "response_completed"
 
 
+async def test_envelope_drops_followup_after_terminal_response() -> None:
+    stream = RecordingStream()
+    envelope = Envelope(stream)
+
+    await envelope.send_followup(["继续分析？"])
+    await envelope.complete()
+    await envelope.send_followup(["这条不能出现"])
+
+    followups = [
+        payload
+        for name, payload in stream.calls
+        if name == "followup_generated"
+    ]
+    assert followups == [{"questions": ["继续分析？"]}]
+    assert stream.calls[-1][0] == "response_completed"
+
+
 async def test_envelope_renders_hint_block() -> None:
     stream = RecordingStream()
     envelope = Envelope(stream)

--- a/packages/qwenpaw-data-host-core/tests/test_followup_recommend.py
+++ b/packages/qwenpaw-data-host-core/tests/test_followup_recommend.py
@@ -251,7 +251,7 @@ async def test_the_eof_sentinel_freezes_without_a_join() -> None:
     snapshot = await unit._snapshot  # type: ignore[arg-type]
 
     assert isinstance(snapshot, SignalSnapshot)
-    assert unit._pipeline is None
+    assert unit._questions is None
 
 
 async def test_join_answers_the_same_way_twice() -> None:
@@ -268,55 +268,24 @@ async def test_join_without_start_recommends_nothing() -> None:
     assert await _recommend().join() == []
 
 
-async def test_an_over_budget_recommendation_arrives_late(
+async def test_a_slow_model_falls_back_before_join_returns(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The turn closes on time; the result is still worth persisting when it
-    lands, so the next Chat can carry it."""
+    class SlowLLM:
+        async def complete(self, prompt: str) -> dict[str, Any]:
+            await asyncio.sleep(0.2)
+            return {
+                "questions": [
+                    {"text": "按页面拆解 GAAP用户数", "intent": "drilldown"}
+                ]
+            }
 
-    late = Candidate(
-        text="按渠道类型拆解一下 GAAP用户数",
-        intent_category="drilldown",
-        target_entities=[],
-        source_channel="rules",
-    )
+    monkeypatch.setattr(FollowUpRecommend, "_build_llm", lambda self: SlowLLM())
 
-    async def slow_recommend(self: Any, snapshot: SignalSnapshot) -> list[Candidate]:
-        await asyncio.sleep(0.2)
-        return [late]
+    questions = await _drive(_recommend(timeout_sec=0.02))
 
-    monkeypatch.setattr(
-        recommend_module.FollowUpService, "recommend", slow_recommend
-    )
-    delivered: list[list[str]] = []
-
-    async def deliver(questions: list[str]) -> None:
-        delivered.append(questions)
-
-    unit = _recommend(
-        deliver=deliver, timeout_sec=0.02
-    )
-
-    assert await _drive(unit) == []
-
-    await unit._late  # type: ignore[arg-type]
-    assert delivered == [[late.text]]
-
-
-async def test_a_late_result_is_dropped_when_the_host_wants_none(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    async def slow_recommend(self: Any, snapshot: SignalSnapshot) -> list[Candidate]:
-        await asyncio.sleep(0.05)
-        return []
-
-    monkeypatch.setattr(
-        recommend_module.FollowUpService, "recommend", slow_recommend
-    )
-    unit = _recommend(timeout_sec=0.01)
-
-    assert await _drive(unit) == []
-    assert unit._late is None
+    assert questions
+    assert all("GAAP用户数" in question for question in questions)
 
 
 async def test_a_failing_pipeline_costs_the_host_nothing(

--- a/packages/qwenpaw-data-host-core/tests/test_followup_runtime.py
+++ b/packages/qwenpaw-data-host-core/tests/test_followup_runtime.py
@@ -12,6 +12,13 @@ import pytest
 pytest.importorskip("fastapi")
 import httpx  # noqa: E402
 
+from qwenpaw_data.host.core.algo.followup.collector import (  # noqa: E402
+    SignalCollector,
+)
+from qwenpaw_data.host.core.algo.followup.models import (  # noqa: E402
+    EntityRecord,
+    SignalSnapshot,
+)
 from qwenpaw_data.host.core.algo.followup.recommend import (  # noqa: E402
     FollowUpRecommend,
 )
@@ -98,6 +105,61 @@ async def test_followup_event_precedes_terminal_response(
             "对比Q2的渠道结构",
             "投放成本口径是什么",
         ]
+
+
+async def test_slow_model_falls_back_before_terminal_response(
+    tmp_path, monkeypatch
+) -> None:
+    snapshot = SignalSnapshot(
+        user_input="分析 GAAP用户数",
+        final_answer_summary="GAAP用户数环比下降。",
+        anchor_metric="GAAP用户数",
+        metrics=(
+            EntityRecord(name="GAAP用户数", analyzed=True, relevance=1.0),
+        ),
+        dimensions=(EntityRecord(name="页面", relevance=0.8),),
+        unused_dimensions=("页面",),
+        business_entities=("GAAP用户数", "页面"),
+    )
+
+    class SlowLLM:
+        async def complete(self, prompt: str) -> dict:
+            import asyncio
+
+            await asyncio.sleep(0.1)
+            return {"questions": []}
+
+    original_init = FollowUpRecommend.__init__
+
+    def short_budget(self, **kwargs):
+        original_init(self, timeout_sec=0.01, **kwargs)
+
+    monkeypatch.setattr(
+        SignalCollector, "_build_snapshot", lambda self: snapshot
+    )
+    monkeypatch.setattr(FollowUpRecommend, "__init__", short_budget)
+    monkeypatch.setattr(
+        FollowUpRecommend, "_build_llm", lambda self: SlowLLM()
+    )
+
+    async with service_client(tmp_path, monkeypatch) as http:
+        session_id = await _new_session(http)
+        payloads = await _run_turn(http, session_id)
+
+    objects = [payload["object"] for payload in payloads]
+    followup = next(
+        payload
+        for payload in payloads
+        if payload["object"] == "followup.generated"
+    )
+    assert followup["followup"]["questions"]
+    assert all(
+        "GAAP用户数" in question
+        for question in followup["followup"]["questions"]
+    )
+    assert objects.index("followup.generated") < len(objects) - 1
+    assert payloads[-1]["object"] == "response"
+    assert payloads[-1]["status"] == "completed"
 
 
 async def test_previous_followups_flow_into_next_chat(


### PR DESCRIPTION
## Summary
- make `FollowUpService` own the single model timeout and deterministic rules fallback
- remove post-terminal late delivery, which SSE consumers cannot observe
- guard follow-up emission after terminal completion and cover the ordering through the HTTP/SSE boundary

## Test plan
- [x] `uv run pytest packages/qwenpaw-data-host-core/tests/test_followup_recommend.py packages/qwenpaw-data-host-core/tests/test_followup_runtime.py packages/qwenpaw-data-host-core/tests/test_envelope.py packages/qwenpaw-data-host-core/tests/test_service_smoke.py -q`
- [x] `uv run pytest packages/qwenpaw-data-host-core/tests/test_event_hub.py packages/qwenpaw-data-host-core/tests/test_stream_objects.py -q`
- [x] `bash scripts/verify.sh --frontend` (934 passed, 9 skipped; API smoke, frontend lint, and frontend build passed)
- [x] real-socket slow-model smoke: `followup.generated` sequence 20 preceded terminal `response.completed` sequence 21
- [x] L3 deep security review: no findings