### PR TITLE
chore(release): prepare QwenPaw-Data 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,43 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-09-07
+
+### Added
+
+- A headless engine service with HTTP and replayable SSE APIs for sessions,
+  chats, attachments, artifacts, files, scheduled runs, steering, feedback,
+  trace views, snapshots, forks, and signed share links.
+- End-of-turn follow-up recommendations with model generation, deterministic
+  rule fallback, entity grounding, relevance ranking, and prior-question
+  deduplication.
+- Pluggable graph backends, universal datasource connectors, a datasource type
+  registry, and MySQL-compatible, DuckDB, and SQLite integrations.
+- BizTrace segments, SQL-result artifacts, and confirmed semantic-knowledge
+  settlement for analytical runs.
+
+### Changed
+
+- **Breaking:** renamed the public `datapaw-*` distributions, Python namespaces,
+  and CLI to the `qwenpaw-data-*` package line and `qwenpaw-data` command.
+- **Breaking:** removed engine-owned IM channel delivery. Hosts now own delivery
+  and consume the engine through its HTTP/SSE boundary.
+- The four Python distributions now follow one coordinated `0.3.x` minor line;
+  internal package dependencies require `>=0.3,<0.4`.
+
+### Fixed
+
+- Follow-up timeout fallback now emits deterministic recommendations before the
+  terminal SSE response instead of attempting an unobservable late event.
+- Semantic-config writes commit before returning, and renamed CORS allow-header
+  configuration is honored.
+
+### Security
+
+- Hardened explorer subgraph search and global snapshot caching.
+- Raised `pypdf`, `dbt-core`, and `sqlparse` constraints past published
+  advisories.
+
 ## [0.2.4] - 2026-08-20
 
 ### Added
@@ -135,7 +172,8 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Initial local-first open-source baseline.
 
-[Unreleased]: https://github.com/agentscope-ai/QwenPaw-Data/compare/v0.2.4...HEAD
+[Unreleased]: https://github.com/agentscope-ai/QwenPaw-Data/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/agentscope-ai/QwenPaw-Data/compare/v0.2.4...v0.3.0
 [0.2.4]: https://github.com/agentscope-ai/QwenPaw-Data/compare/v0.2.0...v0.2.4
 [0.2.0]: https://github.com/agentscope-ai/QwenPaw-Data/compare/v0.1.2...v0.2.0
 [0.1.2]: https://github.com/agentscope-ai/QwenPaw-Data/compare/v0.1.1...v0.1.2

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -4,6 +4,14 @@ QwenPaw-Data is pre-1.0 software. Minor releases may contain breaking changes,
 but deprecations are announced in `CHANGELOG.md` whenever practical. Patch
 releases are intended to remain API compatible within the same minor line.
 
+## Release compatibility
+
+The four Python distributions are released as one coordinated `0.3.x` line.
+Consumers should keep `qwenpaw-data-skills`, `qwenpaw-data-context`,
+`qwenpaw-data-host-core`, and `qwenpaw-data-cli` on the same minor version.
+Consumers that run the engine service must install
+`qwenpaw-data-host-core[service]>=0.3,<0.4`.
+
 ## Validated environments
 
 | Component | Supported / validated baseline |

--- a/packages/qwenpaw-data-cli/pyproject.toml
+++ b/packages/qwenpaw-data-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qwenpaw-data-cli"
-version = "0.1.0"
+version = "0.3.0"
 description = "Standalone command-line interface for QwenPaw-Data."
 readme = "README.md"
 license = "Apache-2.0"
@@ -20,7 +20,7 @@ classifiers = [
 ]
 requires-python = ">=3.11"
 dependencies = [
-  "qwenpaw-data-host-core>=0.1,<0.2",
+  "qwenpaw-data-host-core>=0.3,<0.4",
   "python-dotenv>=1.2.2,<2.0",
 ]
 

--- a/packages/qwenpaw-data-context/pyproject.toml
+++ b/packages/qwenpaw-data-context/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qwenpaw-data-context"
-version = "0.1.0"
+version = "0.3.0"
 description = "Context management and graph memory foundation for QwenPaw-Data."
 readme = "README.md"
 license = "Apache-2.0"
@@ -82,6 +82,13 @@ packages = [
   "src/qwenpaw_data/context",
   "src/context_manager",
   "src/semantic_config",
+]
+
+[tool.hatch.build.targets.sdist]
+exclude = [
+  "/frontend/node_modules",
+  "/frontend/dist",
+  "/frontend/dist-ssr",
 ]
 
 [tool.hatch.build.targets.sdist.force-include]

--- a/packages/qwenpaw-data-context/src/context_manager/__init__.py
+++ b/packages/qwenpaw-data-context/src/context_manager/__init__.py
@@ -2,4 +2,4 @@
 Context Manager - A knowledge graph-based system for managing and querying structured data.
 """
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"

--- a/packages/qwenpaw-data-context/src/context_manager/api/server.py
+++ b/packages/qwenpaw-data-context/src/context_manager/api/server.py
@@ -503,7 +503,7 @@ def create_app() -> FastAPI:
                         sync_route_limiter.total_tokens = previous_sync_route_tokens
             log.info("Neo4j driver closed")
 
-    app = FastAPI(title="QwenPaw Data Context Manager", version="0.1.0", lifespan=lifespan)
+    app = FastAPI(title="QwenPaw Data Context Manager", version="0.3.0", lifespan=lifespan)
     from qwenpaw_data.context.errors import install_error_handlers
 
     install_error_handlers(app)

--- a/packages/qwenpaw-data-context/src/semantic_config/main.py
+++ b/packages/qwenpaw-data-context/src/semantic_config/main.py
@@ -31,7 +31,7 @@ async def lifespan(_: FastAPI):
 
 def create_app() -> FastAPI:
     settings = get_settings()
-    app = FastAPI(title="数据语义配置 - 本地版", version="0.1.0", lifespan=lifespan)
+    app = FastAPI(title="数据语义配置 - 本地版", version="0.3.0", lifespan=lifespan)
 
     # Keep the standalone semantic-config process behind the same auth boundary
     # as the unified server. Install before CORS so error responses retain CORS.

--- a/packages/qwenpaw-data-host-core/pyproject.toml
+++ b/packages/qwenpaw-data-host-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qwenpaw-data-host-core"
-version = "0.1.0"
+version = "0.3.0"
 description = "Shared host foundation for QwenPaw-Data."
 readme = "README.md"
 license = "Apache-2.0"
@@ -21,7 +21,7 @@ requires-python = ">=3.11"
 dependencies = [
   "agentscope>=2.0.6,<2.1",
   "aiodocker>=0.27,<0.28",
-  "qwenpaw-data-skills>=0.1,<0.2",
+  "qwenpaw-data-skills>=0.3,<0.4",
   "httpx>=0.28,<0.29",
   "pydantic>=2.13,<3.0",
   "pyyaml>=6.0,<7.0",

--- a/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/__version__.py
+++ b/packages/qwenpaw-data-host-core/src/qwenpaw_data/host/core/__version__.py
@@ -1,3 +1,3 @@
 """Package version."""
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"

--- a/packages/qwenpaw-data-skills/pyproject.toml
+++ b/packages/qwenpaw-data-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qwenpaw-data-skills"
-version = "0.1.0"
+version = "0.3.0"
 description = "Reusable data analysis skills for QwenPaw-Data."
 readme = "README.md"
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qwenpaw-data-workspace"
-version = "0.1.0"
+version = "0.3.0"
 description = "QwenPaw-Data monorepo workspace."
 readme = "README.md"
 license = "Apache-2.0"
@@ -42,10 +42,10 @@ dev = [
   "pytest>=9.0.3,<10.0",
   "pytest-asyncio>=0.24,<2.0",
   "httpx>=0.28,<0.29",
-  "qwenpaw-data-context>=0.1,<0.2",
-  "qwenpaw-data-host-core[service]>=0.1,<0.2",
-  "qwenpaw-data-cli>=0.1,<0.2",
-  "qwenpaw-data-skills>=0.1,<0.2",
+  "qwenpaw-data-context>=0.3,<0.4",
+  "qwenpaw-data-host-core[service]>=0.3,<0.4",
+  "qwenpaw-data-cli>=0.3,<0.4",
+  "qwenpaw-data-skills>=0.3,<0.4",
 ]
 
 [tool.uv.sources]

--- a/uv.lock
+++ b/uv.lock
@@ -3198,7 +3198,7 @@ wheels = [
 
 [[package]]
 name = "qwenpaw-data-cli"
-version = "0.1.0"
+version = "0.3.0"
 source = { editable = "packages/qwenpaw-data-cli" }
 dependencies = [
     { name = "python-dotenv" },
@@ -3213,7 +3213,7 @@ requires-dist = [
 
 [[package]]
 name = "qwenpaw-data-context"
-version = "0.1.0"
+version = "0.3.0"
 source = { editable = "packages/qwenpaw-data-context" }
 dependencies = [
     { name = "aiohttp" },
@@ -3301,7 +3301,7 @@ provides-extras = ["bigquery", "duckdb"]
 
 [[package]]
 name = "qwenpaw-data-host-core"
-version = "0.1.0"
+version = "0.3.0"
 source = { editable = "packages/qwenpaw-data-host-core" }
 dependencies = [
     { name = "agentscope" },
@@ -3343,12 +3343,12 @@ provides-extras = ["service"]
 
 [[package]]
 name = "qwenpaw-data-skills"
-version = "0.1.0"
+version = "0.3.0"
 source = { editable = "packages/qwenpaw-data-skills" }
 
 [[package]]
 name = "qwenpaw-data-workspace"
-version = "0.1.0"
+version = "0.3.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- align all four Python distributions, runtime versions, application metadata, internal constraints, and `uv.lock` on `0.3.0`
- document the headless engine/runtime, Context and datasource additions, security updates, and observable follow-up fallback
- exclude generated frontend dependencies/build output from the Context sdist (reduced from 72 MB to 924 KB)

## Breaking changes
- public packages and namespaces have moved from `datapaw-*` to `qwenpaw-data-*`
- engine-owned IM delivery is removed; hosts now own delivery through the HTTP/SSE boundary
- coordinated internal dependencies require `>=0.3,<0.4`

## PyPI packages
- `qwenpaw-data-skills`
- `qwenpaw-data-context`
- `qwenpaw-data-host-core`
- `qwenpaw-data-cli`

## Local verification
- [x] `bash scripts/verify.sh --frontend` (934 passed, 9 skipped; API smoke, frontend lint, frontend build passed)
- [x] `uv run python scripts/check_release_versions.py v0.3.0`
- [x] clean `uv build --all-packages --out-dir dist` produced exactly four wheels and four sdists
- [x] `uvx --from twine==7.0.0 twine check dist/*`
- [x] `uv run python scripts/check_release_versions.py v0.3.0 --dist-dir dist`
- [x] inspected versions, `>=0.3,<0.4` metadata, host engine routers, package data, LICENSE/NOTICE, and leakage indicators
- [x] generated and verified SHA-256 checksums for the exact eight distributions
- [x] fresh-environment wheel-only smoke: Context import, engine app factory, CLI help, and engine `/health`
- [x] L3 deep security review: no findings

QwenPaw consumer adoption follows publication and is not part of this PR.