### PR TITLE
fix(cm): add missing datasets/{name}/columns endpoint for get_dataset_columns

### DIFF
--- a/packages/qwenpaw-data-context/src/context_manager/api/authorization.py
+++ b/packages/qwenpaw-data-context/src/context_manager/api/authorization.py
@@ -77,6 +77,7 @@ _register(
     ("GET", "/api/v1/cm/metric-dimensions"),
     ("GET", "/api/v1/cm/dimension-metrics"),
     ("GET", "/api/v1/cm/datasets"),
+    ("GET", "/api/v1/cm/datasets/{name}/columns"),
     ("POST", "/api/v1/cm/search_context"),
     ("POST", "/api/v1/cm/search_event"),
     ("POST", "/api/v1/cm/explore_entity"),

--- a/packages/qwenpaw-data-context/src/context_manager/api/cm_api.py
+++ b/packages/qwenpaw-data-context/src/context_manager/api/cm_api.py
@@ -1034,6 +1034,31 @@ def cm_datasets(
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
+@router.get("/datasets/{name}/columns", response_model=list[ColumnMeta])
+def cm_dataset_columns(
+    request: Request,
+    name: str,
+    domain: Optional[str] = Query(None),
+    session_ref: Optional[str] = Query(None),
+    datasource_id: Optional[str] = Query(None),
+) -> Union[list[ColumnMeta], JSONResponse]:
+    driver = _driver(request)
+    dom, sess = _domain_from_request(request, domain=domain, session_ref=session_ref)
+    ds_id = _read_datasource_id(dom, sess, datasource_id or "")
+    resolved = resolve_entity(driver, domain=dom, name=name.strip(), kind="dataset", datasource_id=ds_id)
+    if resolved.kind == "ambiguous":
+        return JSONResponse(
+            status_code=200,
+            content=ambiguous_payload(resolved.candidates, entity_type="Dataset"),
+        )
+    if resolved.kind == "not_found":
+        raise not_found_http("dataset", dom, name)
+    try:
+        return sem_store.get_dataset_columns(driver, dom, resolved.canonical_name, datasource_id=ds_id)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
 # ---------------------------------------------------------------------- #
 # L1 — search_context
 # ---------------------------------------------------------------------- #

--- a/packages/qwenpaw-data-context/tests/test_api_auth.py
+++ b/packages/qwenpaw-data-context/tests/test_api_auth.py
@@ -255,3 +255,32 @@ def test_every_application_api_route_has_an_explicit_policy(
     from context_manager.api.server import create_app
 
     assert unclassified_app_routes(create_app()) == []
+
+
+def test_get_dataset_columns_endpoint_is_registered_and_classified(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """回归测试：get_dataset_columns MCP 工具依赖的 CM 端点必须存在且已分类。
+
+    该 MCP 工具调用 ``GET /api/v1/cm/datasets/{name}/columns``，但历史上只
+    注册了工具而未实现后端端点，导致请求被 fail-closed 中间件以 403
+    （unclassified_route）拦截。此测试同时防住「端点缺失」与「端点未分类」
+    两类回归。
+    """
+    monkeypatch.delenv("QWENPAW_DATA_API_TOKEN", raising=False)
+    from context_manager.api.authorization import (
+        _walk_route_templates,
+        required_scopes_for_request,
+    )
+    from context_manager.api.server import create_app
+
+    app = create_app()
+    registered = {
+        (path, method)
+        for path, methods in _walk_route_templates(app.routes)
+        for method in methods
+    }
+    assert ("/api/v1/cm/datasets/{name}/columns", "GET") in registered
+    assert required_scopes_for_request(
+        "GET", "/api/v1/cm/datasets/realtime_viz/columns"
+    ) == frozenset({SCOPE_QUERY})


### PR DESCRIPTION
## Problem

The `get_dataset_columns` MCP tool returns HTTP 403 for every call, even with a valid token.

Issue #19 was closed as fixed in v0.2.0, but that fix was incomplete: the tool was registered along with its function body, yet the backend REST endpoint it depends on was never implemented.

## Root cause

`get_dataset_columns` (in `packages/qwenpaw-data-context/src/context_manager/mcp/cm_server.py`) calls:

    GET /api/v1/cm/datasets/{name}/columns

but `cm_api.py` only implemented `/datasets` (the list endpoint), not `/datasets/{name}/columns`. Because the auth middleware is fail-closed and runs before routing, the missing route is classified as `unclassified_route` and rejected with **403** rather than 404.

## Fix

- Implement `GET /api/v1/cm/datasets/{name}/columns` in `cm_api.py`, reusing the same `resolve_entity` → ambiguous / not-found semantics as `get_dataset`, then returning `sem_store.get_dataset_columns(...)`.
- Register the route with query scope in `authorization.py`.
- Add a regression test asserting the route is both registered and classified — the existing `unclassified_app_routes` invariant only catches routes that exist but lack a policy, so an entirely-missing endpoint (this bug) would otherwise slip through.

## Verification

- `compileall` passes.
- `pytest packages/qwenpaw-data-context/tests/test_api_auth.py` → 11 passed (includes the new regression test).
- Full `uv run pytest -q` → 933 passed, 9 skipped, 2 failed; the 2 failures are pre-existing, environment-specific, and unrelated to this change (both pass in isolation).
